### PR TITLE
Feat/send dust to treasury

### DIFF
--- a/integration-tests/src/constants.rs
+++ b/integration-tests/src/constants.rs
@@ -469,6 +469,7 @@ pub mod polimec_base {
 	use super::*;
 	use crate::PolimecBase;
 	use pallet_funding::AcceptedFundingAsset;
+	use polimec_base_runtime::PayMaster;
 	use xcm::{prelude::Parachain, v3::Parent};
 
 	pub const PARA_ID: u32 = 3344;
@@ -496,6 +497,7 @@ pub mod polimec_base {
 		funded_accounts.extend(accounts::init_balances().iter().cloned().map(|k| (k, INITIAL_DEPOSIT)));
 		funded_accounts.extend(collators::initial_authorities().iter().cloned().map(|(acc, _)| (acc, 20_005 * PLMC)));
 		funded_accounts.push((get_account_id_from_seed::<sr25519::Public>("TREASURY_STASH"), 20_005 * PLMC));
+		funded_accounts.push((PayMaster::get(), 20_005 * PLMC));
 
 		let genesis_config = polimec_base_runtime::RuntimeGenesisConfig {
 			system: polimec_base_runtime::SystemConfig {

--- a/integration-tests/src/tests/vest.rs
+++ b/integration-tests/src/tests/vest.rs
@@ -23,7 +23,7 @@ use frame_support::traits::fungible::Mutate;
 use macros::generate_accounts;
 use pallet_funding::assert_close_enough;
 use pallet_vesting::VestingInfo;
-use polimec_base_runtime::{Balances, ParachainStaking, RuntimeOrigin, Vesting};
+use polimec_base_runtime::{Balances, ParachainStaking, PayMaster, RuntimeOrigin, Vesting};
 use sp_runtime::Perquintill;
 use tests::defaults::*;
 use xcm_emulator::get_account_id_from_seed;
@@ -142,5 +142,42 @@ fn base_can_withdraw_when_free_is_below_frozen_with_hold() {
 		assert_eq!(Balances::usable_balance(&CARLOS.into()), 0);
 		assert_eq!(Balances::free_balance(&CARLOS.into()), ED);
 		assert_eq!(Balances::reserved_balance(&CARLOS.into()), 2_000 * PLMC);
+	})
+}
+
+// Tests the behavior of transferring the dust to the Blockchain Operation Treasury.
+// When an account's balance falls below the Existential Deposit (ED) threshold following a transfer,
+// the account is killed and the dust is sent to the treasury.
+#[test]
+fn dust_to_treasury() {
+	PolimecBase::execute_with(|| {
+		// Create two new accounts: a sender and a receiver.
+		let sender = get_account_id_from_seed::<sr25519::Public>("SENDER");
+		let receiver = get_account_id_from_seed::<sr25519::Public>("RECEIVER");
+
+		// Set the sender's initial balance to 1 PLMC.
+		let initial_sender_balance = 1 * PLMC;
+		Balances::set_balance(&sender, initial_sender_balance);
+
+		// Get the total issuance and Treasury balance before the transfer.
+		let initial_total_issuance = Balances::total_issuance();
+		let initial_treasury_balance = Balances::free_balance(PayMaster::get());
+
+		// Transfer funds from sender to receiver, designed to deplete the sender's balance below the ED.
+		// The sender account will be killed and the dust will be sent to the treasury.
+		// This happens because at the end of the transfer, the user has free_balance < ED.
+		assert_ok!(Balances::transfer_allow_death(
+			RuntimeOrigin::signed(sender),
+			sp_runtime::MultiAddress::Id(receiver),
+			initial_sender_balance - ED + 1
+		));
+
+		// Confirm the total issuance remains unchanged post-transfer.
+		let post_total_issuance = Balances::total_issuance();
+		assert_eq!(initial_total_issuance, post_total_issuance);
+
+		// Verify the Treasury has received the dust from the sender's account.
+		let final_treasury_balance = Balances::free_balance(PayMaster::get());
+		assert_eq!(initial_treasury_balance + ED - 1, final_treasury_balance);
 	})
 }

--- a/runtimes/base/src/lib.rs
+++ b/runtimes/base/src/lib.rs
@@ -195,7 +195,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("polimec-mainnet"),
 	impl_name: create_runtime_str!("polimec-mainnet"),
 	authoring_version: 1,
-	spec_version: 0_005_005,
+	spec_version: 0_005_006,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtimes/base/src/lib.rs
+++ b/runtimes/base/src/lib.rs
@@ -340,10 +340,19 @@ impl pallet_authorship::Config for Runtime {
 	type FindAuthor = pallet_session::FindAccountFromAuthorIndex<Self, Aura>;
 }
 
+pub struct DustRemovalAdapter;
+
+impl tokens::imbalance::OnUnbalanced<CreditOf<Runtime>> for DustRemovalAdapter {
+	fn on_nonzero_unbalanced(amount: CreditOf<Runtime>) {
+		let treasury_account = PayMaster::get();
+		let _ = <Balances as tokens::fungible::Balanced<AccountId>>::resolve(&treasury_account, amount);
+	}
+}
+
 impl pallet_balances::Config for Runtime {
 	type AccountStore = System;
 	type Balance = Balance;
-	type DustRemoval = ();
+	type DustRemoval = DustRemovalAdapter;
 	type ExistentialDeposit = ExistentialDeposit;
 	type FreezeIdentifier = RuntimeFreezeReason;
 	type MaxFreezes = MaxReserves;


### PR DESCRIPTION
## What?

When an account is closed but still holds a balance below the Existential Deposit (ED), some PLMC "dust" is generated. This dust should be directed to the Blockchain Operation Treasury instead of being burned.

## Why?

The following extrinsic https://explorer.polimec.org/polimec/extrinsic/767479-2 resulted in the account of the sender being killed, and the residual dust was burned rather than allocated to the Blockchain Operation Treasury.

## How?

We can adjust this behavior through the `DustRemoval` configuration option in the `Balances` pallet.

## Testing?

A new integration test now compares the total issuance before and after a `DustLost` event to ensure the dust is properly accounted for.

