### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Polimec is a blockchain platform built on Substrate, designed for robustness and
 ### Running the Network
 
 1. **Launch the network with Zombienet**:
-   `zombienet spawn scripts/local_parachain.toml -p native`
+   `zombienet spawn scripts/zombienet/native/local-testnet.toml`
+2. A Polimec node is now reachable at https://polkadot.js.org/apps/?rpc=ws://127.0.0.1:8080#/explorer 
 
 ## Additional Resources
 

--- a/scripts/zombienet/native/local-testnet.toml
+++ b/scripts/zombienet/native/local-testnet.toml
@@ -1,0 +1,32 @@
+[settings]
+timeout = 1000
+provider = "native"
+
+[relaychain]
+default_command = "polkadot"
+chain = "rococo-local"
+
+	[[relaychain.nodes]]
+	name = "eve"
+
+	[[relaychain.nodes]]
+	name = "ferdie"
+
+	[[relaychain.nodes]]
+	name = "charlie"
+
+	[[relaychain.nodes]]
+	name = "dave"
+
+[[parachains]]
+id = 3344
+chain = "polimec-rococo-local"
+
+	[[parachains.collators]]
+	name = "alice"
+	command = "polimec"
+    ws_port = 8080
+
+	[[parachains.collators]]
+	name = "bob"
+	command = "polimec"


### PR DESCRIPTION
In the README the guide to starting a node locally had not been updated. This PR fixes the README and adds a new Zombienet `.toml` to start a testnet locally. 