### PR TITLE
chore: prepare 0.5 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3918,7 +3918,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "asset-hub-polkadot-runtime",
  "cumulus-pallet-xcm",
@@ -3932,8 +3932,8 @@ dependencies = [
  "pallet-assets",
  "pallet-balances",
  "pallet-collective",
- "pallet-democracy 0.4.0",
- "pallet-elections-phragmen 0.4.0",
+ "pallet-democracy 0.5.0",
+ "pallet-elections-phragmen 0.5.0",
  "pallet-funding",
  "pallet-im-online",
  "pallet-linear-release",
@@ -6037,7 +6037,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-democracy"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6111,7 +6111,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-elections-phragmen"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6170,7 +6170,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-funding"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "assert_matches2",
  "frame-benchmarking",
@@ -6318,7 +6318,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-linear-release"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6541,7 +6541,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-oracle-ocw"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6565,7 +6565,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-parachain-staking"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7468,7 +7468,7 @@ dependencies = [
 
 [[package]]
 name = "polimec-base-runtime"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -7493,8 +7493,8 @@ dependencies = [
  "pallet-authorship",
  "pallet-balances",
  "pallet-collective",
- "pallet-democracy 0.4.0",
- "pallet-elections-phragmen 0.4.0",
+ "pallet-democracy 0.5.0",
+ "pallet-elections-phragmen 0.5.0",
  "pallet-identity",
  "pallet-membership",
  "pallet-multisig",
@@ -7568,7 +7568,7 @@ dependencies = [
 
 [[package]]
 name = "polimec-parachain-node"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "color-print",
@@ -7639,7 +7639,7 @@ dependencies = [
 
 [[package]]
 name = "polimec-parachain-runtime"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -7666,8 +7666,8 @@ dependencies = [
  "pallet-authorship",
  "pallet-balances",
  "pallet-collective",
- "pallet-democracy 0.4.0",
- "pallet-elections-phragmen 0.4.0",
+ "pallet-democracy 0.5.0",
+ "pallet-elections-phragmen 0.5.0",
  "pallet-funding",
  "pallet-identity",
  "pallet-insecure-randomness-collective-flip",
@@ -7739,7 +7739,7 @@ dependencies = [
 
 [[package]]
 name = "polimec-xcm-executor"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -11473,7 +11473,7 @@ dependencies = [
 
 [[package]]
 name = "shared-configuration"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://www.polimec.org/"
 license-file = "LICENSE"
 readme = "README.md"
 repository = "https://github.com/Polimec/polimec-node"
-version = "0.4.0"
+version = "0.5.0"
 
 [profile.release]
 # Substrate runtime requires unwinding.

--- a/runtimes/base/src/lib.rs
+++ b/runtimes/base/src/lib.rs
@@ -198,7 +198,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("polimec-mainnet"),
 	impl_name: create_runtime_str!("polimec-mainnet"),
 	authoring_version: 1,
-	spec_version: 0_005_001,
+	spec_version: 0_005_000,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
## What?

Bump the version to `0.5`.

## Why?

We are ready for a new runtime upgrtade! A tentative changelog is available here: https://github.com/Polimec/polimec-node/releases/tag/v0.5.0
