### PR TITLE
Feat/benchmarks refactor

### DIFF
--- a/justfile
+++ b/justfile
@@ -18,9 +18,9 @@ test-integration:
 
 # Run the Runtime benchmarks
 # src: https://github.com/polkadot-fellows/runtimes/blob/48ccfae6141d2924f579d81e8b1877efd208693f/system-parachains/asset-hubs/asset-hub-polkadot/src/weights/cumulus_pallet_xcmp_queue.rs
-benchmark-runtime pallet="pallet-linear-release" features="runtime-benchmarks":
+benchmark-runtime pallet="pallet-elections-phragmen" features="runtime-benchmarks":
     cargo run --features {{ features }} --release -p polimec-parachain-node benchmark pallet \
-      --chain=polimec-rococo-local \
+      --chain=base-polkadot \
       --steps=50 \
       --repeat=20 \
       --pallet={{ pallet }} \
@@ -31,9 +31,9 @@ benchmark-runtime pallet="pallet-linear-release" features="runtime-benchmarks":
 
 # Benchmark the "Testnet" Runtime
 # src: https://github.com/paritytech/polkadot-sdk/blob/bc2e5e1fe26e2c2c8ee766ff9fe7be7e212a0c62/substrate/frame/nfts/src/weights.rs
-benchmark-pallet pallet="pallet-linear-release" features="runtime-benchmarks":
+benchmark-pallet pallet="pallet-elections-phragmen" features="runtime-benchmarks":
     cargo run --features {{ features }} --release -p polimec-parachain-node benchmark pallet \
-      --chain=polimec-rococo-local \
+      --chain=base-polkadot \
       --steps=50 \
       --repeat=20 \
       --pallet={{ pallet }}  \

--- a/justfile
+++ b/justfile
@@ -16,30 +16,35 @@ test-runtime-features:
 test-integration:
     cargo test -p integration-tests
 
-# Run the runtime benchmarks
-# src: https://github.com/polkadot-fellows/runtimes/blob/main/system-parachains/asset-hubs/asset-hub-polkadot/src/weights/cumulus_pallet_xcmp_queue.rs
+# Run the Runtime benchmarks
+# src: https://github.com/polkadot-fellows/runtimes/blob/48ccfae6141d2924f579d81e8b1877efd208693f/system-parachains/asset-hubs/asset-hub-polkadot/src/weights/cumulus_pallet_xcmp_queue.rs
 benchmark-runtime pallet="pallet-linear-release" features="runtime-benchmarks":
     cargo run --features {{ features }} --release -p polimec-parachain-node benchmark pallet \
-    	--chain=polimec-rococo-local \
-    	--steps=50 \
-    	--repeat=20 \
-    	--pallet={{ pallet }} \
-    	--extrinsic=* \
-    	--wasm-execution=compiled \
-    	--heap-pages=4096 \
-    	--output=runtimes/base/src/weights/{{ replace(pallet, "-", "_") }}.rs
+      --chain=polimec-rococo-local \
+      --steps=50 \
+      --repeat=20 \
+      --pallet={{ pallet }} \
+      --extrinsic=* \
+      --wasm-execution=compiled \
+      --heap-pages=4096 \
+      --output=runtimes/base/src/weights/{{ replace(pallet, "-", "_") }}.rs
 
 # Benchmark the "Testnet" Runtime
+# src: https://github.com/paritytech/polkadot-sdk/blob/bc2e5e1fe26e2c2c8ee766ff9fe7be7e212a0c62/substrate/frame/nfts/src/weights.rs
 benchmark-pallet pallet="pallet-linear-release" features="runtime-benchmarks":
     cargo run --features {{ features }} --release -p polimec-parachain-node benchmark pallet \
-    	--chain=polimec-rococo-local \
-    	--steps=50 \
-    	--repeat=20 \
-    	--pallet={{ pallet }}  \
-    	--extrinsic '*' \
-    	--heap-pages=4096 \
-    	--output=pallets/{{ replace(pallet, "pallet-", "") }}/src/weights.rs \
-    	--template=./.maintain/frame-weight-template.hbs
+      --chain=polimec-rococo-local \
+      --steps=50 \
+      --repeat=20 \
+      --pallet={{ pallet }}  \
+      --no-storage-info \
+      --no-median-slopes \
+      --no-min-squares \
+      --extrinsic '*' \
+      --wasm-execution=compiled \
+      --heap-pages=4096 \
+      --output=pallets/{{ replace(pallet, "pallet-", "") }}/src/weights.rs \
+      --template=./.maintain/frame-weight-template.hbs
 
 # Build the Node Docker Image
 docker-build tag="latest" package="polimec-parachain-node":

--- a/justfile
+++ b/justfile
@@ -1,100 +1,54 @@
 # Help information
 default:
-  @just --list
-
-# Build everything
-build-all:
-	cargo build --release
-
-# Build the "Base" Runtime
-build-base-runtime:
-	cargo build --release -p polimec-base-runtime
-
-# Build the "Testnet" Runtime
-build-parachain-runtime:
-	cargo build --release -p polimec-parachain-runtime
-
-# Build the "Parachain" Node
-build-parachain-node:
-	cargo build --release -p polimec-parachain-node
+    @just --list
 
 # Build the "Base" Runtime using srtool
 build-base-srtool:
-	srtool build --root -p polimec-base-runtime --runtime-dir runtimes/base --build-opts="--features=on-chain-release-build"
+    srtool build --root -p polimec-base-runtime --runtime-dir runtimes/base --build-opts="--features=on-chain-release-build"
 
 # Build the "Testnet" Runtime using srtool
-build-parachain-srtool:
-	srtool build --root -p polimec-parachain-runtime --runtime-dir runtimes/testnet
 
 # Test the runtimes features
 test-runtime-features:
-	cargo test --features runtime-benchmarks -p polimec-parachain-runtime
+    cargo test --features runtime-benchmarks -p polimec-parachain-runtime
 
 # Run the integration tests
 test-integration:
-	cargo test -p integration-tests
+    cargo test -p integration-tests
 
-
-# Benchmark the "Testnet" Runtime
-benchmark-runtime-funding:
-	cargo run --features runtime-benchmarks --release -p polimec-parachain-node benchmark pallet \
-		--chain=polimec-rococo-local \
-		--steps=50 \
-		--repeat=20 \
-		--pallet=pallet_funding \
-		--extrinsic '*' \
-		--wasm-execution=compiled \
-		--heap-pages=4096 \
-		--output=runtimes/testnet/src/weights/pallet_funding.rs
-
-
-# Benchmark the "Testnet" Runtime
-benchmark-runtime-linear-release:
-	cargo run --features runtime-benchmarks --release -p polimec-parachain-node benchmark pallet \
-		--chain=polimec-rococo-local \
-		--steps=50 \
-		--repeat=20 \
-		--pallet=pallet_linear_release \
-		--extrinsic '*' \
-		--wasm-execution=compiled \
-		--heap-pages=4096 \
-		--output=runtimes/testnet/src/weights/pallet_linear_release.rs
+# Run the runtime benchmarks
+# src: https://github.com/polkadot-fellows/runtimes/blob/main/system-parachains/asset-hubs/asset-hub-polkadot/src/weights/cumulus_pallet_xcmp_queue.rs
+benchmark-runtime pallet="pallet-linear-release" features="runtime-benchmarks":
+    cargo run --features {{ features }} --release -p polimec-parachain-node benchmark pallet \
+    	--chain=polimec-rococo-local \
+    	--steps=50 \
+    	--repeat=20 \
+    	--pallet={{ pallet }} \
+    	--extrinsic=* \
+    	--wasm-execution=compiled \
+    	--heap-pages=4096 \
+    	--output=runtimes/base/src/weights/{{ replace(pallet, "-", "_") }}.rs
 
 # Benchmark the "Testnet" Runtime
-benchmark-pallet-funding:
-	cargo run --features runtime-benchmarks,fast-mode --release -p polimec-parachain-node benchmark pallet \
-		--chain=polimec-rococo-local \
-		--steps=50 \
-		--repeat=20 \
-		--pallet=pallet_funding \
-		--extrinsic '*' \
-		--heap-pages=4096 \
-		--output=pallets/funding/src/weights-test.rs \
-		--template=./.maintain/frame-weight-template.hbs
-
-benchmark-pallet-linear-release:
-	cargo run --features runtime-benchmarks,fast-mode --release -p polimec-parachain-node benchmark pallet \
-		--chain=polimec-rococo-local \
-		--steps=50 \
-		--repeat=20 \
-		--pallet=pallet_linear_release \
-		--extrinsic '*' \
-		--heap-pages=4096 \
-		--output=pallets/linear-release/src/weights.rs \
-		--template=./.maintain/frame-weight-template.hbs
-
-benchmarks-test:
-    cargo test --features runtime-benchmarks -p pallet-funding benchmarks
-
+benchmark-pallet pallet="pallet-linear-release" features="runtime-benchmarks":
+    cargo run --features {{ features }} --release -p polimec-parachain-node benchmark pallet \
+    	--chain=polimec-rococo-local \
+    	--steps=50 \
+    	--repeat=20 \
+    	--pallet={{ pallet }}  \
+    	--extrinsic '*' \
+    	--heap-pages=4096 \
+    	--output=pallets/{{ replace(pallet, "pallet-", "") }}/src/weights.rs \
+    	--template=./.maintain/frame-weight-template.hbs
 
 # Build the Node Docker Image
-docker-build tag = "latest" package= "polimec-parachain-node":
-	./scripts/build_image.sh {{tag}} ./Dockerfile {{package}}
+docker-build tag="latest" package="polimec-parachain-node":
+    ./scripts/build_image.sh {{ tag }} ./Dockerfile {{ package }}
 
 # Create the "Base" Runtime Chainspec
 create-chainspec-base:
-	./scripts/create_base_chain_spec.sh ./runtimes/base/target/srtool/release/wbuild/polimec-base-runtime/polimec_base_runtime.compact.compressed.wasm 2105
+    ./scripts/create_base_chain_spec.sh ./runtimes/base/target/srtool/release/wbuild/polimec-base-runtime/polimec_base_runtime.compact.compressed.wasm 2105
 
 # Use zombienet to spawn rococo + polimec testnet
-zombienet path_to_file = "scripts/zombienet/native/base-rococo-local.toml":
-	zombienet spawn {{path_to_file}}
+zombienet path_to_file="scripts/zombienet/native/base-rococo-local.toml":
+    zombienet spawn {{ path_to_file }}

--- a/justfile
+++ b/justfile
@@ -16,8 +16,8 @@ test-runtime-features:
 test-integration:
     cargo test -p integration-tests
 
-# Run the Runtime benchmarks
 # src: https://github.com/polkadot-fellows/runtimes/blob/48ccfae6141d2924f579d81e8b1877efd208693f/system-parachains/asset-hubs/asset-hub-polkadot/src/weights/cumulus_pallet_xcmp_queue.rs
+# Benchmark a specific pallet on the "Base" Runtime
 benchmark-runtime pallet="pallet-elections-phragmen" features="runtime-benchmarks":
     cargo run --features {{ features }} --release -p polimec-parachain-node benchmark pallet \
       --chain=base-polkadot \
@@ -29,8 +29,8 @@ benchmark-runtime pallet="pallet-elections-phragmen" features="runtime-benchmark
       --heap-pages=4096 \
       --output=runtimes/base/src/weights/{{ replace(pallet, "-", "_") }}.rs
 
-# Benchmark the "Testnet" Runtime
 # src: https://github.com/paritytech/polkadot-sdk/blob/bc2e5e1fe26e2c2c8ee766ff9fe7be7e212a0c62/substrate/frame/nfts/src/weights.rs
+# Run the Runtime benchmarks for a specific pallet
 benchmark-pallet pallet="pallet-elections-phragmen" features="runtime-benchmarks":
     cargo run --features {{ features }} --release -p polimec-parachain-node benchmark pallet \
       --chain=base-polkadot \

--- a/nodes/parachain/src/chain_spec/base.rs
+++ b/nodes/parachain/src/chain_spec/base.rs
@@ -31,7 +31,7 @@ use base_runtime::{
 		inflation::{perbill_annual_to_perbill_round, BLOCKS_PER_YEAR},
 		InflationInfo, Range,
 	},
-	AccountId, AuraId as AuthorityId, Balance, BalancesConfig, MinCandidateStk, ParachainInfoConfig,
+	AccountId, AuraId as AuthorityId, Balance, BalancesConfig, ElectionsConfig, MinCandidateStk, ParachainInfoConfig,
 	ParachainStakingConfig, PolkadotXcmConfig, RuntimeGenesisConfig, SessionConfig, SudoConfig, SystemConfig, PLMC,
 };
 
@@ -216,9 +216,12 @@ fn base_testnet_genesis(
 	sudo_account: AccountId,
 	id: ParaId,
 ) -> RuntimeGenesisConfig {
+	const ENDOWMENT: Balance = 10_000_000 * PLMC;
+	const STASH: Balance = ENDOWMENT / 1000;
+
 	RuntimeGenesisConfig {
 		system: SystemConfig { code: wasm_binary.to_vec(), ..Default::default() },
-		balances: BalancesConfig { balances: endowed_accounts },
+		balances: BalancesConfig { balances: endowed_accounts.clone() },
 		parachain_info: ParachainInfoConfig { parachain_id: id, ..Default::default() },
 		parachain_staking: ParachainStakingConfig {
 			candidates: stakers.iter().map(|(accunt, _, balance)| (accunt.clone(), *balance)).collect::<Vec<_>>(),
@@ -254,7 +257,15 @@ fn base_testnet_genesis(
 		council: Default::default(),
 		technical_committee: Default::default(),
 		democracy: Default::default(),
-		elections: Default::default(),
+		elections: ElectionsConfig {
+			members: endowed_accounts
+				.iter()
+				.map(|(member, _)| member)
+				.take((endowed_accounts.len() + 1) / 2)
+				.cloned()
+				.map(|member| (member, STASH))
+				.collect(),
+		},
 		treasury: Default::default(),
 		vesting: Default::default(),
 	}

--- a/pallets/democracy/Cargo.toml
+++ b/pallets/democracy/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "pallet-democracy"
-version = "4.0.0-dev"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
-license = "Apache-2.0"
-homepage = "https://substrate.io"
+license-file.workspace = true
+homepage.workspace = true
 repository.workspace = true
 description = "FRAME pallet for democracy"
 readme = "README.md"

--- a/pallets/elections-phragmen/Cargo.toml
+++ b/pallets/elections-phragmen/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "pallet-elections-phragmen"
-version = "5.0.0-dev"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
-license = "Apache-2.0"
-homepage = "https://substrate.io"
+license-file.workspace = true
+homepage.workspace = true
 repository.workspace = true
 description = "FRAME pallet based on seq-Phragmén election method."
 readme = "README.md"

--- a/pallets/elections-phragmen/src/benchmarking.rs
+++ b/pallets/elections-phragmen/src/benchmarking.rs
@@ -24,14 +24,12 @@ use frame_system::RawOrigin;
 
 use crate::Pallet as Elections;
 
-const BALANCE_FACTOR: u32 = 250;
-
 /// grab new account with infinite balance.
 fn endowed_account<T: Config>(name: &'static str, index: u32) -> T::AccountId {
 	let account: T::AccountId = account(name, index, 0);
 	// Fund each account with at-least their stake but still a sane amount as to not mess up
 	// the vote calculation.
-	let amount = default_stake::<T>(T::MaxVoters::get()) * BalanceOf::<T>::from(BALANCE_FACTOR);
+	let amount = default_stake::<T>(T::MaxVoters::get()) * T::CandidacyBond::get();
 	let _ = T::Currency::set_balance(&account, amount);
 	// important to increase the total issuance since T::CurrencyToVote will need it to be sane for
 	// phragmen to work.

--- a/runtimes/base/src/lib.rs
+++ b/runtimes/base/src/lib.rs
@@ -814,6 +814,7 @@ mod benches {
 		[pallet_session, SessionBench::<Runtime>]
 		[pallet_timestamp, Timestamp]
 		[cumulus_pallet_xcmp_queue, XcmpQueue]
+		[pallet_elections_phragmen, Elections]
 	);
 }
 

--- a/runtimes/base/src/lib.rs
+++ b/runtimes/base/src/lib.rs
@@ -809,12 +809,38 @@ construct_runtime!(
 #[cfg(feature = "runtime-benchmarks")]
 mod benches {
 	frame_benchmarking::define_benchmarks!(
+		// System support stuff.
 		[frame_system, SystemBench::<Runtime>]
-		[pallet_balances, Balances]
-		[pallet_session, SessionBench::<Runtime>]
 		[pallet_timestamp, Timestamp]
+		[pallet_sudo, Sudo]
+		[pallet_utility, Utility]
+		[pallet_multisig, Multisig]
+		[pallet_proxy, Proxy]
+
+		// Monetary stuff.
+		[pallet_balances, Balances]
+		[pallet_vesting, Vesting]
+		
+		// Collator support.
+		[pallet_session, SessionBench::<Runtime>]
+		[pallet_parachain_staking, ParachainStaking]
+		
+		// XCM helpers.
 		[cumulus_pallet_xcmp_queue, XcmpQueue]
+		[pallet_xcm, PolkadotXcm]
+
+		// Governance
+		[pallet_treasury, Treasury]
+		[pallet_democracy, Democracy]
+		[pallet_collective, Council]
+		[pallet_collective, TechnicalCommittee]
 		[pallet_elections_phragmen, Elections]
+		[pallet_preimage, Preimage]
+		[pallet_scheduler, Scheduler]
+
+		// Oracle
+		[pallet_membership, OracleProvidersMembership]
+		//[orml_oracle, Oracle]
 	);
 }
 

--- a/runtimes/shared-configuration/src/governance.rs
+++ b/runtimes/shared-configuration/src/governance.rs
@@ -104,20 +104,24 @@ parameter_types! {
 	pub const MinimumDeposit: Balance = 100 * PLMC;
 	pub const EnactmentPeriod: BlockNumber = ENACTMENT_PERIOD;
 	pub const CooloffPeriod: BlockNumber = COOLOFF_PERIOD;
+
 	// Council Pallet
 	pub const CouncilMotionDuration: BlockNumber = COUNCIL_MOTION_DURATION;
 	pub const CouncilMaxProposals: u32 = 7;
 	pub const CouncilMaxMembers: u32 = 20;
+	
 	// Technical Committee
 	pub const TechnicalMotionDuration: BlockNumber = TECHNICAL_MOTION_DURATION;
 	pub const TechnicalMaxProposals: u32 = 7;
 	pub const TechnicalMaxMembers: u32 = 5;
+	
 	// Extras
 	pub const PreimageBaseDeposit: Balance = deposit(2, 64);
 	pub const MaxProposals: u32 = 10;
 	pub const MaxVotes: u32 = 100;
 	pub const MaxBlacklisted: u32 = 100;
 	pub const MaxDeposits: u32 = 100;
+	
 	//Treasury
 	pub const ProposalBond: Permill = Permill::from_percent(5);
 	pub const ProposalBondMinimum: Balance = 50 * PLMC;


### PR DESCRIPTION
This PR lays the groundwork for properly benchmarking our runtime.

+ We've included all pallets that contain a `WeightInfo` config parameter within the `define_benchmarks!` macro. This inclusion allows us to start the benchmark using the node compiled with the `runtime-benchmarks` feature.
+ The `just` command for executing the benchmarks has been made generic to the pallet's name. For instance, executing `just benchmark-runtime pallet-proxy` allows us to benchmark `pallet-proxy.` Any pallet that is part of the `define_benchmarks! `macro can be benchmarked using this command.

> Curious to see which pallets/extrinsic we can run benchmarks of? `cargo run --features runtime-benchmarks --release benchmark pallets --list --chain=base-polkadot `

+ Following the merge of https://github.com/Polimec/polimec-node/pull/154, we encountered failures in the runtime benchmarks for the `pallet-elections-phragmen`. To address this:
  + We added the ElectionsConfig to the Genesis Config, as in https://github.com/paritytech/polkadot-sdk/blob/8c1c99f07a4623c9454e40e6bc077c6ba4611e4e/substrate/bin/node/cli/src/chain_spec.rs#L408-L415.
  + ❗To be Verified: The balance of the endowed accounts was modified during the benchmarks otherwise the balance was too loo. This adjustment needs further review to ensure its accuracy and correctness. https://github.com/Polimec/polimec-node/blob/a7928b74d2123d8e56f8dd3559813a80fff22b62/pallets/elections-phragmen/src/benchmarking.rs#L32