### PR TITLE
Chore/bump version

### DIFF
--- a/runtimes/base/src/lib.rs
+++ b/runtimes/base/src/lib.rs
@@ -189,7 +189,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("polimec-mainnet"),
 	impl_name: create_runtime_str!("polimec-mainnet"),
 	authoring_version: 1,
-	spec_version: 0_004_000,
+	spec_version: 0_005_000,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2023-06-15"
+channel = "1.74.0"
 components = [ "rustfmt", "clippy", "rust-analyzer" ]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
+ Bump Runtime version to `0.5`.
+ Bump Rust toolchain version to `1.74.0`, the same one used to compile the runtime using [srtool v0.13.0](https://github.com/paritytech/srtool/releases/tag/v0.13.0).