### PR TITLE
Tightly couple the evaluation success threshold to the early reward threshold

### DIFF
--- a/polimec-skeleton/pallets/funding/src/functions.rs
+++ b/polimec-skeleton/pallets/funding/src/functions.rs
@@ -247,7 +247,7 @@ impl<T: Config> Pallet<T> {
 				total.saturating_add(user_total_plmc_bond)
 			});
 
-		let evaluation_target_usd = Perquintill::from_percent(10) * fundraising_target_usd;
+		let evaluation_target_usd = <T as Config>::EvaluationSuccessThreshold::get() * fundraising_target_usd;
 		let evaluation_target_plmc = current_plmc_price
 			.reciprocal()
 			.ok_or(Error::<T>::BadMath)?
@@ -790,7 +790,7 @@ impl<T: Config> Pallet<T> {
 		let mut caller_existing_evaluations = Evaluations::<T>::get(project_id, evaluator.clone());
 		let plmc_usd_price = T::PriceProvider::get_price(PLMC_STATEMINT_ID).ok_or(Error::<T>::PLMCPriceNotAvailable)?;
 		let early_evaluation_reward_threshold_usd =
-			T::EarlyEvaluationThreshold::get() * project_details.fundraising_target;
+			T::EvaluationSuccessThreshold::get() * project_details.fundraising_target;
 		let evaluation_round_info = &mut project_details.evaluation_round_info;
 
 		// * Validity Checks *

--- a/polimec-skeleton/pallets/funding/src/lib.rs
+++ b/polimec-skeleton/pallets/funding/src/lib.rs
@@ -379,7 +379,7 @@ pub mod pallet {
 
 		type FeeBrackets: Get<Vec<(Percent, Self::Balance)>>;
 
-		type EarlyEvaluationThreshold: Get<Percent>;
+		type EvaluationSuccessThreshold: Get<Percent>;
 	}
 
 	#[pallet::storage]

--- a/polimec-skeleton/pallets/funding/src/mock.rs
+++ b/polimec-skeleton/pallets/funding/src/mock.rs
@@ -257,7 +257,7 @@ impl pallet_funding::Config for TestRuntime {
 	type BenchmarkHelper = ();
 	type WeightInfo = ();
 	type FeeBrackets = FeeBrackets;
-	type EarlyEvaluationThreshold = EarlyEvaluationThreshold;
+	type EvaluationSuccessThreshold = EarlyEvaluationThreshold;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/polimec-skeleton/runtime/src/lib.rs
+++ b/polimec-skeleton/runtime/src/lib.rs
@@ -602,7 +602,7 @@ impl pallet_funding::Config for Runtime {
 	type BenchmarkHelper = ();
 	type WeightInfo = ();
 	type FeeBrackets = FeeBrackets;
-	type EarlyEvaluationThreshold = EarlyEvaluationThreshold;
+	type EvaluationSuccessThreshold = EarlyEvaluationThreshold;
 }
 
 impl pallet_credentials::Config for Runtime {


### PR DESCRIPTION
The early reward threshold is chosen always as the threshold for a successful evaluation. We should use a single config type when referring to both concepts in the code