### PR TITLE
Feat/PLMC-420: All extrinsics failing on new testing node

### DIFF
--- a/pallets/funding/src/lib.rs
+++ b/pallets/funding/src/lib.rs
@@ -1384,6 +1384,8 @@ pub mod pallet {
 				let inst = GenesisInstantiator::<T>::new(None);
 				<T as Config>::SetPrices::set_prices();
 				instantiator::async_features::create_multiple_projects_at(inst, self.starting_projects.clone());
+
+				frame_system::Pallet::<T>::set_block_number(0u32.into());
 			}
 		}
 	}


### PR DESCRIPTION
Set the block to zero after the genesis build of pallet-funding, so transactions are queued at the start of the blockchain, instead of automatically rejected.

If this isn't merged, transactions are still possible, but we need to wait until the collator is overriding the block number