### PR TITLE
feature/plmc-480-rename-create-extrinsic-to-create_project

### DIFF
--- a/integration-tests/src/tests/credentials.rs
+++ b/integration-tests/src/tests/credentials.rs
@@ -29,11 +29,11 @@ fn test_jwt_for_create() {
 		assert_ok!(PolitestBalances::force_set_balance(PolitestOrigin::root(), issuer.into(), 10_000 * PLMC));
 		let retail_jwt = get_test_jwt(PolitestAccountId::from(ISSUER), InvestorType::Retail);
 		assert_noop!(
-			PolitestFundingPallet::create(PolitestOrigin::signed(ISSUER.into()), retail_jwt, project.clone()),
+			PolitestFundingPallet::create_project(PolitestOrigin::signed(ISSUER.into()), retail_jwt, project.clone()),
 			pallet_funding::Error::<PolitestRuntime>::NotAllowed
 		);
 		let inst_jwt = get_test_jwt(PolitestAccountId::from(ISSUER), InvestorType::Institutional);
-		assert_ok!(PolitestFundingPallet::create(PolitestOrigin::signed(ISSUER.into()), inst_jwt, project.clone()));
+		assert_ok!(PolitestFundingPallet::create_project(PolitestOrigin::signed(ISSUER.into()), inst_jwt, project.clone()));
 	});
 }
 
@@ -46,7 +46,7 @@ fn test_jwt_verification() {
 		// This JWT tokens is signed with a private key that is not the one set in the Pallet Funding configuration in the real runtime.
 		let inst_jwt = get_fake_jwt(PolitestAccountId::from(ISSUER), InvestorType::Institutional);
 		assert_noop!(
-			PolitestFundingPallet::create(PolitestOrigin::signed(ISSUER.into()), inst_jwt, project.clone()),
+			PolitestFundingPallet::create_project(PolitestOrigin::signed(ISSUER.into()), inst_jwt, project.clone()),
 			DispatchError::BadOrigin
 		);
 	});

--- a/pallets/funding/src/benchmarking.rs
+++ b/pallets/funding/src/benchmarking.rs
@@ -381,7 +381,7 @@ mod benchmarks {
 	// Extrinsics
 	//
 	#[benchmark]
-	fn create() {
+	fn create_project() {
 		// * setup *
 		let mut inst = BenchInstantiator::<T>::new(None);
 		// real benchmark starts at block 0, and we can't call `events()` at block 0
@@ -405,7 +405,7 @@ mod benchmarks {
 		let jwt = get_mock_jwt(issuer.clone(), InvestorType::Institutional, generate_did_from_account(issuer.clone()));
 
 		#[extrinsic_call]
-		create(RawOrigin::Signed(issuer.clone()), jwt, project_metadata.clone());
+		create_project(RawOrigin::Signed(issuer.clone()), jwt, project_metadata.clone());
 
 		// * validity checks *
 		// Storage
@@ -3459,9 +3459,9 @@ mod benchmarks {
 		use crate::mock::{new_test_ext, TestRuntime};
 
 		#[test]
-		fn bench_create() {
+		fn bench_create_project() {
 			new_test_ext().execute_with(|| {
-				assert_ok!(PalletFunding::<TestRuntime>::test_create());
+				assert_ok!(PalletFunding::<TestRuntime>::test_create_project());
 			});
 		}
 

--- a/pallets/funding/src/functions.rs
+++ b/pallets/funding/src/functions.rs
@@ -862,7 +862,7 @@ impl<T: Config> Pallet<T> {
 	/// The issuer will call an extrinsic to start the evaluation round of the project.
 	/// [`do_start_evaluation`](Self::do_start_evaluation) will be executed.
 	#[transactional]
-	pub fn do_create(issuer: &AccountIdOf<T>, initial_metadata: ProjectMetadataOf<T>, did: Did) -> DispatchResult {
+	pub fn do_create_project(issuer: &AccountIdOf<T>, initial_metadata: ProjectMetadataOf<T>, did: Did) -> DispatchResult {
 		// * Get variables *
 		let project_id = NextProjectId::<T>::get();
 		let maybe_active_project = DidWithActiveProjects::<T>::get(did.clone());

--- a/pallets/funding/src/instantiator.rs
+++ b/pallets/funding/src/instantiator.rs
@@ -1027,7 +1027,7 @@ impl<
 		self.mint_plmc_to(vec![UserToPLMCBalance::new(issuer.clone(), Self::get_ed() * 2u64.into())]);
 
 		self.execute(|| {
-			crate::Pallet::<T>::do_create(&issuer, project_metadata.clone(), generate_did_from_account(issuer.clone()))
+			crate::Pallet::<T>::do_create_project(&issuer, project_metadata.clone(), generate_did_from_account(issuer.clone()))
 				.unwrap();
 			let last_project_metadata = ProjectsMetadata::<T>::iter().last().unwrap();
 			log::trace!("Last project metadata: {:?}", last_project_metadata);
@@ -1713,7 +1713,7 @@ pub mod async_features {
 			Instantiator::<T, AllPalletsWithoutSystem, RuntimeEvent>::get_ed() * 2u64.into(),
 		)]);
 		inst.execute(|| {
-			crate::Pallet::<T>::do_create(
+			crate::Pallet::<T>::do_create_project(
 				&issuer.clone(),
 				project_metadata.clone(),
 				generate_did_from_account(issuer.clone()),

--- a/pallets/funding/src/lib.rs
+++ b/pallets/funding/src/lib.rs
@@ -43,7 +43,7 @@
 //!
 //! | Step                      | Description                                                                                                                                                                                                                                                                                                                                                                                                 | Resulting Project State                                             |
 //! |---------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|
-//! | Creation                  | Issuer creates a project with the [`create()`](Pallet::create) extrinsic.                                                                                                                                                                                                                                                                                                                                   | [`Application`](ProjectStatus::Application)                         |
+//! | Creation                  | Issuer creates a project with the [`create()`](Pallet::create_project) extrinsic.                                                                                                                                                                                                                                                                                                                                   | [`Application`](ProjectStatus::Application)                         |
 //! | Evaluation Start          | Issuer starts the evaluation round with the [`start_evaluation()`](Pallet::start_evaluation) extrinsic.                                                                                                                                                                                                                                                                                                     | [`EvaluationRound`](ProjectStatus::EvaluationRound)                 |
 //! | Evaluation Submissions    | Evaluators assess the project information, and if they think it is good enough to get funding, they bond Polimec's native token PLMC with [`bond_evaluation()`](Pallet::evaluate)                                                                                                                                                                                                                    | [`EvaluationRound`](ProjectStatus::EvaluationRound)                 |
 //! | Evaluation End            | Evaluation round ends automatically after the [`Config::EvaluationDuration`] has passed. This is achieved by the [`on_initialize()`](Pallet::on_initialize) function.                                                                                                                                                                                                                                       | [`AuctionInitializePeriod`](ProjectStatus::AuctionInitializePeriod) |
@@ -62,7 +62,7 @@
 //! ## Interface
 //! All users who wish to participate need to have a valid credential, given to them on the KILT parachain, by a KYC/AML provider.
 //! ### Extrinsics
-//! * [`create`](Pallet::create) : Creates a new project.
+//! * [`create`](Pallet::create_project) : Creates a new project.
 //! * [`edit_metadata`](Pallet::edit_metadata) : Submit a new Hash of the project metadata.
 //! * [`start_evaluation`](Pallet::start_evaluation) : Start the Evaluation round of a project.
 //! * [`start_auction`](Pallet::start_auction) : Start the English Auction round of a project.
@@ -994,11 +994,11 @@ pub mod pallet {
 		/// Creates a project and assigns it to the `issuer` account.
 		#[pallet::call_index(0)]
 		#[pallet::weight(WeightInfoOf::<T>::create())]
-		pub fn create(origin: OriginFor<T>, jwt: UntrustedToken, project: ProjectMetadataOf<T>) -> DispatchResult {
+		pub fn create_project(origin: OriginFor<T>, jwt: UntrustedToken, project: ProjectMetadataOf<T>) -> DispatchResult {
 			let (account, did, investor_type) =
 				T::InvestorOrigin::ensure_origin(origin, &jwt, T::VerifierPublicKey::get())?;
 			ensure!(investor_type == InvestorType::Institutional, Error::<T>::NotAllowed);
-			Self::do_create(&account, project, did)
+			Self::do_create_project(&account, project, did)
 		}
 
 		#[pallet::call_index(35)]

--- a/pallets/funding/src/tests.rs
+++ b/pallets/funding/src/tests.rs
@@ -363,7 +363,7 @@ mod creation {
 		let project_metadata = default_project_metadata(inst.get_new_nonce(), ISSUER_1);
 		inst.mint_plmc_to(default_plmc_balances());
 		let jwt = get_mock_jwt(ISSUER_1, InvestorType::Institutional, generate_did_from_account(ISSUER_1));
-		assert_ok!(inst.execute(|| crate::Pallet::<TestRuntime>::create(
+		assert_ok!(inst.execute(|| crate::Pallet::<TestRuntime>::create_project(
 			RuntimeOrigin::signed(ISSUER_1),
 			jwt,
 			project_metadata
@@ -586,7 +586,7 @@ mod creation {
 		let mut inst = MockInstantiator::new(Some(RefCell::new(new_test_ext())));
 		inst.mint_plmc_to(default_plmc_balances());
 		let project_err = inst.execute(|| {
-			Pallet::<TestRuntime>::do_create(&ISSUER_1, wrong_project, generate_did_from_account(ISSUER_1)).unwrap_err()
+			Pallet::<TestRuntime>::do_create_project(&ISSUER_1, wrong_project, generate_did_from_account(ISSUER_1)).unwrap_err()
 		});
 		assert_eq!(project_err, Error::<TestRuntime>::PriceTooLow.into());
 	}
@@ -667,7 +667,7 @@ mod creation {
 
 		for project in wrong_projects {
 			let project_err = inst.execute(|| {
-				Pallet::<TestRuntime>::do_create(
+				Pallet::<TestRuntime>::do_create_project(
 					&ISSUER_1,
 					with_different_metadata(project),
 					generate_did_from_account(ISSUER_1),
@@ -686,7 +686,7 @@ mod creation {
 
 		inst.mint_plmc_to(vec![UserToPLMCBalance::new(ISSUER_1, ed)]);
 		let project_err = inst.execute(|| {
-			Pallet::<TestRuntime>::do_create(&ISSUER_1, project_metadata, generate_did_from_account(ISSUER_1))
+			Pallet::<TestRuntime>::do_create_project(&ISSUER_1, project_metadata, generate_did_from_account(ISSUER_1))
 				.unwrap_err()
 		});
 		assert_eq!(project_err, Error::<TestRuntime>::NotEnoughFundsForEscrowCreation.into());
@@ -752,7 +752,7 @@ mod creation {
 			let issuer_mint = (issuer, 1000 * PLMC).into();
 			inst.mint_plmc_to(vec![issuer_mint]);
 			assert_ok!(inst.execute(|| {
-				Pallet::<TestRuntime>::do_create(&issuer, project_metadata_new, generate_did_from_account(issuer))
+				Pallet::<TestRuntime>::do_create_project(&issuer, project_metadata_new, generate_did_from_account(issuer))
 			}));
 		}
 
@@ -782,7 +782,7 @@ mod creation {
 			let issuer_mint = (issuer, 1000 * PLMC).into();
 			inst.mint_plmc_to(vec![issuer_mint]);
 			let project_err = inst.execute(|| {
-				Pallet::<TestRuntime>::do_create(
+				Pallet::<TestRuntime>::do_create_project(
 					&issuer,
 					with_different_metadata(project),
 					generate_did_from_account(issuer),
@@ -817,7 +817,7 @@ mod creation {
 
 		// Cannot create 2 projects consecutively
 		inst.execute(|| {
-			assert_ok!(Pallet::<TestRuntime>::create(
+			assert_ok!(Pallet::<TestRuntime>::create_project(
 				RuntimeOrigin::signed(ISSUER_1),
 				jwt.clone(),
 				with_different_hash(project_metadata.clone())
@@ -825,7 +825,7 @@ mod creation {
 		});
 		inst.execute(|| {
 			assert_noop!(
-				Pallet::<TestRuntime>::create(
+				Pallet::<TestRuntime>::create_project(
 					RuntimeOrigin::signed(ISSUER_1),
 					jwt.clone(),
 					with_different_hash(project_metadata.clone())
@@ -838,7 +838,7 @@ mod creation {
 		inst.start_evaluation(0, ISSUER_1).unwrap();
 		inst.execute(|| {
 			assert_noop!(
-				Pallet::<TestRuntime>::create(
+				Pallet::<TestRuntime>::create_project(
 					RuntimeOrigin::signed(ISSUER_1),
 					jwt.clone(),
 					with_different_hash(project_metadata.clone())
@@ -849,7 +849,7 @@ mod creation {
 		inst.advance_time(<TestRuntime as Config>::EvaluationDuration::get() + 1).unwrap();
 		assert_eq!(inst.get_project_details(0).status, ProjectStatus::EvaluationFailed);
 		inst.execute(|| {
-			assert_ok!(Pallet::<TestRuntime>::create(
+			assert_ok!(Pallet::<TestRuntime>::create_project(
 				RuntimeOrigin::signed(ISSUER_1),
 				jwt.clone(),
 				with_different_hash(project_metadata.clone())
@@ -862,7 +862,7 @@ mod creation {
 		inst.start_auction(1, ISSUER_1).unwrap();
 		inst.execute(|| {
 			assert_noop!(
-				Pallet::<TestRuntime>::create(
+				Pallet::<TestRuntime>::create_project(
 					RuntimeOrigin::signed(ISSUER_1),
 					jwt.clone(),
 					with_different_hash(project_metadata.clone())
@@ -874,7 +874,7 @@ mod creation {
 		inst.advance_time(1).unwrap();
 		assert_eq!(inst.get_project_details(1).status, ProjectStatus::FundingFailed);
 		inst.execute(|| {
-			assert_ok!(Pallet::<TestRuntime>::create(
+			assert_ok!(Pallet::<TestRuntime>::create_project(
 				RuntimeOrigin::signed(ISSUER_1),
 				jwt.clone(),
 				with_different_hash(project_metadata.clone())
@@ -889,7 +889,7 @@ mod creation {
 		inst.start_community_funding(2).unwrap();
 		inst.execute(|| {
 			assert_noop!(
-				Pallet::<TestRuntime>::create(
+				Pallet::<TestRuntime>::create_project(
 					RuntimeOrigin::signed(ISSUER_1),
 					jwt.clone(),
 					with_different_hash(project_metadata.clone())
@@ -900,7 +900,7 @@ mod creation {
 		inst.finish_funding(2).unwrap();
 		assert_eq!(inst.get_project_details(2).status, ProjectStatus::FundingFailed);
 		inst.execute(|| {
-			assert_ok!(Pallet::<TestRuntime>::create(
+			assert_ok!(Pallet::<TestRuntime>::create_project(
 				RuntimeOrigin::signed(ISSUER_1),
 				jwt.clone(),
 				with_different_hash(project_metadata.clone())
@@ -918,7 +918,7 @@ mod creation {
 		inst.contribute_for_users(3, default_remainder_buys()).unwrap();
 		inst.finish_funding(3).unwrap();
 		assert_eq!(inst.get_project_details(3).status, ProjectStatus::FundingSuccessful);
-		assert_ok!(inst.execute(|| crate::Pallet::<TestRuntime>::create(
+		assert_ok!(inst.execute(|| crate::Pallet::<TestRuntime>::create_project(
 			RuntimeOrigin::signed(ISSUER_1),
 			jwt.clone(),
 			with_different_hash(project_metadata.clone())


### PR DESCRIPTION
## What?
rename extrinsic `create` to `create_project`

## Why?
to be more descriptive

## How?
rename all occurrences, as well as benchmark and do_function namings

## Testing?
rerun all tests
