### PR TITLE
feat(222): Finalizer refactor

### DIFF
--- a/polimec-skeleton/pallets/funding/src/lib.rs
+++ b/polimec-skeleton/pallets/funding/src/lib.rs
@@ -229,6 +229,7 @@ pub type AssetIdOf<T> =
 
 pub type RewardInfoOf<T> = RewardInfo<BalanceOf<T>>;
 pub type EvaluatorsOutcomeOf<T> = EvaluatorsOutcome<AccountIdOf<T>, BalanceOf<T>>;
+
 pub type ProjectMetadataOf<T> =
 	ProjectMetadata<BoundedVec<u8, StringLimitOf<T>>, BalanceOf<T>, PriceOf<T>, AccountIdOf<T>, HashOf<T>>;
 pub type ProjectDetailsOf<T> =
@@ -258,7 +259,7 @@ const PLMC_STATEMINT_ID: u32 = 2069;
 #[frame_support::pallet(dev_mode)]
 pub mod pallet {
 	use super::*;
-	use crate::traits::{BondingRequirementCalculation, DoRemainingOperation, ProvideStatemintPrice};
+	use crate::traits::{BondingRequirementCalculation, ProvideStatemintPrice};
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
 	use local_macros::*;
@@ -429,7 +430,12 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn project_details)]
 	/// StorageMap containing additional information for the projects, relevant for correctness of the protocol
-	pub type ProjectsDetails<T: Config> = StorageMap<_, Blake2_128Concat, T::ProjectIdentifier, ProjectDetailsOf<T>>;
+	pub type ProjectsDetails<T: Config> = StorageMap<
+		_,
+		Blake2_128Concat,
+		T::ProjectIdentifier,
+		ProjectDetails<AccountIdOf<T>, BlockNumberOf<T>, PriceOf<T>, BalanceOf<T>, EvaluationRoundInfoOf<T>>,
+	>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn projects_to_update)]
@@ -715,6 +721,8 @@ pub mod pallet {
 		NoFinalizerSet,
 		/// Tried to do an operation on a finalizer that already finished
 		FinalizerFinished,
+		/// Tried to do an operation on a cleaner that is not ready
+		CleanerNotReady,
 	}
 
 	#[pallet::call]
@@ -924,8 +932,8 @@ pub mod pallet {
 						unwrap_result_or_skip!(Self::do_project_decision(project_id, decision), project_id)
 					},
 
-					UpdateType::StartSettlement(finalizer) => {
-						unwrap_result_or_skip!(Self::do_start_settlement(project_id, finalizer), project_id)
+					UpdateType::StartSettlement => {
+						unwrap_result_or_skip!(Self::do_start_settlement(project_id), project_id)
 					},
 				}
 			}
@@ -938,8 +946,7 @@ pub mod pallet {
 
 			let projects_needing_cleanup = ProjectsDetails::<T>::iter()
 				.filter_map(|(project_id, info)| match info.cleanup {
-					ProjectCleanup::Ready(project_finalizer) if project_finalizer != ProjectFinalizer::None =>
-						Some((project_id, project_finalizer)),
+					cleaner if cleaner.has_remaining_operations() => Some((project_id, cleaner)),
 					_ => None,
 				})
 				.collect::<Vec<_>>();
@@ -951,25 +958,23 @@ pub mod pallet {
 
 			let mut max_weight_per_project = remaining_weight.saturating_div(projects_amount);
 
-			for (remaining_projects, (project_id, mut project_finalizer)) in
+			for (remaining_projects, (project_id, mut cleaner)) in
 				projects_needing_cleanup.into_iter().enumerate().rev()
 			{
 				let mut consumed_weight = T::WeightInfo::insert_cleaned_project();
 				while !consumed_weight.any_gt(max_weight_per_project) {
-					if let Ok(weight) = project_finalizer.do_one_operation::<T>(project_id) {
+					if let Ok(weight) = cleaner.do_one_operation::<T>(project_id) {
 						consumed_weight.saturating_accrue(weight);
 					} else {
 						break
 					}
 				}
-				let mut details = if let Some(d) = ProjectsDetails::<T>::get(project_id) { d } else { continue };
-				if let ProjectFinalizer::None = project_finalizer {
-					details.cleanup = ProjectCleanup::Finished;
-				} else {
-					details.cleanup = ProjectCleanup::Ready(project_finalizer);
-				}
 
+				let mut details =
+					if let Some(details) = ProjectsDetails::<T>::get(project_id) { details } else { continue };
+				details.cleanup = cleaner;
 				ProjectsDetails::<T>::insert(project_id, details);
+
 				remaining_weight = remaining_weight.saturating_sub(consumed_weight);
 				if remaining_projects > 0 {
 					max_weight_per_project = remaining_weight.saturating_div(remaining_projects as u64);

--- a/polimec-skeleton/pallets/funding/src/traits.rs
+++ b/polimec-skeleton/pallets/funding/src/traits.rs
@@ -14,7 +14,7 @@ pub trait ProvideStatemintPrice {
 }
 
 pub trait DoRemainingOperation {
-	fn is_done(&self) -> bool;
+	fn has_remaining_operations(&self) -> bool;
 
 	fn do_one_operation<T: crate::Config>(&mut self, project_id: T::ProjectIdentifier)
 		-> Result<Weight, DispatchError>;


### PR DESCRIPTION
# Objective
Reduce complexity of the finalizer

# Problem
We have a state machine which is actually divided in 2. One for a successful project, and one for an unsuccessful project.

We need a safe way of ensuring one machine is not doing transitions into the other one's states.

But we also don't want too much code overhead.

# Outcome
Went from 3 layers to 2 layers for the finalizer.
Old:
ProjectCleanup -> ProjectFinalizer -> SuccessFinalizer | FailureFinalizer

New:
Cleaner -> CleanerState

# Explanation
CleanerState contains all possible states for both a successful and failed project.
It encodes legal transitions by having the Success or Failure as a type, and doing a custom impl on them.
Having PhantomData might be a bit too verbose, but this way I believe we guarantee state transitions are always valid

One other proposal was instead of using PhantomData and encoding the outcome as a type, to use a bool and do an if statement on the transition.

It's my understanding that type state machines have safer guarantees since you can not just instantiate a new enum with a different value because it's a different type.

## Example:
Instead of showing the full Cleaner (a.k.a finalizer), the following is a more succint example to show what I mean.

### Using a bool for deciding which state machine
```rust
Enum BoolMachine {
    InitialState(bool),
    SecondCommonState(bool)
    TrueState(bool),
    FalseState(bool)
}

impl BoolMachine {
    fn next(&mut self) {
        match self {
            BoolMachine::InitialState(bool_val) => {*self = SecondCommonState(bool_val)}
            BoolMachine::SecondCommonState(bool_val) if bool_val == true -> {
                *self = TrueState
            },
            BoolMachine::SecondCommonState(bool_val) if bool_val == false -> {
                *self = FalseState
            }
            _ => {}
            
        }
    }
}
```

if we want to accept this state machine, we cannot have any guarantees the state will be corrupted at some point:
```rust

pub type StoredMachine<T: Config> = StorageMap<_, BoolMachine, ValueQuery>

fn initialize_true_state() {
    StoredMachine::<T>::insert(BoolMachine::InitialState(true));
}

fn oops_i_forgot_to_read() {
    let mut stored_machine = StoredMachine::<T>::get();
    
    // I  feel like skipping a transition
    stored_machine = BoolMachine::SecondCommonState(false);
    
    // give me the next state
    stored_machine.next();
    
    // oops!
    assert_eq!(stored_machine, BoolMachine::TrueState)
    
}

```

## Using Types 
```rust
struct True;
struct False;

enum TypeMachine {
    True(MachineState<True>),
    False(MachineState<False>)
}

enum MachineState<T> {
    InitialState(PhantomData<T>),
    SecondCommonState(PhantomData<T>),
    TrueState(PhantomData<T>),
    FalseState(PhantomData<T>)
}

impl MachineState<True> {
    fn next(&mut self) {
        match self {
            MachineState::InitialState(_) => {
                *self = MachineState::SecondCommonState(PhantomData)
            },
            MachineState::SecondCommonState(_) => {
                *self = MachineState::TrueState(PhantomData)
            },
            MachineState::TrueState(_) => {
                // here we could add the next valid state
            }
            _ => {
                // here we do nothing, since the fact that we have a 
                // `MachineState::<True>::FalseState` means someone made a mistake in the code
            }
        }
    }
} 

// MachineState<False> impl is missing here, but you get the idea
```

Trying to make the same mistake as before:
```rust
pub type StoredMachine<T: Config> = StorageMap<_, TypeMachine, ValueQuery>

fn initialize_true_state() {
    StoredMachine::<T>::insert(TypeMachine::True(MachineState::<True>::InitialState(PhantomData)));
}

fn oops_i_forgot_to_read() {
    let mut stored_machine = StoredMachine::<T>::get();
    
    // first of all its not as easy to replace a state. This code below is illegal since we cannot handle
    // the state of both cases as one because they are different types
	/*let state = match stored_machine {
		// MachineState<True>
		TypeMachine::True(state) => state,
		// MachineState<False>
		TypeMachine::False(state) => state,
	};*/

	// I feel like skipping a transition anyway :^)
	let state: &mut MachineState<True> =
		if let TypeMachine::True(state) = stored_machine { state.as_ref() } else { panic!("unreachable") };

	*state = MachineState::FalseState(PhantomData);

	// this will never do anything. Our machine has no real implementation for this
	stored_machine.next();
}
```

Worth noting that changing a <True> TypeMachine to a <False> machine is hard enough that someone doing it would at that point be malicious and not an honest mistake, unlike the bool.

And in the case where we keep the same machine type, but forcefully move to an invalid state, then the machine gets stuck, instead of continuing to transition into other invalid states (and by consequence doing disastreous side effects)