### PR TITLE
potential changes

### DIFF
--- a/pallets/funding/src/functions.rs
+++ b/pallets/funding/src/functions.rs
@@ -84,18 +84,13 @@ impl<T: Config> Pallet<T> {
 		}
 
 		let min_bidder_bound_usd: BalanceOf<T> = (5000 * (US_DOLLAR as u64)).into();
-		let usd_bounds = AllUSDBounds {
-			bidding: BiddingUSDBounds {
-				professional: (Some(min_bidder_bound_usd), None).into(),
-				institutional: (Some(min_bidder_bound_usd), None).into(),
-			},
-			contributing: ContributingUSDBounds {
-				retail: (None, None).into(),
-				professional: (None, None).into(),
-				institutional: (None, None).into(),
-			},
-		};
-		if let Err(error) = initial_metadata.is_valid(usd_bounds) {
+		let auction_bounds = vec![
+			InvestorTypeUSDBounds::Professional((Some(min_bidder_bound_usd), None).into()),
+			InvestorTypeUSDBounds::Institutional((Some(min_bidder_bound_usd), None).into()),
+		];
+		let contribution_bounds = vec![];
+		
+		if let Err(error) = initial_metadata.is_valid(auction_bounds, contribution_bounds) {
 			return match error {
 				ValidityError::PriceTooLow => Err(Error::<T>::PriceTooLow.into()),
 				ValidityError::TicketSizeError => Err(Error::<T>::TicketSizeError.into()),
@@ -1077,8 +1072,8 @@ impl<T: Config> Pallet<T> {
 		);
 
 		let bidder_ticket_size = match investor_type {
-			InvestorType::Institutional => project_metadata.round_ticket_sizes.bidding.institutional,
-			InvestorType::Professional => project_metadata.round_ticket_sizes.bidding.professional,
+			InvestorType::Institutional => project_metadata.bidding_ticket_sizes.institutional,
+			InvestorType::Professional => project_metadata.bidding_ticket_sizes.professional,
 			_ => return Err(Error::<T>::NotAllowed.into()),
 		};
 		ensure!(bidder_ticket_size.ct_above_minimum_per_participation(ct_amount), Error::<T>::BidTooLow);
@@ -1324,9 +1319,9 @@ impl<T: Config> Pallet<T> {
 		let ticket_size = ct_usd_price.checked_mul_int(buyable_tokens).ok_or(Error::<T>::BadMath)?;
 
 		let contributor_ticket_size = match investor_type {
-			InvestorType::Institutional => project_metadata.round_ticket_sizes.contributing.institutional,
-			InvestorType::Professional => project_metadata.round_ticket_sizes.contributing.professional,
-			InvestorType::Retail => project_metadata.round_ticket_sizes.contributing.retail,
+			InvestorType::Institutional => project_metadata.contributing_ticket_sizes.institutional,
+			InvestorType::Professional => project_metadata.contributing_ticket_sizes.professional,
+			InvestorType::Retail => project_metadata.contributing_ticket_sizes.retail,
 		};
 		ensure!(
 			contributor_ticket_size.ct_above_minimum_per_participation(buyable_tokens),

--- a/pallets/funding/src/lib.rs
+++ b/pallets/funding/src/lib.rs
@@ -171,19 +171,12 @@ pub type RewardInfoOf<T> = RewardInfo<BalanceOf<T>>;
 pub type EvaluatorsOutcomeOf<T> = EvaluatorsOutcome<BalanceOf<T>>;
 
 pub type TicketSizeOf<T> = TicketSize<BalanceOf<T>>;
-pub type RoundTicketSizesOf<T> = RoundTicketSizes<
-	PriceOf<T>,
-	BalanceOf<T>,
-	BiddingTicketSizes<PriceOf<T>, BalanceOf<T>, TicketSizeOf<T>, TicketSizeOf<T>>,
-	ContributingTicketSizes<PriceOf<T>, BalanceOf<T>, TicketSizeOf<T>, TicketSizeOf<T>, TicketSizeOf<T>>,
->;
 pub type ProjectMetadataOf<T> = ProjectMetadata<
 	BoundedVec<u8, StringLimitOf<T>>,
 	BalanceOf<T>,
 	PriceOf<T>,
 	AccountIdOf<T>,
 	HashOf<T>,
-	RoundTicketSizesOf<T>,
 >;
 pub type ProjectDetailsOf<T> =
 	ProjectDetails<AccountIdOf<T>, BlockNumberFor<T>, PriceOf<T>, BalanceOf<T>, EvaluationRoundInfoOf<T>>;


### PR DESCRIPTION
## What?
Try to simplify ticket sizes by decreasing amount of trait bounds, structs and traits:
 - Split the rounds into two seperate items in the metadata.
 - Delete all the specific traits and simplify it to TicketSizeValidityCheck and TicketSizeParticipationChecks
 - Other changes

TODO:
- Switch from Vec<InvestorTypeUSDBounds> to BoundedVec. 
- Fix tests, benchmarks, etc (did not try them) 
- Potentially still to complicated as we currently only check in the full is_valid flow if bids for both Prof and Inst are > 5k. - - Could remove all these traits and more and do a simple check in the is_valid from ProjectMetadata where we check if bidding Ticket both have a lower bound > 5k.
- min_price is now not used in the validity checks. Probably needed for check based on min CT instead of USD, so I let you chose which way to go with CT vs USD discussion and the need of this min_price
- Improve naming + location in files (for example move trait definitions to traits file?) 
