### PR TITLE
Feature/plmc 251 errors refactor

### DIFF
--- a/pallets/funding/src/functions.rs
+++ b/pallets/funding/src/functions.rs
@@ -674,16 +674,14 @@ impl<T: Config> Pallet<T> {
 		ProjectsDetails::<T>::insert(project_id, project_details.clone());
 
 		if project_details.status == ProjectStatus::FundingSuccessful {
-			T::ContributionTokenCurrency::create(project_id, project_details.issuer.clone(), false, 1_u32.into())
-				.map_err(|_| Error::<T>::AssetCreationFailed)?;
+			T::ContributionTokenCurrency::create(project_id, project_details.issuer.clone(), false, 1_u32.into())?;
 			T::ContributionTokenCurrency::set(
 				project_id,
 				&project_details.issuer,
 				token_information.name.into(),
 				token_information.symbol.into(),
 				token_information.decimals,
-			)
-			.map_err(|_| Error::<T>::AssetMetadataUpdateFailed)?;
+			)?;
 		}
 
 		Ok(())
@@ -815,8 +813,7 @@ impl<T: Config> Pallet<T> {
 
 		// * Update Storage *
 		if caller_existing_evaluations.len() < T::MaxEvaluationsPerUser::get() as usize {
-			T::NativeCurrency::hold(&LockType::Evaluation(project_id), &evaluator, plmc_bond)
-				.map_err(|_| Error::<T>::InsufficientBalance)?;
+			T::NativeCurrency::hold(&LockType::Evaluation(project_id), &evaluator, plmc_bond)?;
 		} else {
 			let (low_id, lowest_evaluation) = caller_existing_evaluations
 				.iter()
@@ -835,11 +832,9 @@ impl<T: Config> Pallet<T> {
 				&lowest_evaluation.evaluator,
 				lowest_evaluation.original_plmc_bond,
 				Precision::Exact,
-			)
-			.map_err(|_| Error::<T>::InsufficientBalance)?;
+			)?;
 
-			T::NativeCurrency::hold(&LockType::Evaluation(project_id), &evaluator, plmc_bond)
-				.map_err(|_| Error::<T>::InsufficientBalance)?;
+			T::NativeCurrency::hold(&LockType::Evaluation(project_id), &evaluator, plmc_bond)?;
 
 			Evaluations::<T>::remove((project_id, evaluator.clone(), low_id));
 		}
@@ -2109,8 +2104,7 @@ impl<T: Config> Pallet<T> {
 			to_convert = to_convert.saturating_sub(converted)
 		}
 
-		T::NativeCurrency::hold(&LockType::Participation(project_id), who, to_convert)
-			.map_err(|_| Error::<T>::InsufficientBalance)?;
+		T::NativeCurrency::hold(&LockType::Participation(project_id), who, to_convert)?;
 
 		Ok(())
 	}

--- a/pallets/funding/src/lib.rs
+++ b/pallets/funding/src/lib.rs
@@ -753,9 +753,6 @@ pub mod pallet {
 		Frozen,
 		/// The bid is too low
 		BidTooLow,
-		/// The user has not enough balance to perform the action
-		InsufficientBalance,
-		NotAuthorized,
 		/// The Funding Round of the project has not ended yet
 		CannotClaimYet,
 		/// No bids were made for the project at the time of the auction close
@@ -774,14 +771,10 @@ pub mod pallet {
 		ProjectNotInCandleAuctionRound,
 		/// Tried to move the project to RemainderRound, but it was not in CommunityRound before
 		ProjectNotInCommunityRound,
-		/// Tried to move the project to FundingEndedRound, but it was not in RemainderRound before
-		ProjectNotInRemainderRound,
 		/// Tried to move the project to ReadyToLaunch round, but it was not in FundingEnded round before
 		ProjectNotInFundingEndedRound,
 		/// Tried to start an auction before the initialization period
 		TooEarlyForEnglishAuctionStart,
-		/// Tried to start an auction after the initialization period
-		TooLateForEnglishAuctionStart,
 		/// Tried to move the project to CandleAuctionRound, but its too early for that
 		TooEarlyForCandleAuctionStart,
 		/// Tried to move the project to CommunityRound, but its too early for that
@@ -792,34 +785,16 @@ pub mod pallet {
 		TooEarlyForFundingEnd,
 		/// Checks for other projects not copying metadata of others
 		MetadataAlreadyExists,
-		/// The specified issuer does not exist
-		ProjectIssuerNotFound,
 		/// The specified project info does not exist
 		ProjectInfoNotFound,
 		/// Tried to finish an evaluation before its target end block
 		EvaluationPeriodNotEnded,
 		/// Tried to access field that is not set
 		FieldIsNone,
-		/// Tried to create the contribution token after the remaining round but it failed
-		AssetCreationFailed,
-		/// Tried to update the metadata of the contribution token but it failed
-		AssetMetadataUpdateFailed,
-		/// Tried to do an operation assuming the evaluation failed, when in fact it did not
-		EvaluationNotFailed,
-		/// Tried to unbond PLMC after unsuccessful evaluation, but specified bond does not exist.
-		BondNotFound,
 		/// Checked math failed
 		BadMath,
-		/// Tried to bond PLMC for bidding, but that phase has already ended
-		TooLateForBidBonding,
 		/// Tried to retrieve a bid but it does not exist
 		BidNotFound,
-		/// Tried to append a new bid to storage but too many bids were already made
-		TooManyBids,
-		/// Tried to append a new contribution to storage but too many were made for that user
-		TooManyContributions,
-		/// Tried to bond PLMC for contributing in the community or remainder round, but remainder round ended already
-		TooLateForContributingBonding,
 		/// Tried to contribute but its too low to be accepted
 		ContributionTooLow,
 		/// Contribution is higher than the limit set by the issuer
@@ -834,16 +809,11 @@ pub mod pallet {
 		PriceNotFound,
 		/// Bond is either lower than the minimum set by the issuer, or the vec is full and can't replace an old one with a lower value
 		EvaluationBondTooLow,
-		/// Bond is bigger than the limit set by issuer
-		EvaluationBondTooHigh,
 		/// Tried to do an operation on an evaluation that does not exist
 		EvaluationNotFound,
-		/// Tried to do an operation on a finalizer that is not yet set
-		NoFinalizerSet,
 		/// Tried to do an operation on a finalizer that already finished
 		FinalizerFinished,
-		/// Tried to do an operation on a cleaner that is not ready
-		CleanerNotReady,
+		///
 		ContributionNotFound,
 	}
 

--- a/pallets/funding/src/tests.rs
+++ b/pallets/funding/src/tests.rs
@@ -27,7 +27,7 @@ use std::{
 
 use assert_matches2::assert_matches;
 use frame_support::{
-	assert_noop, assert_ok,
+	assert_err, assert_noop, assert_ok,
 	traits::{
 		fungible::{Inspect as FungibleInspect, InspectHold as FungibleInspectHold, Mutate as FungibleMutate},
 		fungibles::{
@@ -43,7 +43,7 @@ use itertools::Itertools;
 use parachains_common::DAYS;
 use sp_arithmetic::{traits::Zero, Percent, Perquintill};
 use sp_core::H256;
-use sp_runtime::{DispatchError, Either};
+use sp_runtime::{DispatchError, Either, TokenError};
 use sp_std::marker::PhantomData;
 
 use defaults::*;
@@ -2106,8 +2106,8 @@ mod evaluation_round_failure {
 
 		let evaluating_project = EvaluatingProject::new_with(&test_env, project, issuer);
 
-		let dispatch_error = evaluating_project.bond_for_users(evaluations).unwrap_err();
-		assert_eq!(dispatch_error, Error::<TestRuntime>::InsufficientBalance.into())
+		let dispatch_error = evaluating_project.bond_for_users(evaluations);
+		assert_err!(dispatch_error, TokenError::FundsUnavailable)
 	}
 }
 


### PR DESCRIPTION
- Remove the unused errors.
- Remove unnecessary errors, we now rethrow the underlying errors.
- Use the `assert_err` macro from `frame_support` instead of `unwrap_err()` +` assert_ok`.