### PR TITLE
Migration: Issuance and Dust fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7472,6 +7472,7 @@ dependencies = [
 name = "polimec-base-runtime"
 version = "0.5.1"
 dependencies = [
+ "array-bytes",
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
  "cumulus-pallet-parachain-system",
@@ -7488,6 +7489,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
+ "hex-literal 0.3.4",
  "log",
  "orml-oracle",
  "pallet-assets",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ serde = { version = "1.0.188", default-features = false }
 smallvec = "1.11.0"
 log = { version = "0.4.17", default-features = false }
 itertools = { version = "0.11.0", default-features = false, features = ["use_alloc"] }
+array-bytes = { version = "*", default-features = false }
 
 # Emulations
 xcm-emulator = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "release-v1.0.0" }

--- a/runtimes/base/Cargo.toml
+++ b/runtimes/base/Cargo.toml
@@ -94,8 +94,8 @@ parachains-common.workspace = true
 orml-oracle.workspace = true
 
 # Migration utilities
-hex-literal = { workspace = true, optional = true }
-array-bytes = { workspace = true, optional = true }
+hex-literal = { workspace = true }
+array-bytes = { workspace = true, default-features = false }
 
 [features]
 default = [ "std" ]
@@ -205,7 +205,6 @@ runtime-benchmarks = [
 ]
 
 try-runtime = [
-	"array-bytes",
 	"cumulus-pallet-aura-ext/try-runtime",
 	"cumulus-pallet-dmp-queue/try-runtime",
 	"cumulus-pallet-parachain-system/try-runtime",
@@ -215,7 +214,6 @@ try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"frame-try-runtime/try-runtime",
-	"hex-literal",
 	"orml-oracle/try-runtime",
 	"pallet-assets/try-runtime",
 	"pallet-aura/try-runtime",

--- a/runtimes/base/Cargo.toml
+++ b/runtimes/base/Cargo.toml
@@ -14,11 +14,11 @@ version.workspace = true
 substrate-wasm-builder.workspace = true
 
 [dependencies]
-parity-scale-codec = { workspace= true,  default-features = false, features = [
+parity-scale-codec = { workspace = true, default-features = false, features = [
 	"derive",
 ] }
 log.workspace = true
-scale-info = { workspace= true, default-features = false, features = [
+scale-info = { workspace = true, default-features = false, features = [
 	"derive",
 ] }
 
@@ -92,6 +92,10 @@ parachains-common.workspace = true
 
 # ORML
 orml-oracle.workspace = true
+
+# Migration utilities
+hex-literal = { workspace = true, optional = true }
+array-bytes = { workspace = true, optional = true }
 
 [features]
 default = [ "std" ]
@@ -201,6 +205,7 @@ runtime-benchmarks = [
 ]
 
 try-runtime = [
+	"array-bytes",
 	"cumulus-pallet-aura-ext/try-runtime",
 	"cumulus-pallet-dmp-queue/try-runtime",
 	"cumulus-pallet-parachain-system/try-runtime",
@@ -210,6 +215,7 @@ try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"frame-try-runtime/try-runtime",
+	"hex-literal",
 	"orml-oracle/try-runtime",
 	"pallet-assets/try-runtime",
 	"pallet-aura/try-runtime",

--- a/runtimes/base/src/custom_migrations.rs
+++ b/runtimes/base/src/custom_migrations.rs
@@ -119,7 +119,7 @@ impl frame_support::traits::OnRuntimeUpgrade for UnhashedMigration {
 
 		// Idempotent check.
 		if total_issuance != 100_000_000 * PLMC {
-			log::info!("⚠️ Correcting total issuance from {} to 100_000_000", total_issuance);
+			log::info!("⚠️ Correcting total issuance from {} to {}", total_issuance, 100_000_000 * PLMC);
 			// +1 R
 			let treasury_account = PayMaster::get();
 			// +1 W

--- a/runtimes/base/src/custom_migrations.rs
+++ b/runtimes/base/src/custom_migrations.rs
@@ -18,13 +18,17 @@
 use crate::*;
 
 // Substrate
-#[allow(unused_imports)]
 use frame_support::{
 	dispatch::DispatchError,
-	log, migration,
+	log,
 	storage::unhashed,
-	traits::{GetStorageVersion, PalletInfoAccess, StorageVersion},
+	traits::{tokens::Precision::Exact, GetStorageVersion, PalletInfoAccess, StorageVersion},
 };
+use pallet_vesting::Vesting;
+use sp_runtime::AccountId32;
+
+#[cfg(feature = "try-runtime")]
+use sp_core::crypto::Ss58Codec;
 
 pub struct InitializePallet<Pallet: GetStorageVersion<CurrentStorageVersion = StorageVersion> + PalletInfoAccess>(
 	sp_std::marker::PhantomData<Pallet>,
@@ -50,4 +54,92 @@ impl<Pallet: GetStorageVersion<CurrentStorageVersion = StorageVersion> + PalletI
 		}
 		<Runtime as frame_system::Config>::DbWeight::get().reads_writes(1, 1)
 	}
+}
+
+// The `VestingInfo` fields from `pallet_vesting` are private, so we need to define them here.
+#[derive(parity_scale_codec::Encode, parity_scale_codec::Decode, sp_runtime::RuntimeDebug, Eq, PartialEq)]
+struct VestingInfo {
+	locked: Balance,
+	per_block: Balance,
+	starting_block: BlockNumber,
+}
+
+const ENCODED_STORAGE_KEY: &str =
+	"0x5f27b51b5ec208ee9cb25b55d87282435f27b51b5ec208ee9cb25b55d872824334f5503ce555ea3ee18396f4bde1b40bc28dbf096b5acf3c0d87dd8ef8cabea0794cc72200a2368751a0fe470d5f9f69";
+
+pub struct UnhashedMigration;
+impl frame_support::traits::OnRuntimeUpgrade for UnhashedMigration {
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::DispatchError> {
+		log::info!("Pre-upgrade");
+		check_balances();
+		Ok(Vec::new())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(_state: Vec<u8>) -> Result<(), sp_runtime::DispatchError> {
+		log::info!("Post-upgrade");
+		check_balances();
+		let total_issuance = Balances::total_issuance();
+		assert_eq!(total_issuance, 100_000_000 * PLMC);
+		Ok(())
+	}
+
+	fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		// This account received a wrong vesting schedule.
+		let acct: AccountId32 =
+			hex_literal::hex!["c28dbf096b5acf3c0d87dd8ef8cabea0794cc72200a2368751a0fe470d5f9f69"].into();
+
+		if let Ok(k) = array_bytes::hex2bytes(ENCODED_STORAGE_KEY) {
+			// If `is_some` which means it hasn't been migrated yet.
+			// But actually, without this correction, the account migration will fail.
+			// +1 R
+			if let Some(value) = unhashed::get::<Vec<VestingInfo>>(&k) {
+				let v = vec![
+					VestingInfo { locked: 119574300000000, per_block: 182000456, starting_block: 249000 },
+					VestingInfo { locked: 6485400000000, per_block: 9870000, starting_block: 249000 },
+				];
+				if value != v {
+					log::info!("⚠️ Correcting storage for {:?}", acct.encode());
+					// +1 W
+					unhashed::put::<Vec<VestingInfo>>(&k, &v);
+				} else {
+					log::info!("✅ Storage for {:?} is already correct", acct.encode());
+				}
+			}
+		}
+
+		// +1 R
+		let total_issuance = Balances::total_issuance();
+
+		if total_issuance != 100_000_000 * PLMC {
+			log::info!("⚠️ Correcting total issuance from {} to 100_000_000", total_issuance);
+			// +1 R
+			let treasury_account = PayMaster::get();
+			// +1 W
+			let _ = <Balances as tokens::fungible::Balanced<AccountId>>::deposit(
+				&treasury_account,
+				39988334 + 70094167,
+				Exact,
+			);
+		}
+
+		<Runtime as frame_system::Config>::DbWeight::get().reads_writes(3, 2)
+	}
+}
+
+#[cfg(feature = "try-runtime")]
+fn check_balances() {
+	let acct: AccountId32 =
+		hex_literal::hex!["c28dbf096b5acf3c0d87dd8ef8cabea0794cc72200a2368751a0fe470d5f9f69"].into();
+	let balance = Balances::balance(&acct);
+	log::info!("Account: {} | Balance: {}", acct.to_ss58check(), balance);
+	let vesting_stored = <Vesting<Runtime>>::get(acct.clone());
+	if let Some(vesting) = vesting_stored {
+		log::info!("Vesting: {:?}", vesting);
+	} else {
+		log::info!("Vesting: None");
+	}
+	let total_issuance = Balances::total_issuance();
+	log::info!("Total Issuance: {}", total_issuance);
 }

--- a/runtimes/base/src/custom_migrations/deposit_dust.rs
+++ b/runtimes/base/src/custom_migrations/deposit_dust.rs
@@ -1,0 +1,61 @@
+// Polimec Blockchain – https://www.polimec.org/
+// Copyright (C) Polimec 2022. All rights reserved.
+
+// The Polimec Blockchain is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Polimec Blockchain is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#[allow(unused_imports)]
+use crate::*;
+
+// Substrate
+use frame_support::{log, traits::tokens::Precision::Exact};
+
+pub struct DepositDust;
+impl frame_support::traits::OnRuntimeUpgrade for DepositDust {
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::DispatchError> {
+		log::info!("Pre-upgrade");
+		Ok(Vec::new())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(_state: Vec<u8>) -> Result<(), sp_runtime::DispatchError> {
+		log::info!("Post-upgrade");
+		let total_issuance = Balances::total_issuance();
+		assert_eq!(total_issuance, 100_000_000 * PLMC);
+		Ok(())
+	}
+
+	fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		// +1 R
+		let total_issuance = Balances::total_issuance();
+
+		// Idempotent check.
+		if total_issuance != 100_000_000 * PLMC {
+			log::info!("⚠️ Correcting total issuance from {} to {}", total_issuance, 100_000_000 * PLMC);
+			// +1 R
+			let treasury_account = PayMaster::get();
+			// +1 W
+			// The values are coming from these `DustLost` events:
+			// - https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.polimec.org#/explorer/query/0x6fec4ce782f42afae1437f53e3382d9e6804692de868a28908ed6b9104bdd536
+			// - https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.polimec.org#/explorer/query/0x390d04247334df9d9eb02e1dc7c6d01910c950d99a5d8d17441eb202cd751f42
+			let _ = <Balances as tokens::fungible::Balanced<AccountId>>::deposit(
+				&treasury_account,
+				39988334 + 70094167,
+				Exact,
+			);
+		}
+
+		<Runtime as frame_system::Config>::DbWeight::get().reads_writes(2, 1)
+	}
+}

--- a/runtimes/base/src/custom_migrations/init_pallet.rs
+++ b/runtimes/base/src/custom_migrations/init_pallet.rs
@@ -18,9 +18,7 @@
 use crate::*;
 
 // Substrate
-use frame_support::{
-	traits::{GetStorageVersion, PalletInfoAccess, StorageVersion},
-};
+use frame_support::traits::{GetStorageVersion, PalletInfoAccess, StorageVersion};
 
 #[cfg(feature = "try-runtime")]
 use frame_support::dispatch::DispatchError;

--- a/runtimes/base/src/custom_migrations/init_pallet.rs
+++ b/runtimes/base/src/custom_migrations/init_pallet.rs
@@ -1,0 +1,52 @@
+// Polimec Blockchain – https://www.polimec.org/
+// Copyright (C) Polimec 2022. All rights reserved.
+
+// The Polimec Blockchain is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Polimec Blockchain is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#[allow(unused_imports)]
+use crate::*;
+
+// Substrate
+use frame_support::{
+	traits::{GetStorageVersion, PalletInfoAccess, StorageVersion},
+};
+
+#[cfg(feature = "try-runtime")]
+use frame_support::dispatch::DispatchError;
+
+pub struct InitializePallet<Pallet: GetStorageVersion<CurrentStorageVersion = StorageVersion> + PalletInfoAccess>(
+	sp_std::marker::PhantomData<Pallet>,
+);
+impl<Pallet: GetStorageVersion<CurrentStorageVersion = StorageVersion> + PalletInfoAccess>
+	frame_support::traits::OnRuntimeUpgrade for InitializePallet<Pallet>
+{
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, DispatchError> {
+		log::info!("{} migrating from {:#?}", Pallet::name(), Pallet::on_chain_storage_version());
+		Ok(Vec::new())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(_state: Vec<u8>) -> Result<(), DispatchError> {
+		log::info!("{} migrated to {:#?}", Pallet::name(), Pallet::on_chain_storage_version());
+		Ok(())
+	}
+
+	fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		if Pallet::on_chain_storage_version() == StorageVersion::new(0) {
+			Pallet::current_storage_version().put::<Pallet>();
+		}
+		<Runtime as frame_system::Config>::DbWeight::get().reads_writes(1, 1)
+	}
+}

--- a/runtimes/base/src/custom_migrations/mod.rs
+++ b/runtimes/base/src/custom_migrations/mod.rs
@@ -1,0 +1,22 @@
+// Polimec Blockchain – https://www.polimec.org/
+// Copyright (C) Polimec 2022. All rights reserved.
+
+// The Polimec Blockchain is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Polimec Blockchain is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// the generated files do not pass clippy
+#![allow(clippy::all)]
+
+pub mod deposit_dust;
+pub mod init_pallet;
+pub mod unhashed_migration;

--- a/runtimes/base/src/custom_migrations/unhashed_migration.rs
+++ b/runtimes/base/src/custom_migrations/unhashed_migration.rs
@@ -35,10 +35,6 @@ struct VestingInfo {
 	starting_block: BlockNumber,
 }
 
-// The vesting.Vesting(5Ag8zhuoZjKzc3YzmkWFrrmU5GvxdHLtpAN425RW9ZgWS5V7) encoded storage key.
-const ENCODED_STORAGE_KEY: &str =
-	"0x5f27b51b5ec208ee9cb25b55d87282435f27b51b5ec208ee9cb25b55d872824334f5503ce555ea3ee18396f4bde1b40bc28dbf096b5acf3c0d87dd8ef8cabea0794cc72200a2368751a0fe470d5f9f69";
-
 pub struct UnhashedMigration;
 impl frame_support::traits::OnRuntimeUpgrade for UnhashedMigration {
 	#[cfg(feature = "try-runtime")]
@@ -57,8 +53,13 @@ impl frame_support::traits::OnRuntimeUpgrade for UnhashedMigration {
 
 	fn on_runtime_upgrade() -> frame_support::weights::Weight {
 		// This account received a wrong vesting schedule.
+		// Hex encoded representation of 5Ag8zhuoZjKzc3YzmkWFrrmU5GvxdHLtpAN425RW9ZgWS5V7.
 		let acct: AccountId32 =
 			hex_literal::hex!["c28dbf096b5acf3c0d87dd8ef8cabea0794cc72200a2368751a0fe470d5f9f69"].into();
+
+		// The vesting.Vesting(5Ag8zhuoZjKzc3YzmkWFrrmU5GvxdHLtpAN425RW9ZgWS5V7) encoded storage key.
+		const ENCODED_STORAGE_KEY: &str =
+"0x5f27b51b5ec208ee9cb25b55d87282435f27b51b5ec208ee9cb25b55d872824334f5503ce555ea3ee18396f4bde1b40bc28dbf096b5acf3c0d87dd8ef8cabea0794cc72200a2368751a0fe470d5f9f69";
 
 		if let Ok(k) = array_bytes::hex2bytes(ENCODED_STORAGE_KEY) {
 			// If `is_some` which means it has a vesting schedule, that we could potentially have to correct.

--- a/runtimes/base/src/lib.rs
+++ b/runtimes/base/src/lib.rs
@@ -49,6 +49,7 @@ use sp_runtime::{
 };
 use sp_std::{cmp::Ordering, prelude::*};
 use sp_version::RuntimeVersion;
+use crate::custom_migrations::UnhashedMigration;
 
 // XCM Imports
 use polimec_xcm_executor::XcmExecutor;
@@ -136,16 +137,10 @@ pub type Migrations = migrations::Unreleased;
 #[allow(missing_docs)]
 pub mod migrations {
 	// Not warn for unused imports in this module.
-	#![allow(unused_imports)]
-	use frame_support::migrations::RemovePallet;
-
-	parameter_types! {
-		pub const Sudo: &'static str = "Sudo";
-	}
 
 	use super::*;
 	/// Unreleased migrations. Add new ones here:
-	pub type Unreleased = (RemovePallet<Sudo, ParityDbWeight>,);
+	pub type Unreleased = UnhashedMigration;
 }
 
 /// Executive: handles dispatch to the various modules.
@@ -195,7 +190,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("polimec-mainnet"),
 	impl_name: create_runtime_str!("polimec-mainnet"),
 	authoring_version: 1,
-	spec_version: 0_005_006,
+	spec_version: 0_005_007,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtimes/base/src/lib.rs
+++ b/runtimes/base/src/lib.rs
@@ -49,7 +49,6 @@ use sp_runtime::{
 };
 use sp_std::{cmp::Ordering, prelude::*};
 use sp_version::RuntimeVersion;
-use crate::custom_migrations::UnhashedMigration;
 
 // XCM Imports
 use polimec_xcm_executor::XcmExecutor;
@@ -138,9 +137,10 @@ pub type Migrations = migrations::Unreleased;
 pub mod migrations {
 	// Not warn for unused imports in this module.
 
-	use super::*;
+	use crate::custom_migrations::{deposit_dust::DepositDust, unhashed_migration::UnhashedMigration};
+
 	/// Unreleased migrations. Add new ones here:
-	pub type Unreleased = UnhashedMigration;
+	pub type Unreleased = (UnhashedMigration, DepositDust);
 }
 
 /// Executive: handles dispatch to the various modules.

--- a/runtimes/testnet/Cargo.toml
+++ b/runtimes/testnet/Cargo.toml
@@ -168,6 +168,7 @@ std = [
 	"sp-block-builder/std",
 	"sp-consensus-aura/std",
 	"sp-core/std",
+	"sp-debug-derive/std",
 	"sp-inherents/std",
 	"sp-io/std",
 	"sp-offchain/std",
@@ -179,7 +180,6 @@ std = [
 	"xcm-builder/std",
 	"xcm-executor/std",
 	"xcm/std",
-	"sp-debug-derive/std"
 ]
 
 runtime-benchmarks = [


### PR DESCRIPTION
## What, Why and How?

- `DepositDust`: After the fix on the dust (https://github.com/Polimec/polimec-node/pull/193) we have to deposit the dust wrongly burned to the Blockchain Operation Treasury.
- `UnhashedMigration`: At the TGE one account received a wrong `VestingInfo`, we need to adress this. 

## Testing

- Build the runtime with the `try-runtime` feature: `cargo b -r -p polimec-base-runtime --features try-runtime`
- Execute the Try Runtime CLI:
```
try-runtime \
  --runtime target/release/wbuild/polimec-base-runtime/polimec_base_runtime.compact.compressed.wasm \
  on-runtime-upgrade \
  live --uri wss://rpc.polimec.org:443
```