### PR TITLE
Runtime upgrade to 1.0.0

### DIFF
--- a/runtimes/base/src/lib.rs
+++ b/runtimes/base/src/lib.rs
@@ -179,7 +179,7 @@ pub fn native_version() -> NativeVersion {
 
 parameter_types! {
 	pub const Version: RuntimeVersion = VERSION;
-	pub const SS58Prefix: u16 = 42;
+	pub const SS58Prefix: u16 = 41;
 }
 
 // Configure FRAME pallets to include in runtime.


### PR DESCRIPTION
- add migrations to base runtime to pass try-runtime on-runtime-upgrade