### PR TITLE
Feature/plmc 466 research if storage layers dont get dropped when calling

### DIFF
--- a/pallets/funding/src/functions.rs
+++ b/pallets/funding/src/functions.rs
@@ -18,12 +18,18 @@
 
 //! Functions for the Funding pallet.
 use crate::ProjectStatus::FundingSuccessful;
-use frame_support::{dispatch::{DispatchErrorWithPostInfo, DispatchResult, DispatchResultWithPostInfo, PostDispatchInfo}, ensure, pallet_prelude::*, traits::{
-	fungible::{Mutate, MutateHold as FungibleMutateHold},
-	fungibles::{metadata::Mutate as MetadataMutate, Create, Inspect, Mutate as FungiblesMutate},
-	tokens::{Fortitude, Precision, Preservation, Restriction},
-	Get,
-}, transactional};
+use frame_support::{
+	dispatch::{DispatchErrorWithPostInfo, DispatchResult, DispatchResultWithPostInfo, PostDispatchInfo},
+	ensure,
+	pallet_prelude::*,
+	traits::{
+		fungible::{Mutate, MutateHold as FungibleMutateHold},
+		fungibles::{metadata::Mutate as MetadataMutate, Create, Inspect, Mutate as FungiblesMutate},
+		tokens::{Fortitude, Precision, Preservation, Restriction},
+		Get,
+	},
+	transactional,
+};
 use frame_system::pallet_prelude::BlockNumberFor;
 use itertools::Itertools;
 use polimec_common::{
@@ -807,6 +813,7 @@ impl<T: Config> Pallet<T> {
 	/// # Next step
 	/// The issuer will call an extrinsic to start the evaluation round of the project.
 	/// [`do_start_evaluation`](Self::do_start_evaluation) will be executed.
+	#[transactional]
 	pub fn do_create(issuer: &AccountIdOf<T>, initial_metadata: ProjectMetadataOf<T>, did: Did) -> DispatchResult {
 		// * Get variables *
 		let project_id = NextProjectId::<T>::get();
@@ -880,6 +887,7 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
+	#[transactional]
 	pub fn do_remove_project(issuer: &AccountIdOf<T>, project_id: ProjectId, did: Did) -> DispatchResult {
 		// * Get variables *
 		let project_details = ProjectsDetails::<T>::get(project_id).ok_or(Error::<T>::ProjectDetailsNotFound)?;
@@ -912,6 +920,7 @@ impl<T: Config> Pallet<T> {
 	/// * [`Images`] - Check that the image exists
 	/// * [`ProjectsDetails`] - Check that the project is not frozen
 	/// * [`ProjectsMetadata`] - Update the metadata hash
+	#[transactional]
 	pub fn do_edit_metadata(
 		issuer: AccountIdOf<T>,
 		project_id: ProjectId,
@@ -938,6 +947,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	// Note: usd_amount needs to have the same amount of decimals as PLMC, so when multiplied by the plmc-usd price, it gives us the PLMC amount with the decimals we wanted.
+	#[transactional]
 	pub fn do_evaluate(
 		evaluator: &AccountIdOf<T>,
 		project_id: ProjectId,
@@ -1061,6 +1071,7 @@ impl<T: Config> Pallet<T> {
 	/// * [`ProjectsDetails`] - Check that the project is in the bidding stage
 	/// * [`BiddingBonds`] - Update the storage with the bidder's PLMC bond for that bid
 	/// * [`Bids`] - Check previous bids by that user, and update the storage with the new bid
+	#[transactional]
 	pub fn do_bid(
 		bidder: &AccountIdOf<T>,
 		project_id: ProjectId,
@@ -1176,6 +1187,7 @@ impl<T: Config> Pallet<T> {
 		})
 	}
 
+	#[transactional]
 	fn perform_do_bid(
 		bidder: &AccountIdOf<T>,
 		project_id: ProjectId,
@@ -1252,6 +1264,7 @@ impl<T: Config> Pallet<T> {
 	///   are limited by the total amount of tokens available in the Community Round.
 	/// * multiplier: Decides how much PLMC bonding is required for buying that amount of tokens
 	/// * asset: The asset used for the contribution
+	#[transactional]
 	pub fn do_community_contribute(
 		contributor: &AccountIdOf<T>,
 		project_id: ProjectId,
@@ -1291,6 +1304,7 @@ impl<T: Config> Pallet<T> {
 	///   are limited by the total amount of tokens available after the Auction and Community rounds.
 	/// * multiplier: Decides how much PLMC bonding is required for buying that amount of tokens
 	/// * asset: The asset used for the contribution
+	#[transactional]
 	pub fn do_remaining_contribute(
 		contributor: &AccountIdOf<T>,
 		project_id: ProjectId,
@@ -1321,6 +1335,7 @@ impl<T: Config> Pallet<T> {
 		)
 	}
 
+	#[transactional]
 	fn do_contribute(
 		contributor: &AccountIdOf<T>,
 		project_id: ProjectId,
@@ -1464,6 +1479,7 @@ impl<T: Config> Pallet<T> {
 		Ok(PostDispatchInfo { actual_weight, pays_fee: Pays::Yes })
 	}
 
+	#[transactional]
 	pub fn do_decide_project_outcome(
 		issuer: AccountIdOf<T>,
 		project_id: ProjectId,
@@ -1499,6 +1515,7 @@ impl<T: Config> Pallet<T> {
 		})
 	}
 
+	#[transactional]
 	pub fn do_bid_ct_mint_for(
 		releaser: &AccountIdOf<T>,
 		project_id: ProjectId,
@@ -1548,6 +1565,7 @@ impl<T: Config> Pallet<T> {
 		})
 	}
 
+	#[transactional]
 	pub fn do_contribution_ct_mint_for(
 		releaser: &AccountIdOf<T>,
 		project_id: ProjectId,
@@ -1597,6 +1615,7 @@ impl<T: Config> Pallet<T> {
 		})
 	}
 
+	#[transactional]
 	pub fn do_evaluation_unbond_for(
 		releaser: &AccountIdOf<T>,
 		project_id: ProjectId,
@@ -1645,6 +1664,7 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
+	#[transactional]
 	pub fn do_evaluation_reward_payout_for(
 		caller: &AccountIdOf<T>,
 		project_id: ProjectId,
@@ -1714,6 +1734,7 @@ impl<T: Config> Pallet<T> {
 		})
 	}
 
+	#[transactional]
 	pub fn do_evaluation_slash_for(
 		caller: &AccountIdOf<T>,
 		project_id: ProjectId,
@@ -1767,6 +1788,7 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
+	#[transactional]
 	pub fn do_start_bid_vesting_schedule_for(
 		caller: &AccountIdOf<T>,
 		project_id: ProjectId,
@@ -1813,6 +1835,7 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
+	#[transactional]
 	pub fn do_start_contribution_vesting_schedule_for(
 		caller: &AccountIdOf<T>,
 		project_id: ProjectId,
@@ -1858,6 +1881,7 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
+	#[transactional]
 	pub fn do_vest_plmc_for(
 		caller: AccountIdOf<T>,
 		project_id: ProjectId,
@@ -1878,6 +1902,7 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
+	#[transactional]
 	pub fn do_release_bid_funds_for(
 		caller: &AccountIdOf<T>,
 		project_id: ProjectId,
@@ -1925,6 +1950,7 @@ impl<T: Config> Pallet<T> {
 
 	// Unbond the PLMC of a bid instantly, following a failed funding outcome.
 	// Unbonding of PLMC in a successful funding outcome is handled by the vesting schedule.
+	#[transactional]
 	pub fn do_bid_unbond_for(
 		caller: &AccountIdOf<T>,
 		project_id: ProjectId,
@@ -1964,6 +1990,7 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
+	#[transactional]
 	pub fn do_release_contribution_funds_for(
 		caller: &AccountIdOf<T>,
 		project_id: ProjectId,
@@ -2008,6 +2035,7 @@ impl<T: Config> Pallet<T> {
 
 	// Unbond the PLMC of a contribution instantly, following a failed funding outcome.
 	// Unbonding of PLMC in a successful funding outcome is handled by the vesting schedule.
+	#[transactional]
 	pub fn do_contribution_unbond_for(
 		caller: &AccountIdOf<T>,
 		project_id: ProjectId,
@@ -2043,6 +2071,7 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
+	#[transactional]
 	pub fn do_payout_bid_funds_for(
 		caller: &AccountIdOf<T>,
 		project_id: ProjectId,
@@ -2089,6 +2118,7 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
+	#[transactional]
 	pub fn do_payout_contribution_funds_for(
 		caller: &AccountIdOf<T>,
 		project_id: ProjectId,
@@ -2132,6 +2162,7 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
+	#[transactional]
 	pub fn do_set_para_id_for_project(
 		caller: &AccountIdOf<T>,
 		project_id: ProjectId,
@@ -2275,6 +2306,7 @@ impl<T: Config> Pallet<T> {
 		}
 	}
 
+	#[transactional]
 	pub fn do_start_migration_readiness_check(caller: &AccountIdOf<T>, project_id: ProjectId) -> DispatchResult {
 		// * Get variables *
 		let mut project_details = ProjectsDetails::<T>::get(project_id).ok_or(Error::<T>::ProjectDetailsNotFound)?;
@@ -2362,6 +2394,7 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
+	#[transactional]
 	pub fn do_migration_check_response(
 		location: MultiLocation,
 		query_id: xcm::v3::QueryId,
@@ -2443,6 +2476,7 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
+	#[transactional]
 	pub fn do_start_migration(caller: &AccountIdOf<T>, project_id: ProjectId) -> DispatchResult {
 		// * Get variables *
 		let project_details = ProjectsDetails::<T>::get(project_id).ok_or(Error::<T>::ProjectDetailsNotFound)?;
@@ -2461,6 +2495,7 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
+	#[transactional]
 	pub fn do_migrate_one_participant(
 		caller: AccountIdOf<T>,
 		project_id: ProjectId,
@@ -2528,6 +2563,7 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
+	#[transactional]
 	pub fn do_confirm_migrations(location: MultiLocation, query_id: QueryId, response: Response) -> DispatchResult {
 		use xcm::v3::prelude::*;
 		let unconfirmed_migrations = UnconfirmedMigrations::<T>::take(query_id).ok_or(Error::<T>::NotAllowed)?;
@@ -2567,6 +2603,7 @@ impl<T: Config> Pallet<T> {
 }
 
 // Helper functions
+// ATTENTION: if this is called directly, it will not be transactional
 impl<T: Config> Pallet<T> {
 	/// The account ID of the project pot.
 	///
@@ -2615,7 +2652,7 @@ impl<T: Config> Pallet<T> {
 		plmc_price.reciprocal().ok_or(Error::<T>::BadMath)?.checked_mul_int(usd_bond).ok_or(Error::<T>::BadMath.into())
 	}
 
-	/// Based on the amount of tokens and price to buy, a desired multiplier, and the type of investor the caller is,
+	// Based on the amount of tokens and price to buy, a desired multiplier, and the type of investor the caller is,
 	/// calculate the amount and vesting periods of bonded PLMC and reward CT tokens.
 	pub fn calculate_vesting_info(
 		_caller: &AccountIdOf<T>,

--- a/pallets/funding/src/functions.rs
+++ b/pallets/funding/src/functions.rs
@@ -1099,18 +1099,10 @@ impl<T: Config> Pallet<T> {
 			_ => return Err(Error::<T>::NotAllowed.into()),
 		};
 		let max_multiplier = match investor_type {
-			InvestorType::Retail => {
-				RetailParticipations::<T>::mutate(&did, |project_participations| {
-					if project_participations.contains(&project_id).not() {
-						// We don't care if it fails, since it means the user already has access to the max multiplier
-						let _ = project_participations.try_push(project_id);
-					}
-					retail_max_multiplier_for_participations(project_participations.len() as u8)
-				})
-			},
-
 			InvestorType::Professional => PROFESSIONAL_MAX_MULTIPLIER,
 			InvestorType::Institutional => INSTITUTIONAL_MAX_MULTIPLIER,
+			// unreachable
+			_ => return Err(Error::<T>::NotAllowed.into()),
 		};
 
 		// * Validity checks *
@@ -1377,6 +1369,7 @@ impl<T: Config> Pallet<T> {
 			InvestorType::Institutional => INSTITUTIONAL_MAX_MULTIPLIER,
 		};
 		// * Validity checks *
+		ensure!(multiplier.into() <= max_multiplier && multiplier.into() > 0u8, Error::<T>::ForbiddenMultiplier);
 		ensure!(
 			project_metadata.participation_currencies.contains(&funding_asset),
 			Error::<T>::FundingAssetNotAccepted
@@ -1394,7 +1387,6 @@ impl<T: Config> Pallet<T> {
 			contributor_ticket_size.usd_ticket_below_maximum_per_did(total_usd_bought_by_did + ticket_size),
 			Error::<T>::ContributionTooHigh
 		);
-		ensure!(multiplier.into() <= max_multiplier && multiplier.into() > 0u8, Error::<T>::ForbiddenMultiplier);
 		ensure!(
 			project_metadata.participation_currencies.contains(&funding_asset),
 			Error::<T>::FundingAssetNotAccepted

--- a/pallets/funding/src/lib.rs
+++ b/pallets/funding/src/lib.rs
@@ -556,6 +556,11 @@ pub mod pallet {
 		StorageMap<_, Blake2_128Concat, Did, BoundedVec<ProjectId, MaxParticipationsForMaxMultiplier>, ValueQuery>;
 
 	#[pallet::storage]
+	// After 25 participations, the retail user has access to the max multiplier of 10x, so no need to keep tracking it
+	pub type RetailParticipations<T: Config> =
+		StorageMap<_, Blake2_128Concat, Did, BoundedVec<ProjectId, MaxParticipationsForMaxMultiplier>, ValueQuery>;
+
+	#[pallet::storage]
 	/// A map to keep track of what issuer's did has an active project. It prevents one issuer having multiple active projects
 	pub type DidWithActiveProjects<T: Config> = StorageMap<_, Blake2_128Concat, Did, ProjectId, OptionQuery>;
 

--- a/pallets/funding/src/lib.rs
+++ b/pallets/funding/src/lib.rs
@@ -201,15 +201,17 @@ pub mod pallet {
 	use super::*;
 	use crate::traits::{BondingRequirementCalculation, ProvideAssetPrice, VestingDurationCalculation};
 	use frame_support::{
-		dispatch::PostDispatchInfo,
+		dispatch::{GetDispatchInfo, PostDispatchInfo},
 		pallet_prelude::*,
 		traits::{OnFinalize, OnIdle, OnInitialize},
 	};
-	use frame_support::dispatch::GetDispatchInfo;
 	use frame_system::pallet_prelude::*;
 	use local_macros::*;
 	use sp_arithmetic::Percent;
-	use sp_runtime::{traits::{Convert, ConvertBack, Get}, DispatchErrorWithPostInfo, TransactionOutcome};
+	use sp_runtime::{
+		traits::{Convert, ConvertBack, Get},
+		DispatchErrorWithPostInfo, TransactionOutcome,
+	};
 
 	#[cfg(any(feature = "runtime-benchmarks", feature = "std"))]
 	use crate::traits::SetPrices;
@@ -1399,10 +1401,7 @@ pub mod pallet {
 
 		#[pallet::call_index(59)]
 		#[pallet::weight(WeightInfoOf::<T>::start_auction_manually(<T as Config>::MaxProjectsToUpdateInsertionAttempts::get() - 1))]
-		pub fn root_do_english_auction(
-			origin: OriginFor<T>,
-			project_id: ProjectId,
-		) -> DispatchResultWithPostInfo {
+		pub fn root_do_english_auction(origin: OriginFor<T>, project_id: ProjectId) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;
 			Self::do_english_auction(T::PalletId::get().into_account_truncating(), project_id)
 		}
@@ -1486,22 +1485,21 @@ pub mod pallet {
 		}
 	}
 
-	fn update_weight(used_weight: &mut Weight, call: DispatchResultWithPostInfo, fallback_weight: Weight){
+	fn update_weight(used_weight: &mut Weight, call: DispatchResultWithPostInfo, fallback_weight: Weight) {
 		match call {
-			Ok(post_dispatch_info) => {
+			Ok(post_dispatch_info) =>
 				if let Some(actual_weight) = post_dispatch_info.actual_weight {
 					*used_weight = used_weight.saturating_add(actual_weight);
 				} else {
 					*used_weight = used_weight.saturating_add(fallback_weight);
-				}
-			},
-			Err(DispatchErrorWithPostInfo::<PostDispatchInfo>{error, post_info}) => {
+				},
+			Err(DispatchErrorWithPostInfo::<PostDispatchInfo> { error, post_info }) => {
 				if let Some(actual_weight) = post_info.actual_weight {
 					*used_weight = used_weight.saturating_add(actual_weight);
 				} else {
 					*used_weight = used_weight.saturating_add(fallback_weight);
 				}
-			}
+			},
 		}
 	}
 
@@ -1515,74 +1513,64 @@ pub mod pallet {
 					// EvaluationRound -> AuctionInitializePeriod | EvaluationFailed
 					UpdateType::EvaluationEnd => {
 						let call = Self::do_evaluation_end(project_id);
-						let fallback_weight = Call::<T>::root_do_evaluation_end {
-							project_id,
-						}.get_dispatch_info().weight;
+						let fallback_weight =
+							Call::<T>::root_do_evaluation_end { project_id }.get_dispatch_info().weight;
 						update_weight(&mut used_weight, call, fallback_weight);
-					}
+					},
 
 					// AuctionInitializePeriod -> AuctionRound(AuctionPhase::English)
 					// Only if it wasn't first handled by user extrinsic
 					UpdateType::EnglishAuctionStart => {
-						let call = Self::do_english_auction(T::PalletId::get().into_account_truncating(), project_id,);
-						let fallback_weight = Call::<T>::root_do_english_auction{
-							project_id,
-						}.get_dispatch_info().weight;
+						let call = Self::do_english_auction(T::PalletId::get().into_account_truncating(), project_id);
+						let fallback_weight =
+							Call::<T>::root_do_english_auction { project_id }.get_dispatch_info().weight;
 						update_weight(&mut used_weight, call, fallback_weight);
 					},
 
 					// AuctionRound(AuctionPhase::English) -> AuctionRound(AuctionPhase::Candle)
 					UpdateType::CandleAuctionStart => {
 						let call = Self::do_candle_auction(project_id);
-						let fallback_weight = Call::<T>::root_do_candle_auction {
-							project_id,
-						}.get_dispatch_info().weight;
+						let fallback_weight =
+							Call::<T>::root_do_candle_auction { project_id }.get_dispatch_info().weight;
 						update_weight(&mut used_weight, call, fallback_weight);
 					},
 
 					// AuctionRound(AuctionPhase::Candle) -> CommunityRound
 					UpdateType::CommunityFundingStart => {
 						let call = Self::do_community_funding(project_id);
-						let fallback_weight = Call::<T>::root_do_community_funding {
-							project_id,
-						}.get_dispatch_info().weight;
+						let fallback_weight =
+							Call::<T>::root_do_community_funding { project_id }.get_dispatch_info().weight;
 						update_weight(&mut used_weight, call, fallback_weight);
 					},
 
 					// CommunityRound -> RemainderRound
 					UpdateType::RemainderFundingStart => {
 						let call = Self::do_remainder_funding(project_id);
-						let fallback_weight = Call::<T>::root_do_remainder_funding {
-							project_id,
-						}.get_dispatch_info().weight;
+						let fallback_weight =
+							Call::<T>::root_do_remainder_funding { project_id }.get_dispatch_info().weight;
 						update_weight(&mut used_weight, call, fallback_weight);
 					},
 
 					// CommunityRound || RemainderRound -> FundingEnded
 					UpdateType::FundingEnd => {
 						let call = Self::do_end_funding(project_id);
-						let fallback_weight = Call::<T>::root_do_end_funding {
-							project_id,
-						}.get_dispatch_info().weight;
+						let fallback_weight = Call::<T>::root_do_end_funding { project_id }.get_dispatch_info().weight;
 						update_weight(&mut used_weight, call, fallback_weight);
 					},
 
 					UpdateType::ProjectDecision(decision) => {
 						let call = Self::do_project_decision(project_id, decision);
-						let fallback_weight = Call::<T>::root_do_project_decision {
-							project_id,
-							decision,
-						}.get_dispatch_info().weight;
+						let fallback_weight =
+							Call::<T>::root_do_project_decision { project_id, decision }.get_dispatch_info().weight;
 						update_weight(&mut used_weight, call, fallback_weight);
 					},
 
 					UpdateType::StartSettlement => {
 						let call = Self::do_start_settlement(project_id);
-						let fallback_weight = Call::<T>::root_do_start_settlement {
-							project_id,
-						}.get_dispatch_info().weight;
+						let fallback_weight =
+							Call::<T>::root_do_start_settlement { project_id }.get_dispatch_info().weight;
 						update_weight(&mut used_weight, call, fallback_weight);
-					}
+					},
 				}
 			}
 			used_weight

--- a/pallets/funding/src/mock.rs
+++ b/pallets/funding/src/mock.rs
@@ -398,9 +398,9 @@ impl Config for TestRuntime {
 	type InvestorOrigin = EnsureInvestor<TestRuntime>;
 	type ManualAcceptanceDuration = ManualAcceptanceDuration;
 	type MaxBidsPerProject = ConstU32<1024>;
-	type MaxBidsPerUser = ConstU32<150>;
+	type MaxBidsPerUser = ConstU32<25>;
 	type MaxCapacityThresholds = MaxCapacityThresholds;
-	type MaxContributionsPerUser = ConstU32<50>;
+	type MaxContributionsPerUser = ConstU32<25>;
 	type MaxEvaluationsPerProject = ConstU32<1024>;
 	type MaxEvaluationsPerUser = ConstU32<4>;
 	type MaxMessageSizeThresholds = MaxMessageSizeThresholds;

--- a/pallets/funding/src/tests.rs
+++ b/pallets/funding/src/tests.rs
@@ -7277,3 +7277,47 @@ mod async_tests {
 		assert_eq!(total_bids_count, max_bids_per_project as usize);
 	}
 }
+
+// Bug hunting
+mod bug_hunting {
+	use super::*;
+
+	#[test]
+	// Check that a failed do_function in a place like on_initialize doesn't change the storage
+	fn corrupted_state() {
+		let inst = MockInstantiator::new(Some(RefCell::new(new_test_ext())));
+		let max_projects_per_update_block: u32 = <TestRuntime as Config>::MaxProjectsToUpdatePerBlock::get();
+		// This bug will more likely happen with a limit of 1
+		assert_eq!(max_projects_per_update_block, 1u32);
+		let max_insertion_attempts: u32 = <TestRuntime as Config>::MaxProjectsToUpdateInsertionAttempts::get();
+
+		for i in max_insertion_attempts {
+			let project_id = inst.create_evaluating_project(
+				default_project_metadata(i, 1000 + i),
+				1000 + i,
+			);
+			inst.evaluate_for_users(project_id, default_evaluations()).unwrap();
+		}
+		let bug_project_id = inst.create_evaluating_project(
+			default_project_metadata(inst.get_new_nonce(), ISSUER_1),
+			ISSUER_1,
+		);
+
+		let update_block = inst.get_update_block(project_id, &UpdateType::EvaluationEnd).unwrap();
+		inst.execute(|| frame_system::Pallet::<TestRuntime>::set_block_number(update_block));
+		let auction_initialize_period_start_block = inst.current_block() + 1u32.into();
+		let auction_initialize_period_end_block =
+			auction_initialize_period_start_block + <TestRuntime as Config>::AuctionInitializePeriodDuration::get();
+		let automatic_auction_start = auction_initialize_period_end_block + 1u32.into();
+
+
+
+		for i in 0..max_insertion_attempts {
+
+		}
+
+
+
+		let max_insertion_attempts
+	}
+}

--- a/pallets/funding/src/tests.rs
+++ b/pallets/funding/src/tests.rs
@@ -414,7 +414,6 @@ mod creation {
 				Error::<TestRuntime>::Frozen
 			);
 		});
-
 	}
 
 	#[test]
@@ -7283,41 +7282,40 @@ mod bug_hunting {
 	use super::*;
 
 	#[test]
-	// Check that a failed do_function in a place like on_initialize doesn't change the storage
-	fn corrupted_state() {
-		let inst = MockInstantiator::new(Some(RefCell::new(new_test_ext())));
+	// Check that a failed do_function in on_initialize doesn't change the storage
+	fn transactional_on_initialize() {
+		let mut inst = MockInstantiator::new(Some(RefCell::new(new_test_ext())));
 		let max_projects_per_update_block: u32 = <TestRuntime as Config>::MaxProjectsToUpdatePerBlock::get();
 		// This bug will more likely happen with a limit of 1
 		assert_eq!(max_projects_per_update_block, 1u32);
 		let max_insertion_attempts: u32 = <TestRuntime as Config>::MaxProjectsToUpdateInsertionAttempts::get();
 
-		for i in max_insertion_attempts {
-			let project_id = inst.create_evaluating_project(
-				default_project_metadata(i, 1000 + i),
-				1000 + i,
-			);
-			inst.evaluate_for_users(project_id, default_evaluations()).unwrap();
-		}
-		let bug_project_id = inst.create_evaluating_project(
-			default_project_metadata(inst.get_new_nonce(), ISSUER_1),
-			ISSUER_1,
-		);
-
+		let project_id =
+			inst.create_evaluating_project(default_project_metadata(inst.get_new_nonce(), ISSUER_1), ISSUER_1);
+		let plmc_balances = MockInstantiator::calculate_evaluation_plmc_spent(default_evaluations());
+		let ed = plmc_balances.accounts().existential_deposits();
+		inst.mint_plmc_to(plmc_balances);
+		inst.mint_plmc_to(ed);
+		inst.evaluate_for_users(project_id, default_evaluations()).unwrap();
 		let update_block = inst.get_update_block(project_id, &UpdateType::EvaluationEnd).unwrap();
-		inst.execute(|| frame_system::Pallet::<TestRuntime>::set_block_number(update_block));
-		let auction_initialize_period_start_block = inst.current_block() + 1u32.into();
+		inst.execute(|| frame_system::Pallet::<TestRuntime>::set_block_number(update_block - 1));
+		let now = inst.current_block();
+
+		let auction_initialize_period_start_block = now + 2u64;
 		let auction_initialize_period_end_block =
 			auction_initialize_period_start_block + <TestRuntime as Config>::AuctionInitializePeriodDuration::get();
-		let automatic_auction_start = auction_initialize_period_end_block + 1u32.into();
-
-
-
+		let automatic_auction_start = auction_initialize_period_end_block + 1u64;
 		for i in 0..max_insertion_attempts {
-
+			let key: BlockNumberFor<TestRuntime> = automatic_auction_start + i as u64;
+			let val: BoundedVec<(ProjectId, UpdateType), <TestRuntime as Config>::MaxProjectsToUpdatePerBlock> =
+				vec![(69u32, UpdateType::EvaluationEnd)].try_into().unwrap();
+			inst.execute(|| crate::ProjectsToUpdate::<TestRuntime>::insert(key, val));
 		}
 
+		let old_project_details = inst.get_project_details(project_id);
+		inst.advance_time(1).unwrap();
 
-
-		let max_insertion_attempts
+		let new_project_details = inst.get_project_details(project_id);
+		assert_eq!(old_project_details, new_project_details);
 	}
 }

--- a/pallets/funding/src/types.rs
+++ b/pallets/funding/src/types.rs
@@ -175,7 +175,6 @@ pub mod config_types {
 			25..=u8::MAX => 10,
 		}
 	}
-	pub const RETAIL_MAX_MULTIPLIER: u8 = 10u8;
 	pub const PROFESSIONAL_MAX_MULTIPLIER: u8 = 10u8;
 	pub const INSTITUTIONAL_MAX_MULTIPLIER: u8 = 25u8;
 }


### PR DESCRIPTION
## What?
- Make sure our inner logic functions don't affect storage if they return an error

## Why?
- We call those functions directly in on_initialize, and so if they failed, the changes to storage would have been permanent

## How?
- add `#[transactional]` to all do_functions that returned a `DispatchResult`

## Testing?
`transactional_on_initialize()`
