### PR TITLE
Feature/plmc 442 delete remove from update store

### DIFF
--- a/pallets/funding/src/benchmarking.rs
+++ b/pallets/funding/src/benchmarking.rs
@@ -329,9 +329,7 @@ pub fn run_blocks_to_execute_next_transition<T: Config>(
 	update_type: UpdateType,
 	inst: &mut BenchInstantiator<T>,
 ) {
-	let pair = inst.get_update_pair(project_id, &update_type);
-	assert!(pair.is_some());
-	let (update_block, _) = pair.unwrap();
+	let update_block = inst.get_update_block(project_id, &update_type).unwrap();
 	frame_system::Pallet::<T>::set_block_number(update_block - 1u32.into());
 	inst.advance_time(One::one()).unwrap();
 }
@@ -2273,7 +2271,7 @@ mod benchmarks {
 		// * validity checks *
 		// Storage
 		let maybe_transition =
-			inst.get_update_pair(project_id, &UpdateType::ProjectDecision(FundingOutcomeDecision::AcceptFunding));
+			inst.get_update_block(project_id, &UpdateType::ProjectDecision(FundingOutcomeDecision::AcceptFunding));
 		assert!(maybe_transition.is_some());
 
 		// Events

--- a/pallets/funding/src/benchmarking.rs
+++ b/pallets/funding/src/benchmarking.rs
@@ -1213,10 +1213,7 @@ mod benchmarks {
 		if let Some(fully_filled_vecs_from_insertion) = ends_round {
 			// if all CTs are sold, next round is scheduled for next block (either remainder or success)
 			let expected_insertion_block = inst.current_block() + One::one();
-			fill_projects_to_update::<T>(
-				fully_filled_vecs_from_insertion,
-				expected_insertion_block,
-			);
+			fill_projects_to_update::<T>(fully_filled_vecs_from_insertion, expected_insertion_block);
 		}
 
 		(
@@ -2231,7 +2228,7 @@ mod benchmarks {
 		let mut inst = BenchInstantiator::<T>::new(None);
 
 		// We need to leave enough block numbers to fill `ProjectsToUpdate` before our project insertion
-		
+
 		let time_advance: u32 = x + 2;
 		frame_system::Pallet::<T>::set_block_number(time_advance.into());
 
@@ -2275,7 +2272,8 @@ mod benchmarks {
 
 		// * validity checks *
 		// Storage
-		let maybe_transition = inst.get_update_pair(project_id, &UpdateType::ProjectDecision(FundingOutcomeDecision::AcceptFunding));
+		let maybe_transition =
+			inst.get_update_pair(project_id, &UpdateType::ProjectDecision(FundingOutcomeDecision::AcceptFunding));
 		assert!(maybe_transition.is_some());
 
 		// Events

--- a/pallets/funding/src/benchmarking.rs
+++ b/pallets/funding/src/benchmarking.rs
@@ -3556,51 +3556,16 @@ mod benchmarks {
 		}
 
 		#[test]
-		fn bench_first_contribution_no_ct_deposit() {
+		fn bench_contribution() {
 			new_test_ext().execute_with(|| {
-				assert_ok!(PalletFunding::<TestRuntime>::test_first_contribution_no_ct_deposit());
+				assert_ok!(PalletFunding::<TestRuntime>::test_contribution());
 			});
 		}
 
 		#[test]
-		fn bench_first_contribution_with_ct_deposit() {
+		fn bench_contribution_ends_round() {
 			new_test_ext().execute_with(|| {
-				assert_ok!(PalletFunding::<TestRuntime>::test_first_contribution_with_ct_deposit());
-			});
-		}
-
-		#[test]
-		fn bench_first_contribution_ends_round_no_ct_deposit() {
-			new_test_ext().execute_with(|| {
-				assert_ok!(PalletFunding::<TestRuntime>::test_first_contribution_ends_round_no_ct_deposit());
-			});
-		}
-
-		#[test]
-		fn bench_first_contribution_ends_round_with_ct_deposit() {
-			new_test_ext().execute_with(|| {
-				assert_ok!(PalletFunding::<TestRuntime>::test_first_contribution_ends_round_with_ct_deposit());
-			});
-		}
-
-		#[test]
-		fn bench_second_to_limit_contribution() {
-			new_test_ext().execute_with(|| {
-				assert_ok!(PalletFunding::<TestRuntime>::test_second_to_limit_contribution());
-			});
-		}
-
-		#[test]
-		fn bench_second_to_limit_contribution_ends_round() {
-			new_test_ext().execute_with(|| {
-				assert_ok!(PalletFunding::<TestRuntime>::test_second_to_limit_contribution_ends_round());
-			});
-		}
-
-		#[test]
-		fn bench_contribution_over_limit() {
-			new_test_ext().execute_with(|| {
-				assert_ok!(PalletFunding::<TestRuntime>::test_contribution_over_limit());
+				assert_ok!(PalletFunding::<TestRuntime>::test_contribution_ends_round());
 			});
 		}
 

--- a/pallets/funding/src/functions.rs
+++ b/pallets/funding/src/functions.rs
@@ -608,7 +608,7 @@ impl<T: Config> Pallet<T> {
 		ensure!(project_details.status == ProjectStatus::CommunityRound, Error::<T>::ProjectNotInCommunityRound);
 
 		// Transition to remainder round was initiated by `do_community_funding`, but the ct
-		// tokens where already sold in the community round. This transition is obsolite.
+		// tokens where already sold in the community round. This transition is obsolete.
 		ensure!(
 			project_details
 				.remaining_contribution_tokens

--- a/pallets/funding/src/functions.rs
+++ b/pallets/funding/src/functions.rs
@@ -610,7 +610,11 @@ impl<T: Config> Pallet<T> {
 		// Transition to remainder round was initiated by `do_community_funding`, but the ct
 		// tokens where already sold in the community round. This transition is obsolite.
 		ensure!(
-			project_details.remaining_contribution_tokens.0.saturating_add(project_details.remaining_contribution_tokens.1) > 0u32.into(),
+			project_details
+				.remaining_contribution_tokens
+				.0
+				.saturating_add(project_details.remaining_contribution_tokens.1) >
+				0u32.into(),
 			Error::<T>::RoundTransitionAlreadyHappened
 		);
 
@@ -691,7 +695,12 @@ impl<T: Config> Pallet<T> {
 		// do_end_funding was already executed, but automatic transition was included in the
 		// do_remainder_funding function. We gracefully skip the this transition.
 		ensure!(
-			!matches!(project_details.status, ProjectStatus::FundingSuccessful | ProjectStatus::FundingFailed | ProjectStatus::AwaitingProjectDecision),
+			!matches!(
+				project_details.status,
+				ProjectStatus::FundingSuccessful |
+					ProjectStatus::FundingFailed |
+					ProjectStatus::AwaitingProjectDecision
+			),
 			Error::<T>::RoundTransitionAlreadyHappened
 		);
 
@@ -776,7 +785,10 @@ impl<T: Config> Pallet<T> {
 	pub fn do_project_decision(project_id: ProjectId, decision: FundingOutcomeDecision) -> DispatchResultWithPostInfo {
 		// * Get variables *
 		let project_details = ProjectsDetails::<T>::get(project_id).ok_or(Error::<T>::ProjectDetailsNotFound)?;
-		ensure!(project_details.status == ProjectStatus::AwaitingProjectDecision, Error::<T>::RoundTransitionAlreadyHappened);
+		ensure!(
+			project_details.status == ProjectStatus::AwaitingProjectDecision,
+			Error::<T>::RoundTransitionAlreadyHappened
+		);
 
 		// * Update storage *
 		match decision {
@@ -1344,11 +1356,10 @@ impl<T: Config> Pallet<T> {
 		// return correct weight function
 		let actual_weight = match weight_round_end_flag {
 			None => Some(WeightInfoOf::<T>::contribution(caller_existing_contributions.len() as u32)),
-			Some(fully_filled_vecs_from_insertion) =>
-				Some(WeightInfoOf::<T>::contribution_ends_round(
-					caller_existing_contributions.len() as u32,
-					fully_filled_vecs_from_insertion,
-				)),
+			Some(fully_filled_vecs_from_insertion) => Some(WeightInfoOf::<T>::contribution_ends_round(
+				caller_existing_contributions.len() as u32,
+				fully_filled_vecs_from_insertion,
+			)),
 		};
 
 		Ok(PostDispatchInfo { actual_weight, pays_fee: Pays::Yes })
@@ -2552,7 +2563,6 @@ impl<T: Config> Pallet<T> {
 		}
 		return Err(T::MaxProjectsToUpdateInsertionAttempts::get());
 	}
-
 
 	pub fn create_bucket_from_metadata(metadata: &ProjectMetadataOf<T>) -> Result<BucketOf<T>, DispatchError> {
 		let bucket_delta_amount = Percent::from_percent(10) * metadata.total_allocation_size.0;

--- a/pallets/funding/src/functions.rs
+++ b/pallets/funding/src/functions.rs
@@ -394,7 +394,7 @@ impl<T: Config> Pallet<T> {
 			Err(insertion_attempts) =>
 				return Err(DispatchErrorWithPostInfo {
 					post_info: PostDispatchInfo {
-						actual_weight: Some(WeightInfoOf::<T>::start_auction_automatically(insertion_attempts)),
+						actual_weight: Some(WeightInfoOf::<T>::start_auction_manually(insertion_attempts)),
 						pays_fee: Pays::Yes,
 					},
 					error: Error::<T>::TooManyInsertionAttempts.into(),
@@ -405,7 +405,7 @@ impl<T: Config> Pallet<T> {
 		Self::deposit_event(Event::EnglishAuctionStarted { project_id, when: now });
 
 		Ok(PostDispatchInfo {
-			actual_weight: Some(WeightInfoOf::<T>::start_auction_automatically(insertion_attempts)),
+			actual_weight: Some(WeightInfoOf::<T>::start_auction_manually(insertion_attempts)),
 			pays_fee: Pays::Yes,
 		})
 	}

--- a/pallets/funding/src/functions.rs
+++ b/pallets/funding/src/functions.rs
@@ -290,7 +290,6 @@ impl<T: Config> Pallet<T> {
 				.update(Some(auction_initialize_period_start_block), Some(auction_initialize_period_end_block));
 			project_details.status = ProjectStatus::AuctionInitializePeriod;
 			ProjectsDetails::<T>::insert(project_id, project_details);
-			// TODO: return real weights
 			let insertion_attempts = match Self::add_to_update_store(
 				auction_initialize_period_end_block + 1u32.into(),
 				(&project_id, UpdateType::EnglishAuctionStart),
@@ -358,11 +357,6 @@ impl<T: Config> Pallet<T> {
 			.auction_initialize_period
 			.start()
 			.ok_or(Error::<T>::EvaluationPeriodNotEnded)?;
-		let auction_initialize_period_end_block = project_details
-			.phase_transition_points
-			.auction_initialize_period
-			.end()
-			.ok_or(Error::<T>::EvaluationPeriodNotEnded)?;
 
 		// * Validity checks *
 		ensure!(
@@ -370,6 +364,9 @@ impl<T: Config> Pallet<T> {
 			Error::<T>::NotAllowed
 		);
 		ensure!(now >= auction_initialize_period_start_block, Error::<T>::TooEarlyForEnglishAuctionStart);
+		// If the auction is first manually started, the automatic transition fails here. This
+		// behaviour is intended, as it gracefully skips the automatic transition if the
+		// auction was started manually.
 		ensure!(
 			project_details.status == ProjectStatus::AuctionInitializePeriod,
 			Error::<T>::ProjectNotInAuctionInitializePeriodRound
@@ -387,28 +384,7 @@ impl<T: Config> Pallet<T> {
 		project_details.status = ProjectStatus::AuctionRound(AuctionPhase::English);
 		ProjectsDetails::<T>::insert(project_id, project_details);
 
-		// If this function was called inside the period, then it was called by the extrinsic and we need to
-		// remove the scheduled automatic transition
-		let mut remove_attempts: u32 = 0u32;
-		let mut insertion_attempts: u32 = 0u32;
-		if now <= auction_initialize_period_end_block {
-			match Self::remove_from_update_store(&project_id) {
-				Ok(iterations) => {
-					remove_attempts = iterations;
-				},
-				Err(iterations) =>
-					return Err(DispatchErrorWithPostInfo {
-						post_info: PostDispatchInfo {
-							actual_weight: Some(WeightInfoOf::<T>::start_auction_manually(
-								insertion_attempts,
-								iterations,
-							)),
-							pays_fee: Pays::Yes,
-						},
-						error: Error::<T>::ProjectNotInUpdateStore.into(),
-					}),
-			}
-		}
+		let insertion_attempts;
 		// Schedule for automatic transition to candle auction round
 		match Self::add_to_update_store(english_end_block + 1u32.into(), (&project_id, UpdateType::CandleAuctionStart))
 		{
@@ -418,11 +394,7 @@ impl<T: Config> Pallet<T> {
 			Err(insertion_attempts) =>
 				return Err(DispatchErrorWithPostInfo {
 					post_info: PostDispatchInfo {
-						actual_weight: if remove_attempts == 0u32 {
-							Some(WeightInfoOf::<T>::start_auction_automatically(insertion_attempts))
-						} else {
-							Some(WeightInfoOf::<T>::start_auction_manually(insertion_attempts, remove_attempts))
-						},
+						actual_weight: Some(WeightInfoOf::<T>::start_auction_automatically(insertion_attempts)),
 						pays_fee: Pays::Yes,
 					},
 					error: Error::<T>::TooManyInsertionAttempts.into(),
@@ -433,11 +405,7 @@ impl<T: Config> Pallet<T> {
 		Self::deposit_event(Event::EnglishAuctionStarted { project_id, when: now });
 
 		Ok(PostDispatchInfo {
-			actual_weight: if remove_attempts == 0u32 {
-				Some(WeightInfoOf::<T>::start_auction_automatically(insertion_attempts))
-			} else {
-				Some(WeightInfoOf::<T>::start_auction_manually(insertion_attempts, remove_attempts))
-			},
+			actual_weight: Some(WeightInfoOf::<T>::start_auction_automatically(insertion_attempts)),
 			pays_fee: Pays::Yes,
 		})
 	}
@@ -639,6 +607,13 @@ impl<T: Config> Pallet<T> {
 		ensure!(now > community_end_block, Error::<T>::TooEarlyForRemainderRoundStart);
 		ensure!(project_details.status == ProjectStatus::CommunityRound, Error::<T>::ProjectNotInCommunityRound);
 
+		// Transition to remainder round was initiated by `do_community_funding`, but the ct
+		// tokens where already sold in the community round. This transition is obsolite.
+		ensure!(
+			project_details.remaining_contribution_tokens.0.saturating_add(project_details.remaining_contribution_tokens.1) > 0u32.into(),
+			Error::<T>::RoundTransitionAlreadyHappened
+		);
+
 		// * Calculate new variables *
 		let remainder_start_block = now + 1u32.into();
 		let remainder_end_block = now + T::RemainderFundingDuration::get();
@@ -712,6 +687,12 @@ impl<T: Config> Pallet<T> {
 				project_details.status == ProjectStatus::FundingFailed ||
 				matches!(remainder_end_block, Some(end_block) if now > end_block),
 			Error::<T>::TooEarlyForFundingEnd
+		);
+		// do_end_funding was already executed, but automatic transition was included in the
+		// do_remainder_funding function. We gracefully skip the this transition.
+		ensure!(
+			!matches!(project_details.status, ProjectStatus::FundingSuccessful | ProjectStatus::FundingFailed | ProjectStatus::AwaitingProjectDecision),
+			Error::<T>::RoundTransitionAlreadyHappened
 		);
 
 		// * Calculate new variables *
@@ -795,6 +776,7 @@ impl<T: Config> Pallet<T> {
 	pub fn do_project_decision(project_id: ProjectId, decision: FundingOutcomeDecision) -> DispatchResultWithPostInfo {
 		// * Get variables *
 		let project_details = ProjectsDetails::<T>::get(project_id).ok_or(Error::<T>::ProjectDetailsNotFound)?;
+		ensure!(project_details.status == ProjectStatus::AwaitingProjectDecision, Error::<T>::RoundTransitionAlreadyHappened);
 
 		// * Update storage *
 		match decision {
@@ -1340,20 +1322,15 @@ impl<T: Config> Pallet<T> {
 		ProjectsDetails::<T>::insert(project_id, project_details);
 		// If no CTs remain, end the funding phase
 
-		let mut weight_round_end_flag: Option<(u32, u32)> = None;
+		let mut weight_round_end_flag: Option<u32> = None;
 		if remaining_cts_after_purchase.is_zero() {
-			// remove the remainder transition or the funding failed transition
-			let total_vecs_in_storage = match Self::remove_from_update_store(&project_id) {
-				Ok(iterations) => iterations,
-				Err(_iterations) => return Err(Error::<T>::TooManyInsertionAttempts.into()),
-			};
 			let fully_filled_vecs_from_insertion =
 				match Self::add_to_update_store(now + 1u32.into(), (&project_id, UpdateType::FundingEnd)) {
 					Ok(iterations) => iterations,
 					Err(_iterations) => return Err(Error::<T>::TooManyInsertionAttempts.into()),
 				};
 
-			weight_round_end_flag = Some((fully_filled_vecs_from_insertion, total_vecs_in_storage));
+			weight_round_end_flag = Some(fully_filled_vecs_from_insertion);
 		}
 
 		// * Emit events *
@@ -1367,11 +1344,10 @@ impl<T: Config> Pallet<T> {
 		// return correct weight function
 		let actual_weight = match weight_round_end_flag {
 			None => Some(WeightInfoOf::<T>::contribution(caller_existing_contributions.len() as u32)),
-			Some((fully_filled_vecs_from_insertion, total_vecs_in_storage)) =>
+			Some(fully_filled_vecs_from_insertion) =>
 				Some(WeightInfoOf::<T>::contribution_ends_round(
 					caller_existing_contributions.len() as u32,
 					fully_filled_vecs_from_insertion,
-					total_vecs_in_storage,
 				)),
 		};
 
@@ -1392,26 +1368,13 @@ impl<T: Config> Pallet<T> {
 		ensure!(project_details.status == ProjectStatus::AwaitingProjectDecision, Error::<T>::NotAllowed);
 
 		// * Update storage *
-		let remove_attempts: u32;
-		let mut insertion_attempts: u32 = 0u32;
-
-		match Self::remove_from_update_store(&project_id) {
-			Ok(iterations) => remove_attempts = iterations,
-			Err(iterations) =>
-				return Err(DispatchErrorWithPostInfo {
-					post_info: PostDispatchInfo {
-						actual_weight: Some(WeightInfoOf::<T>::decide_project_outcome(insertion_attempts, iterations)),
-						pays_fee: Pays::Yes,
-					},
-					error: Error::<T>::TooManyInsertionAttempts.into(),
-				}),
-		};
+		let insertion_attempts: u32;
 		match Self::add_to_update_store(now + 1u32.into(), (&project_id, UpdateType::ProjectDecision(decision))) {
 			Ok(iterations) => insertion_attempts = iterations,
 			Err(iterations) =>
 				return Err(DispatchErrorWithPostInfo {
 					post_info: PostDispatchInfo {
-						actual_weight: Some(WeightInfoOf::<T>::decide_project_outcome(iterations, remove_attempts)),
+						actual_weight: Some(WeightInfoOf::<T>::decide_project_outcome(iterations)),
 						pays_fee: Pays::Yes,
 					},
 					error: Error::<T>::TooManyInsertionAttempts.into(),
@@ -1421,7 +1384,7 @@ impl<T: Config> Pallet<T> {
 		Self::deposit_event(Event::ProjectOutcomeDecided { project_id, decision });
 
 		Ok(PostDispatchInfo {
-			actual_weight: Some(WeightInfoOf::<T>::decide_project_outcome(insertion_attempts, remove_attempts)),
+			actual_weight: Some(WeightInfoOf::<T>::decide_project_outcome(insertion_attempts)),
 			pays_fee: Pays::Yes,
 		})
 	}
@@ -2590,25 +2553,6 @@ impl<T: Config> Pallet<T> {
 		return Err(T::MaxProjectsToUpdateInsertionAttempts::get());
 	}
 
-	// returns the actual iterations for weight calculation either as an Err type or Ok type so the caller can add that
-	// to the corresponding weight function.
-	pub fn remove_from_update_store(project_id: &ProjectId) -> Result<u32, u32> {
-		// used for extrinsic weight calculation
-		let mut total_iterations = 0u32;
-		let (block_position, project_index) = ProjectsToUpdate::<T>::iter()
-			.find_map(|(block, project_vec)| {
-				total_iterations += 1;
-				let project_index = project_vec.iter().position(|(id, _update_type)| id == project_id)?;
-				Some((block, project_index))
-			})
-			.ok_or(total_iterations)?;
-
-		ProjectsToUpdate::<T>::mutate(block_position, |project_vec| {
-			project_vec.remove(project_index);
-		});
-
-		Ok(total_iterations)
-	}
 
 	pub fn create_bucket_from_metadata(metadata: &ProjectMetadataOf<T>) -> Result<BucketOf<T>, DispatchError> {
 		let bucket_delta_amount = Percent::from_percent(10) * metadata.total_allocation_size.0;

--- a/pallets/funding/src/instantiator.rs
+++ b/pallets/funding/src/instantiator.rs
@@ -255,10 +255,10 @@ impl<
 				<frame_system::Pallet<T> as OnInitialize<BlockNumberFor<T>>>::on_initialize(current_block);
 				<AllPalletsWithoutSystem as OnInitialize<BlockNumberFor<T>>>::on_initialize(current_block);
 
-				let post_events = frame_system::Pallet::<T>::events();
-				if post_events.len() > pre_events.len() {
-					Self::err_if_on_initialize_failed(post_events)?;
-				}
+				// let post_events = frame_system::Pallet::<T>::events();
+				// if post_events.len() > pre_events.len() {
+				// 	Self::err_if_on_initialize_failed(post_events)?;
+				// }
 			}
 			Ok(())
 		})
@@ -996,16 +996,15 @@ impl<
 		self.execute(|| ProjectsDetails::<T>::get(project_id).expect("Project details exists"))
 	}
 
-	pub fn get_update_pair(&mut self, project_id: ProjectId) -> (BlockNumberFor<T>, UpdateType) {
+	pub fn get_update_pair(&mut self, project_id: ProjectId, update_type: &UpdateType) -> Option<(BlockNumberFor<T>, UpdateType)> {
 		self.execute(|| {
 			ProjectsToUpdate::<T>::iter()
 				.find_map(|(block, update_vec)| {
 					update_vec
 						.iter()
-						.find(|(pid, _update)| *pid == project_id)
+						.find(|(pid, update)| *pid == project_id && update == update_type)
 						.map(|(_pid, update)| (block, update.clone()))
 				})
-				.unwrap()
 		})
 	}
 
@@ -1278,25 +1277,32 @@ impl<
 	}
 
 	pub fn start_remainder_or_end_funding(&mut self, project_id: ProjectId) -> Result<(), DispatchError> {
-		assert_eq!(self.get_project_details(project_id).status, ProjectStatus::CommunityRound);
-		let (transition_block, _) = self.get_update_pair(project_id);
-		self.execute(|| frame_system::Pallet::<T>::set_block_number(transition_block - One::one()));
-		self.advance_time(1u32.into()).unwrap();
-		match self.get_project_details(project_id).status {
-			ProjectStatus::RemainderRound | ProjectStatus::FundingSuccessful => Ok(()),
-			_ => panic!("Bad state"),
+		let details = self.get_project_details(project_id);
+		assert_eq!(details.status, ProjectStatus::CommunityRound);
+		let remaining_tokens = details.remaining_contribution_tokens.0
+			.saturating_add(details.remaining_contribution_tokens.1);
+		let update_type = if remaining_tokens > Zero::zero() {
+			UpdateType::RemainderFundingStart
+		} else {
+			UpdateType::FundingEnd
+		};
+		if let Some((transition_block, _)) = self.get_update_pair(project_id, &update_type) {
+			self.execute(|| frame_system::Pallet::<T>::set_block_number(transition_block - One::one()));
+			self.advance_time(1u32.into()).unwrap();
+			match self.get_project_details(project_id).status {
+				ProjectStatus::RemainderRound | ProjectStatus::FundingSuccessful => Ok(()),
+				_ => panic!("Bad state"),
+			}
+		} else {
+			panic!("Bad state")
 		}
+		
 	}
 
 	pub fn finish_funding(&mut self, project_id: ProjectId) -> Result<(), DispatchError> {
-		let (update_block, _) = self.get_update_pair(project_id);
+		let (update_block, _) = self.get_update_pair(project_id, &UpdateType::FundingEnd).unwrap();
 		self.execute(|| frame_system::Pallet::<T>::set_block_number(update_block - One::one()));
 		self.advance_time(1u32.into()).unwrap();
-		if self.get_project_details(project_id).status == ProjectStatus::RemainderRound {
-			let (end_block, _) = self.get_update_pair(project_id);
-			self.execute(|| frame_system::Pallet::<T>::set_block_number(end_block - 1u32.into()));
-			self.advance_time(1u32.into()).unwrap();
-		}
 		let project_details = self.get_project_details(project_id);
 		assert!(
 			matches!(
@@ -1752,8 +1758,7 @@ pub mod async_features {
 		let project_details = inst.get_project_details(project_id);
 
 		if project_details.status == ProjectStatus::EvaluationRound {
-			let (update_block, update_type) = inst.get_update_pair(project_id);
-			assert_eq!(update_type, UpdateType::EvaluationEnd);
+			let (update_block, _) = inst.get_update_pair(project_id, &UpdateType::EvaluationEnd).unwrap();
 			let notify = Arc::new(Notify::new());
 			block_orchestrator.add_awaiting_project(update_block + 1u32.into(), notify.clone()).await;
 
@@ -1864,9 +1869,7 @@ pub mod async_features {
 	) -> Result<(), DispatchError> {
 		let mut inst = instantiator.lock().await;
 
-		let (update_block, update_type) = inst.get_update_pair(project_id);
-		assert_eq!(update_type, UpdateType::CandleAuctionStart);
-
+		let (update_block, _) = inst.get_update_pair(project_id, &UpdateType::CandleAuctionStart).unwrap();
 		let candle_start = update_block + 1u32.into();
 
 		let notify = Arc::new(Notify::new());
@@ -1880,8 +1883,7 @@ pub mod async_features {
 		notify.notified().await;
 
 		inst = instantiator.lock().await;
-		let (update_block, update_type) = inst.get_update_pair(project_id);
-		assert_eq!(update_type, UpdateType::CommunityFundingStart);
+		let (update_block, _) = inst.get_update_pair(project_id, &UpdateType::CommunityFundingStart).unwrap();
 		let community_start = update_block + 1u32.into();
 
 		let notify = Arc::new(Notify::new());
@@ -2034,8 +2036,7 @@ pub mod async_features {
 
 		assert_eq!(inst.get_project_details(project_id).status, ProjectStatus::CommunityRound);
 
-		let (update_block, transition_type) = inst.get_update_pair(project_id);
-		assert_eq!(transition_type, UpdateType::RemainderFundingStart);
+		let (update_block, _) = inst.get_update_pair(project_id, &UpdateType::RemainderFundingStart).unwrap();
 		let remainder_start = update_block + 1u32.into();
 
 		let notify = Arc::new(Notify::new());
@@ -2183,24 +2184,25 @@ pub mod async_features {
 	) -> Result<(), DispatchError> {
 		let mut inst = instantiator.lock().await;
 
-		let (update_block, _) = inst.get_update_pair(project_id);
+	
+		let (update_block, _) = inst.get_update_pair(project_id, &UpdateType::FundingEnd).unwrap();
 
 		let notify = Arc::new(Notify::new());
 		block_orchestrator.add_awaiting_project(update_block + 1u32.into(), notify.clone()).await;
-		if inst.get_project_details(project_id).status == ProjectStatus::RemainderRound {
-			let (end_block, _) = inst.get_update_pair(project_id);
-			drop(inst);
+		// if inst.get_project_details(project_id).status == ProjectStatus::RemainderRound {
+		// 	let (end_block, _) = inst.get_update_pair(project_id, &UpdateType::FundingEnd).unwrap();
+		// 	drop(inst);
 
-			let notify = Arc::new(Notify::new());
+		// 	let notify = Arc::new(Notify::new());
 
-			block_orchestrator.add_awaiting_project(end_block + 1u32.into(), notify.clone()).await;
+		// 	block_orchestrator.add_awaiting_project(end_block + 1u32.into(), notify.clone()).await;
 
-			// Wait for the notification that our desired block was reached to continue
+		// 	// Wait for the notification that our desired block was reached to continue
 
-			notify.notified().await;
+		// 	notify.notified().await;
 
-			inst = instantiator.lock().await;
-		}
+		// 	inst = instantiator.lock().await;
+		// }
 
 		let project_details = inst.get_project_details(project_id);
 		assert!(

--- a/pallets/funding/src/lib.rs
+++ b/pallets/funding/src/lib.rs
@@ -1048,7 +1048,7 @@ pub mod pallet {
 		/// institutional user can set bids for a token_amount/token_price pair.
 		/// Any bids from this point until the candle_auction starts, will be considered as valid.
 		#[pallet::call_index(3)]
-		#[pallet::weight(WeightInfoOf::<T>::start_auction_manually(<T as Config>::MaxProjectsToUpdateInsertionAttempts::get() - 1, 10_000u32))]
+		#[pallet::weight(WeightInfoOf::<T>::start_auction_manually(<T as Config>::MaxProjectsToUpdateInsertionAttempts::get() - 1))]
 		pub fn start_auction(
 			origin: OriginFor<T>,
 			jwt: UntrustedToken,
@@ -1423,7 +1423,6 @@ pub mod pallet {
 							.actual_weight
 							.unwrap_or(WeightInfoOf::<T>::start_auction_manually(
 								<T as Config>::MaxProjectsToUpdateInsertionAttempts::get() - 1,
-								10_000,
 							)),
 						);
 					},

--- a/pallets/funding/src/lib.rs
+++ b/pallets/funding/src/lib.rs
@@ -967,8 +967,6 @@ pub mod pallet {
 		ContributionTooLow,
 		/// Contribution is higher than the limit set by the issuer
 		ContributionTooHigh,
-		/// Tried to delete a project from the update store but it is not there to begin with.
-		ProjectNotInUpdateStore,
 		/// The provided asset is not accepted by the project issuer
 		FundingAssetNotAccepted,
 		/// Could not get the price in USD for PLMC
@@ -1006,6 +1004,8 @@ pub mod pallet {
 		TooManyContributionsForUser,
 		// Participant tried to do a community contribution but it already had a winning bid on the auction round.
 		UserHasWinningBids,
+		// Round transition already happened.
+		RoundTransitionAlreadyHappened,
 	}
 
 	#[pallet::call]
@@ -1110,8 +1110,6 @@ pub mod pallet {
 			<T as Config>::MaxContributionsPerUser::get() -1,
 			// Since we didn't remove any previous lower contribution, we can buy all remaining CTs and try to move to the next phase
 			<T as Config>::MaxProjectsToUpdateInsertionAttempts::get() - 1,
-			// Assumed upper bound for deletion attempts for the previous scheduled transition
-			10_000u32,
 			))
 		)]
 		pub fn community_contribute(
@@ -1135,9 +1133,7 @@ pub mod pallet {
 			// Last contribution possible before having to remove an old lower one
 			<T as Config>::MaxContributionsPerUser::get() -1,
 			// Since we didn't remove any previous lower contribution, we can buy all remaining CTs and try to move to the next phase
-			<T as Config>::MaxProjectsToUpdateInsertionAttempts::get() - 1,
-			// Assumed upper bound for deletion attempts for the previous scheduled transition
-			10_000u32,
+			<T as Config>::MaxProjectsToUpdateInsertionAttempts::get() - 1
 			))
 		)]
 		pub fn remaining_contribute(
@@ -1271,8 +1267,7 @@ pub mod pallet {
 
 		#[pallet::call_index(17)]
 		#[pallet::weight(WeightInfoOf::<T>::decide_project_outcome(
-			<T as Config>::MaxProjectsToUpdateInsertionAttempts::get() - 1,
-			10_000u32
+			<T as Config>::MaxProjectsToUpdateInsertionAttempts::get() - 1
 		))]
 		pub fn decide_project_outcome(
 			origin: OriginFor<T>,

--- a/pallets/funding/src/tests.rs
+++ b/pallets/funding/src/tests.rs
@@ -1076,7 +1076,6 @@ mod auction {
 		inst.mint_foreign_asset_to(contributors_funding_assets);
 
 		inst.contribute_for_users(project_id, community_contributions).unwrap();
-		inst.start_remainder_or_end_funding(project_id).unwrap();
 		inst.finish_funding(project_id).unwrap();
 
 		inst.advance_time(<TestRuntime as Config>::SuccessToSettlementTime::get() + 1).unwrap();

--- a/pallets/funding/src/tests.rs
+++ b/pallets/funding/src/tests.rs
@@ -4467,27 +4467,6 @@ mod inner_functions {
 	use super::*;
 
 	#[test]
-	fn remove_from_update_store_works() {
-		let mut inst = MockInstantiator::new(Some(RefCell::new(new_test_ext())));
-		let now = inst.current_block();
-		inst.execute(|| {
-			assert_ok!(PolimecFunding::add_to_update_store(now + 10u64, (&42u32, CommunityFundingStart)));
-			assert_ok!(PolimecFunding::add_to_update_store(now + 20u64, (&69u32, RemainderFundingStart)));
-			assert_ok!(PolimecFunding::add_to_update_store(now + 5u64, (&404u32, RemainderFundingStart)));
-		});
-		inst.advance_time(2u64).unwrap();
-		inst.execute(|| {
-			let stored = ProjectsToUpdate::<TestRuntime>::iter_values().collect::<Vec<_>>();
-			assert_eq!(stored.len(), 3, "There should be 3 blocks scheduled for updating");
-
-			PolimecFunding::remove_from_update_store(&69u32).unwrap();
-
-			let stored = ProjectsToUpdate::<TestRuntime>::iter_values().collect::<Vec<_>>();
-			assert_eq!(stored[2], vec![], "Vector should be empty for that block after deletion");
-		});
-	}
-
-	#[test]
 	fn calculate_vesting_duration() {
 		let default_multiplier = MultiplierOf::<TestRuntime>::default();
 		let default_multiplier_duration = default_multiplier.calculate_vesting_duration::<TestRuntime>();

--- a/pallets/funding/src/tests.rs
+++ b/pallets/funding/src/tests.rs
@@ -1076,6 +1076,7 @@ mod auction {
 		inst.mint_foreign_asset_to(contributors_funding_assets);
 
 		inst.contribute_for_users(project_id, community_contributions).unwrap();
+		inst.start_remainder_or_end_funding(project_id).unwrap();
 		inst.finish_funding(project_id).unwrap();
 
 		inst.advance_time(<TestRuntime as Config>::SuccessToSettlementTime::get() + 1).unwrap();

--- a/pallets/funding/src/weights.rs
+++ b/pallets/funding/src/weights.rs
@@ -52,7 +52,7 @@ pub trait WeightInfo {
 	fn create() -> Weight;
 	fn edit_metadata() -> Weight;
 	fn start_evaluation(x: u32, ) -> Weight;
-	fn start_auction_manually(x: u32, y: u32, ) -> Weight;
+	fn start_auction_manually(x: u32 ) -> Weight;
 	fn first_evaluation() -> Weight;
 	fn second_to_limit_evaluation(x: u32, ) -> Weight;
 	fn evaluation_over_limit() -> Weight;
@@ -79,7 +79,6 @@ pub trait WeightInfo {
 	fn contribution_unbond_for() -> Weight;
 	fn end_evaluation_success(x: u32, ) -> Weight;
 	fn end_evaluation_failure() -> Weight;
-	fn start_auction_automatically(x: u32, ) -> Weight;
 	fn start_candle_phase(x: u32, ) -> Weight;
 	fn start_community_funding_success(x: u32, y: u32, z: u32, ) -> Weight;
 	fn start_community_funding_failure(x: u32, ) -> Weight;
@@ -159,7 +158,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `PolimecFunding::ProjectsToUpdate` (`max_values`: None, `max_size`: Some(27), added: 2502, mode: `MaxEncodedLen`)
 	/// The range of component `x` is `[1, 99]`.
 	/// The range of component `y` is `[1, 10000]`.
-	fn start_auction_manually(x: u32, y: u32, ) -> Weight {
+	fn start_auction_manually(x: u32 ) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0 + x * (539 ±0) + y * (13 ±0)`
 		//  Estimated: `217021 + x * (8051 ±6_772) + y * (979 ±66)`
@@ -721,24 +720,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	}
 	/// Storage: `PolimecFunding::ProjectsDetails` (r:1 w:1)
 	/// Proof: `PolimecFunding::ProjectsDetails` (`max_values`: None, `max_size`: Some(349), added: 2824, mode: `MaxEncodedLen`)
-	/// Storage: `PolimecFunding::ProjectsToUpdate` (r:102 w:2)
-	/// Proof: `PolimecFunding::ProjectsToUpdate` (`max_values`: None, `max_size`: Some(27), added: 2502, mode: `MaxEncodedLen`)
-	/// The range of component `x` is `[1, 99]`.
-	fn start_auction_automatically(x: u32, ) -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `413 + x * (29 ±0)`
-		//  Estimated: `8496 + x * (2502 ±0)`
-		// Minimum execution time: 26_000_000 picoseconds.
-		Weight::from_parts(28_124_881, 8496)
-			// Standard Error: 5_442
-			.saturating_add(Weight::from_parts(2_521_942, 0).saturating_mul(x.into()))
-			.saturating_add(T::DbWeight::get().reads(4_u64))
-			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(x.into())))
-			.saturating_add(T::DbWeight::get().writes(3_u64))
-			.saturating_add(Weight::from_parts(0, 2502).saturating_mul(x.into()))
-	}
-	/// Storage: `PolimecFunding::ProjectsDetails` (r:1 w:1)
-	/// Proof: `PolimecFunding::ProjectsDetails` (`max_values`: None, `max_size`: Some(349), added: 2824, mode: `MaxEncodedLen`)
 	/// Storage: `PolimecFunding::ProjectsToUpdate` (r:100 w:1)
 	/// Proof: `PolimecFunding::ProjectsToUpdate` (`max_values`: None, `max_size`: Some(27), added: 2502, mode: `MaxEncodedLen`)
 	/// The range of component `x` is `[1, 99]`.
@@ -1060,7 +1041,7 @@ impl WeightInfo for () {
 	/// Proof: `PolimecFunding::ProjectsToUpdate` (`max_values`: None, `max_size`: Some(27), added: 2502, mode: `MaxEncodedLen`)
 	/// The range of component `x` is `[1, 99]`.
 	/// The range of component `y` is `[1, 10000]`.
-	fn start_auction_manually(x: u32, y: u32, ) -> Weight {
+	fn start_auction_manually(x: u32 ) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0 + x * (539 ±0) + y * (13 ±0)`
 		//  Estimated: `217021 + x * (8051 ±6_772) + y * (979 ±66)`
@@ -1619,24 +1600,6 @@ impl WeightInfo for () {
 		Weight::from_parts(35_000_000, 12270)
 			.saturating_add(RocksDbWeight::get().reads(6_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
-	}
-	/// Storage: `PolimecFunding::ProjectsDetails` (r:1 w:1)
-	/// Proof: `PolimecFunding::ProjectsDetails` (`max_values`: None, `max_size`: Some(349), added: 2824, mode: `MaxEncodedLen`)
-	/// Storage: `PolimecFunding::ProjectsToUpdate` (r:102 w:2)
-	/// Proof: `PolimecFunding::ProjectsToUpdate` (`max_values`: None, `max_size`: Some(27), added: 2502, mode: `MaxEncodedLen`)
-	/// The range of component `x` is `[1, 99]`.
-	fn start_auction_automatically(x: u32, ) -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `413 + x * (29 ±0)`
-		//  Estimated: `8496 + x * (2502 ±0)`
-		// Minimum execution time: 26_000_000 picoseconds.
-		Weight::from_parts(28_124_881, 8496)
-			// Standard Error: 5_442
-			.saturating_add(Weight::from_parts(2_521_942, 0).saturating_mul(x.into()))
-			.saturating_add(RocksDbWeight::get().reads(4_u64))
-			.saturating_add(RocksDbWeight::get().reads((1_u64).saturating_mul(x.into())))
-			.saturating_add(RocksDbWeight::get().writes(3_u64))
-			.saturating_add(Weight::from_parts(0, 2502).saturating_mul(x.into()))
 	}
 	/// Storage: `PolimecFunding::ProjectsDetails` (r:1 w:1)
 	/// Proof: `PolimecFunding::ProjectsDetails` (`max_values`: None, `max_size`: Some(349), added: 2824, mode: `MaxEncodedLen`)

--- a/pallets/funding/src/weights.rs
+++ b/pallets/funding/src/weights.rs
@@ -167,12 +167,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			// Standard Error: 3_856_088
 			.saturating_add(Weight::from_parts(10_425_661, 0).saturating_mul(x.into()))
 			// Standard Error: 38_223
-			.saturating_add(Weight::from_parts(1_158_523, 0).saturating_mul(y.into()))
 			.saturating_add(T::DbWeight::get().reads(87_u64))
 			.saturating_add(T::DbWeight::get().reads((3_u64).saturating_mul(x.into())))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 			.saturating_add(Weight::from_parts(0, 8051).saturating_mul(x.into()))
-			.saturating_add(Weight::from_parts(0, 979).saturating_mul(y.into()))
 	}
 	/// Storage: `PolimecFunding::ProjectsDetails` (r:1 w:1)
 	/// Proof: `PolimecFunding::ProjectsDetails` (`max_values`: None, `max_size`: Some(349), added: 2824, mode: `MaxEncodedLen`)
@@ -1050,12 +1048,10 @@ impl WeightInfo for () {
 			// Standard Error: 3_856_088
 			.saturating_add(Weight::from_parts(10_425_661, 0).saturating_mul(x.into()))
 			// Standard Error: 38_223
-			.saturating_add(Weight::from_parts(1_158_523, 0).saturating_mul(y.into()))
 			.saturating_add(RocksDbWeight::get().reads(87_u64))
 			.saturating_add(RocksDbWeight::get().reads((3_u64).saturating_mul(x.into())))
 			.saturating_add(RocksDbWeight::get().writes(3_u64))
 			.saturating_add(Weight::from_parts(0, 8051).saturating_mul(x.into()))
-			.saturating_add(Weight::from_parts(0, 979).saturating_mul(y.into()))
 	}
 	/// Storage: `PolimecFunding::ProjectsDetails` (r:1 w:1)
 	/// Proof: `PolimecFunding::ProjectsDetails` (`max_values`: None, `max_size`: Some(349), added: 2824, mode: `MaxEncodedLen`)

--- a/pallets/funding/src/weights.rs
+++ b/pallets/funding/src/weights.rs
@@ -59,7 +59,7 @@ pub trait WeightInfo {
 	fn bid_no_ct_deposit(x: u32, y: u32, ) -> Weight;
 	fn bid_with_ct_deposit(y: u32, ) -> Weight;
 	fn contribution(x: u32, ) -> Weight;
-	fn contribution_ends_round(x: u32, y: u32, z: u32, ) -> Weight;
+	fn contribution_ends_round(x: u32, y: u32 ) -> Weight;
 	fn evaluation_unbond_for() -> Weight;
 	fn evaluation_reward_payout_for_with_ct_account_creation() -> Weight;
 	fn evaluation_reward_payout_for_no_ct_account_creation() -> Weight;
@@ -72,7 +72,7 @@ pub trait WeightInfo {
 	fn start_contribution_vesting_schedule_for() -> Weight;
 	fn payout_bid_funds_for() -> Weight;
 	fn payout_contribution_funds_for() -> Weight;
-	fn decide_project_outcome(x: u32, y: u32, ) -> Weight;
+	fn decide_project_outcome(x: u32 ) -> Weight;
 	fn release_bid_funds_for() -> Weight;
 	fn release_contribution_funds_for() -> Weight;
 	fn bid_unbond_for() -> Weight;
@@ -375,7 +375,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// The range of component `x` is `[1, 255]`.
 	/// The range of component `y` is `[1, 99]`.
 	/// The range of component `z` is `[1, 10000]`.
-	fn contribution_ends_round(x: u32, y: u32, z: u32, ) -> Weight {
+	fn contribution_ends_round(x: u32, y: u32 ) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `44564 + x * (137 ±0) + y * (254 ±0) + z * (21 ±0)`
 		//  Estimated: `15401 + x * (2839 ±0) + y * (92965 ±6_111) + z * (1905 ±59)`
@@ -384,14 +384,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			// Standard Error: 7_331_488
 			.saturating_add(Weight::from_parts(111_668_126, 0).saturating_mul(y.into()))
 			// Standard Error: 71_852
-			.saturating_add(Weight::from_parts(2_292_683, 0).saturating_mul(z.into()))
 			.saturating_add(T::DbWeight::get().reads(17_u64))
 			.saturating_add(T::DbWeight::get().reads((37_u64).saturating_mul(y.into())))
-			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(z.into())))
 			.saturating_add(T::DbWeight::get().writes(8_u64))
 			.saturating_add(Weight::from_parts(0, 2839).saturating_mul(x.into()))
 			.saturating_add(Weight::from_parts(0, 92965).saturating_mul(y.into()))
-			.saturating_add(Weight::from_parts(0, 1905).saturating_mul(z.into()))
 	}
 	/// Storage: `PolimecFunding::ProjectsDetails` (r:1 w:0)
 	/// Proof: `PolimecFunding::ProjectsDetails` (`max_values`: None, `max_size`: Some(349), added: 2824, mode: `MaxEncodedLen`)
@@ -607,7 +604,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `PolimecFunding::ProjectsToUpdate` (`max_values`: None, `max_size`: Some(27), added: 2502, mode: `MaxEncodedLen`)
 	/// The range of component `x` is `[1, 99]`.
 	/// The range of component `y` is `[1, 10000]`.
-	fn decide_project_outcome(x: u32, y: u32, ) -> Weight {
+	fn decide_project_outcome(x: u32 ) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `4454 + x * (93 ±0) + y * (11 ±0)`
 		//  Estimated: `28512 + x * (3946 ±3_374) + y * (1161 ±33)`
@@ -616,12 +613,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			// Standard Error: 3_928_236
 			.saturating_add(Weight::from_parts(3_329_337, 0).saturating_mul(x.into()))
 			// Standard Error: 38_938
-			.saturating_add(Weight::from_parts(1_351_270, 0).saturating_mul(y.into()))
 			.saturating_add(T::DbWeight::get().reads(12_u64))
 			.saturating_add(T::DbWeight::get().reads((2_u64).saturating_mul(x.into())))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 			.saturating_add(Weight::from_parts(0, 3946).saturating_mul(x.into()))
-			.saturating_add(Weight::from_parts(0, 1161).saturating_mul(y.into()))
 	}
 	/// Storage: `PolimecFunding::ProjectsDetails` (r:1 w:0)
 	/// Proof: `PolimecFunding::ProjectsDetails` (`max_values`: None, `max_size`: Some(349), added: 2824, mode: `MaxEncodedLen`)
@@ -1281,7 +1276,7 @@ impl WeightInfo for () {
 	/// The range of component `x` is `[1, 255]`.
 	/// The range of component `y` is `[1, 99]`.
 	/// The range of component `z` is `[1, 10000]`.
-	fn contribution_ends_round(x: u32, y: u32, z: u32, ) -> Weight {
+	fn contribution_ends_round(x: u32, y: u32 ) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `44564 + x * (137 ±0) + y * (254 ±0) + z * (21 ±0)`
 		//  Estimated: `15401 + x * (2839 ±0) + y * (92965 ±6_111) + z * (1905 ±59)`
@@ -1290,14 +1285,11 @@ impl WeightInfo for () {
 			// Standard Error: 7_331_488
 			.saturating_add(Weight::from_parts(111_668_126, 0).saturating_mul(y.into()))
 			// Standard Error: 71_852
-			.saturating_add(Weight::from_parts(2_292_683, 0).saturating_mul(z.into()))
 			.saturating_add(RocksDbWeight::get().reads(17_u64))
 			.saturating_add(RocksDbWeight::get().reads((37_u64).saturating_mul(y.into())))
-			.saturating_add(RocksDbWeight::get().reads((1_u64).saturating_mul(z.into())))
 			.saturating_add(RocksDbWeight::get().writes(8_u64))
 			.saturating_add(Weight::from_parts(0, 2839).saturating_mul(x.into()))
 			.saturating_add(Weight::from_parts(0, 92965).saturating_mul(y.into()))
-			.saturating_add(Weight::from_parts(0, 1905).saturating_mul(z.into()))
 	}
 	/// Storage: `PolimecFunding::ProjectsDetails` (r:1 w:0)
 	/// Proof: `PolimecFunding::ProjectsDetails` (`max_values`: None, `max_size`: Some(349), added: 2824, mode: `MaxEncodedLen`)
@@ -1513,7 +1505,7 @@ impl WeightInfo for () {
 	/// Proof: `PolimecFunding::ProjectsToUpdate` (`max_values`: None, `max_size`: Some(27), added: 2502, mode: `MaxEncodedLen`)
 	/// The range of component `x` is `[1, 99]`.
 	/// The range of component `y` is `[1, 10000]`.
-	fn decide_project_outcome(x: u32, y: u32, ) -> Weight {
+	fn decide_project_outcome(x: u32) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `4454 + x * (93 ±0) + y * (11 ±0)`
 		//  Estimated: `28512 + x * (3946 ±3_374) + y * (1161 ±33)`
@@ -1522,12 +1514,10 @@ impl WeightInfo for () {
 			// Standard Error: 3_928_236
 			.saturating_add(Weight::from_parts(3_329_337, 0).saturating_mul(x.into()))
 			// Standard Error: 38_938
-			.saturating_add(Weight::from_parts(1_351_270, 0).saturating_mul(y.into()))
 			.saturating_add(RocksDbWeight::get().reads(12_u64))
 			.saturating_add(RocksDbWeight::get().reads((2_u64).saturating_mul(x.into())))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 			.saturating_add(Weight::from_parts(0, 3946).saturating_mul(x.into()))
-			.saturating_add(Weight::from_parts(0, 1161).saturating_mul(y.into()))
 	}
 	/// Storage: `PolimecFunding::ProjectsDetails` (r:1 w:0)
 	/// Proof: `PolimecFunding::ProjectsDetails` (`max_values`: None, `max_size`: Some(349), added: 2824, mode: `MaxEncodedLen`)

--- a/runtimes/shared-configuration/src/funding.rs
+++ b/runtimes/shared-configuration/src/funding.rs
@@ -36,7 +36,7 @@ pub const AUCTION_INITIALIZE_PERIOD_DURATION: BlockNumber = 7;
 pub const AUCTION_INITIALIZE_PERIOD_DURATION: BlockNumber = 7 * crate::DAYS;
 
 #[cfg(feature = "instant-mode")]
-pub const ENGLISH_AUCTION_DURATION: BlockNumber = 1;
+pub const ENGLISH_AUCTION_DURATION: BlockNumber = 2;
 #[cfg(feature = "fast-mode")]
 pub const ENGLISH_AUCTION_DURATION: BlockNumber = 10;
 #[cfg(not(any(feature = "fast-mode", feature = "instant-mode")))]


### PR DESCRIPTION
## What?
This pr deletes the `remove_from_update_store` function. This means that we do not remove any project transitions from the update store anymore, if these transitions are not necessary anymore. Instead we handle these unnecessary transitions by gracefully failing the second execution of these transitions. These double transition execution happen, as the project issuer can manually push a project on, or in the situation from the community round, where the round is filled during the community round duration. There were 3 cases of removal of the automatic transition:

- do_english_auction: Auction can be started manually by the Issuer. We now fail the second do_english_auction by checking if the project is in the `AuctionInitializePeriod` status.
- do_contribute: Community round was filled, so we end the funding. Automatic end of funding is now still scheduled in the update store. We fail the second funding by checking if the project status is already either of the following options:
`ProjectStatus::FundingSuccessful | ProjectStatus::FundingFailed | ProjectStatus::AwaitingProjectDecision`
- do_decide_project_outcome: In case a project is not directly failed or successful [70%, 90%], the project issuer can chose to accept or reject successful funding. In the second execution of `do_project_decision` we check if the project is still in the `AwaitingProjectDecision` phase. 

## Why?
To simplify the benchmarking complexity by removing the removal from project store attempts. 

## How?

## Testing?
Fixed testing by updating the get_update_pair to take an UpdateType. As multiple round transition can be stored in update store for a project, and the order of those transitions is not always clear, we now have to explicitly specify which transition we are expecting. This is the case for the funding tests, benchmarks and the integration tests. 

## Screenshots (optional)

## Anything Else?
