### PR TITLE
refactor(multi-mint): Pass a `CurrencyMetadata` to register a new asset

### DIFF
--- a/pallets/multi-mint/src/types.rs
+++ b/pallets/multi-mint/src/types.rs
@@ -7,9 +7,7 @@ pub(super) type BalanceOf<T> = <T as orml_tokens::Config>::Balance;
 
 // Structs
 #[derive(Default, Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
-pub struct CurrencyMetadata<DepositBalance, BoundedString> {
-	/// This pays for the data stored in this struct.
-	pub(super) deposit: DepositBalance,
+pub struct CurrencyMetadata<BoundedString> {
 	/// The user friendly name of this asset. Limited in length by `StringLimit`.
 	pub(super) name: BoundedString,
 	/// The ticker symbol for this asset. Limited in length by `StringLimit`.
@@ -18,31 +16,25 @@ pub struct CurrencyMetadata<DepositBalance, BoundedString> {
 	pub(super) decimals: u8,
 }
 
-impl<DepositBalance, BoundedString> CurrencyMetadata<DepositBalance, BoundedString> {
-	pub fn new(
-		deposit: DepositBalance,
-		name: BoundedString,
-		symbol: BoundedString,
-		decimals: u8,
-	) -> Self {
-		Self { deposit, name, symbol, decimals }
-	}
-}
-
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
 pub struct CurrencyInfo<AccountId> {
+	///
+	pub(super) current_owner: AccountId,
+	///
 	pub(super) issuer: AccountId,
-	pub(super) transfers_frozen: bool,
+	///
+	pub(super) transfers_enabled: TransferStatus,
+	///
 	pub(super) trading_enabled: TradingStatus,
 }
 
-impl<AccountId> CurrencyInfo<AccountId> {
-	pub fn new(issuer: AccountId, transfers_frozen: bool, trading_enabled: TradingStatus) -> Self {
-		Self { issuer, transfers_frozen, trading_enabled }
-	}
+// Enums
+#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+pub enum TransferStatus {
+	Enabled,
+	Disabled,
 }
 
-// Enums
 #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
 pub enum TradingStatus {
 	Enabled,


### PR DESCRIPTION
Instead of just passing the `currency_id`, now the user can associate additional information, `CurrencyMetadata`, to their currency 