### PR TITLE
Feat/update staking filter

### DIFF
--- a/runtimes/base/src/lib.rs
+++ b/runtimes/base/src/lib.rs
@@ -208,7 +208,6 @@ impl Contains<RuntimeCall> for BaseCallFilter {
 			// Staking "disabled" @ TGE.
 			RuntimeCall::ParachainStaking(inner_call) => match inner_call {
 				cancel_candidate_bond_less { .. } => true,
-				cancel_leave_candidates { .. } => true,
 				execute_candidate_bond_less { .. } => true,
 				schedule_candidate_bond_less { .. } => true,
 				set_auto_compound { .. } => true,


### PR DESCRIPTION
1. Update the `BaseCallFilter` to allow:
  + `schedule_candidate_bond_less`: The first call needed to reduce the self-stake of a Collator.
  + `cancel_candidate_bond_less`: In case a Collator changes its mind, it reverts the `schedule_candidate_bond_less` call. 
  + `execute_candidate_bond_less`:  The second call needed to reduce the self-stake of a Collator, this is the one that actually reduces the self-stake.
  + The configuration setters, callable only via the `RootOrigin`.
  + All the others extrinsics are still disabled. 

2. Bump the `spec_version` to `0_003_001`, aka 0.3.1.
3. Remove already released migrations.
