### PR TITLE
feature/plmc-486-change-is_funded-to-use-usd-amounts-of-evaluations-instead

### DIFF
--- a/integration-tests/src/tests/credentials.rs
+++ b/integration-tests/src/tests/credentials.rs
@@ -33,7 +33,11 @@ fn test_jwt_for_create() {
 			pallet_funding::Error::<PolitestRuntime>::NotAllowed
 		);
 		let inst_jwt = get_test_jwt(PolitestAccountId::from(ISSUER), InvestorType::Institutional);
-		assert_ok!(PolitestFundingPallet::create_project(PolitestOrigin::signed(ISSUER.into()), inst_jwt, project.clone()));
+		assert_ok!(PolitestFundingPallet::create_project(
+			PolitestOrigin::signed(ISSUER.into()),
+			inst_jwt,
+			project.clone()
+		));
 	});
 }
 

--- a/integration-tests/src/tests/credentials.rs
+++ b/integration-tests/src/tests/credentials.rs
@@ -29,11 +29,11 @@ fn test_jwt_for_create() {
 		assert_ok!(PolitestBalances::force_set_balance(PolitestOrigin::root(), issuer.into(), 10_000 * PLMC));
 		let retail_jwt = get_test_jwt(PolitestAccountId::from(ISSUER), InvestorType::Retail);
 		assert_noop!(
-			PolitestFundingPallet::create(PolitestOrigin::signed(ISSUER.into()), retail_jwt, project.clone()),
+			PolitestFundingPallet::create_project(PolitestOrigin::signed(ISSUER.into()), retail_jwt, project.clone()),
 			pallet_funding::Error::<PolitestRuntime>::NotAllowed
 		);
 		let inst_jwt = get_test_jwt(PolitestAccountId::from(ISSUER), InvestorType::Institutional);
-		assert_ok!(PolitestFundingPallet::create(PolitestOrigin::signed(ISSUER.into()), inst_jwt, project.clone()));
+		assert_ok!(PolitestFundingPallet::create_project(PolitestOrigin::signed(ISSUER.into()), inst_jwt, project.clone()));
 	});
 }
 
@@ -46,7 +46,7 @@ fn test_jwt_verification() {
 		// This JWT tokens is signed with a private key that is not the one set in the Pallet Funding configuration in the real runtime.
 		let inst_jwt = get_fake_jwt(PolitestAccountId::from(ISSUER), InvestorType::Institutional);
 		assert_noop!(
-			PolitestFundingPallet::create(PolitestOrigin::signed(ISSUER.into()), inst_jwt, project.clone()),
+			PolitestFundingPallet::create_project(PolitestOrigin::signed(ISSUER.into()), inst_jwt, project.clone()),
 			DispatchError::BadOrigin
 		);
 	});

--- a/pallets/funding/src/benchmarking.rs
+++ b/pallets/funding/src/benchmarking.rs
@@ -549,7 +549,9 @@ mod benchmarks {
 		assert_eq!(stored_metadata, project_metadata);
 
 		// Events
-		frame_system::Pallet::<T>::assert_last_event(Event::<T>::MetadataEdited { project_id, metadata: project_metadata }.into());
+		frame_system::Pallet::<T>::assert_last_event(
+			Event::<T>::MetadataEdited { project_id, metadata: project_metadata }.into(),
+		);
 	}
 
 	#[benchmark]

--- a/pallets/funding/src/benchmarking.rs
+++ b/pallets/funding/src/benchmarking.rs
@@ -381,7 +381,7 @@ mod benchmarks {
 	// Extrinsics
 	//
 	#[benchmark]
-	fn create() {
+	fn create_project() {
 		// * setup *
 		let mut inst = BenchInstantiator::<T>::new(None);
 		// real benchmark starts at block 0, and we can't call `events()` at block 0
@@ -405,7 +405,7 @@ mod benchmarks {
 		let jwt = get_mock_jwt(issuer.clone(), InvestorType::Institutional, generate_did_from_account(issuer.clone()));
 
 		#[extrinsic_call]
-		create(RawOrigin::Signed(issuer.clone()), jwt, project_metadata.clone());
+		create_project(RawOrigin::Signed(issuer.clone()), jwt, project_metadata.clone());
 
 		// * validity checks *
 		// Storage
@@ -3459,9 +3459,9 @@ mod benchmarks {
 		use crate::mock::{new_test_ext, TestRuntime};
 
 		#[test]
-		fn bench_create() {
+		fn bench_create_project() {
 			new_test_ext().execute_with(|| {
-				assert_ok!(PalletFunding::<TestRuntime>::test_create());
+				assert_ok!(PalletFunding::<TestRuntime>::test_create_project());
 			});
 		}
 

--- a/pallets/funding/src/functions.rs
+++ b/pallets/funding/src/functions.rs
@@ -160,22 +160,19 @@ impl<T: Config> Pallet<T> {
 
 		// * Calculate new variables *
 		let initial_balance: BalanceOf<T> = 0u32.into();
-		let total_amount_bonded = Evaluations::<T>::iter_prefix((project_id,))
-			.fold(initial_balance, |total, (_evaluator, bond)| total.saturating_add(bond.original_plmc_bond));
+		let usd_total_amount_bonded =
+			Evaluations::<T>::iter_prefix((project_id,)).fold(initial_balance, |total, (_evaluator, bond)| {
+				total.saturating_add(bond.early_usd_amount.saturating_add(bond.late_usd_amount))
+			});
 
 		let evaluation_target_usd = <T as Config>::EvaluationSuccessThreshold::get() * fundraising_target_usd;
-		let evaluation_target_plmc = current_plmc_price
-			.reciprocal()
-			.ok_or(Error::<T>::BadMath)?
-			.checked_mul_int(evaluation_target_usd)
-			.ok_or(Error::<T>::BadMath)?;
 
 		let auction_initialize_period_start_block = now + 1u32.into();
 		let auction_initialize_period_end_block =
 			auction_initialize_period_start_block + T::AuctionInitializePeriodDuration::get();
 
 		// Check which logic path to follow
-		let is_funded = total_amount_bonded >= evaluation_target_plmc;
+		let is_funded = usd_total_amount_bonded >= evaluation_target_usd;
 
 		// * Branch in possible project paths *
 		// Successful path
@@ -862,7 +859,11 @@ impl<T: Config> Pallet<T> {
 	/// The issuer will call an extrinsic to start the evaluation round of the project.
 	/// [`do_start_evaluation`](Self::do_start_evaluation) will be executed.
 	#[transactional]
-	pub fn do_create_project(issuer: &AccountIdOf<T>, initial_metadata: ProjectMetadataOf<T>, did: Did) -> DispatchResult {
+	pub fn do_create_project(
+		issuer: &AccountIdOf<T>,
+		initial_metadata: ProjectMetadataOf<T>,
+		did: Did,
+	) -> DispatchResult {
 		// * Get variables *
 		let project_id = NextProjectId::<T>::get();
 		let maybe_active_project = DidWithActiveProjects::<T>::get(did.clone());

--- a/pallets/funding/src/functions.rs
+++ b/pallets/funding/src/functions.rs
@@ -159,12 +159,7 @@ impl<T: Config> Pallet<T> {
 		ensure!(now > evaluation_end_block, Error::<T>::EvaluationPeriodNotEnded);
 
 		// * Calculate new variables *
-		let initial_balance: BalanceOf<T> = 0u32.into();
-		let usd_total_amount_bonded =
-			Evaluations::<T>::iter_prefix((project_id,)).fold(initial_balance, |total, (_evaluator, bond)| {
-				total.saturating_add(bond.early_usd_amount.saturating_add(bond.late_usd_amount))
-			});
-
+		let usd_total_amount_bonded =  project_details.evaluation_round_info.total_bonded_usd;
 		let evaluation_target_usd = <T as Config>::EvaluationSuccessThreshold::get() * fundraising_target_usd;
 
 		let auction_initialize_period_start_block = now + 1u32.into();

--- a/pallets/funding/src/functions.rs
+++ b/pallets/funding/src/functions.rs
@@ -159,7 +159,7 @@ impl<T: Config> Pallet<T> {
 		ensure!(now > evaluation_end_block, Error::<T>::EvaluationPeriodNotEnded);
 
 		// * Calculate new variables *
-		let usd_total_amount_bonded =  project_details.evaluation_round_info.total_bonded_usd;
+		let usd_total_amount_bonded = project_details.evaluation_round_info.total_bonded_usd;
 		let evaluation_target_usd = <T as Config>::EvaluationSuccessThreshold::get() * fundraising_target_usd;
 
 		let auction_initialize_period_start_block = now + 1u32.into();

--- a/pallets/funding/src/functions.rs
+++ b/pallets/funding/src/functions.rs
@@ -862,7 +862,7 @@ impl<T: Config> Pallet<T> {
 	/// The issuer will call an extrinsic to start the evaluation round of the project.
 	/// [`do_start_evaluation`](Self::do_start_evaluation) will be executed.
 	#[transactional]
-	pub fn do_create(issuer: &AccountIdOf<T>, initial_metadata: ProjectMetadataOf<T>, did: Did) -> DispatchResult {
+	pub fn do_create_project(issuer: &AccountIdOf<T>, initial_metadata: ProjectMetadataOf<T>, did: Did) -> DispatchResult {
 		// * Get variables *
 		let project_id = NextProjectId::<T>::get();
 		let maybe_active_project = DidWithActiveProjects::<T>::get(did.clone());

--- a/pallets/funding/src/instantiator.rs
+++ b/pallets/funding/src/instantiator.rs
@@ -1027,8 +1027,12 @@ impl<
 		self.mint_plmc_to(vec![UserToPLMCBalance::new(issuer.clone(), Self::get_ed() * 2u64.into())]);
 
 		self.execute(|| {
-			crate::Pallet::<T>::do_create_project(&issuer, project_metadata.clone(), generate_did_from_account(issuer.clone()))
-				.unwrap();
+			crate::Pallet::<T>::do_create_project(
+				&issuer,
+				project_metadata.clone(),
+				generate_did_from_account(issuer.clone()),
+			)
+			.unwrap();
 			let last_project_metadata = ProjectsMetadata::<T>::iter().last().unwrap();
 			log::trace!("Last project metadata: {:?}", last_project_metadata);
 		});

--- a/pallets/funding/src/instantiator.rs
+++ b/pallets/funding/src/instantiator.rs
@@ -1027,7 +1027,7 @@ impl<
 		self.mint_plmc_to(vec![UserToPLMCBalance::new(issuer.clone(), Self::get_ed() * 2u64.into())]);
 
 		self.execute(|| {
-			crate::Pallet::<T>::do_create(&issuer, project_metadata.clone(), generate_did_from_account(issuer.clone()))
+			crate::Pallet::<T>::do_create_project(&issuer, project_metadata.clone(), generate_did_from_account(issuer.clone()))
 				.unwrap();
 			let last_project_metadata = ProjectsMetadata::<T>::iter().last().unwrap();
 			log::trace!("Last project metadata: {:?}", last_project_metadata);
@@ -1713,7 +1713,7 @@ pub mod async_features {
 			Instantiator::<T, AllPalletsWithoutSystem, RuntimeEvent>::get_ed() * 2u64.into(),
 		)]);
 		inst.execute(|| {
-			crate::Pallet::<T>::do_create(
+			crate::Pallet::<T>::do_create_project(
 				&issuer.clone(),
 				project_metadata.clone(),
 				generate_did_from_account(issuer.clone()),

--- a/pallets/funding/src/lib.rs
+++ b/pallets/funding/src/lib.rs
@@ -994,7 +994,11 @@ pub mod pallet {
 		/// Creates a project and assigns it to the `issuer` account.
 		#[pallet::call_index(0)]
 		#[pallet::weight(WeightInfoOf::<T>::create())]
-		pub fn create_project(origin: OriginFor<T>, jwt: UntrustedToken, project: ProjectMetadataOf<T>) -> DispatchResult {
+		pub fn create_project(
+			origin: OriginFor<T>,
+			jwt: UntrustedToken,
+			project: ProjectMetadataOf<T>,
+		) -> DispatchResult {
 			let (account, did, investor_type) =
 				T::InvestorOrigin::ensure_origin(origin, &jwt, T::VerifierPublicKey::get())?;
 			ensure!(investor_type == InvestorType::Institutional, Error::<T>::NotAllowed);

--- a/pallets/funding/src/lib.rs
+++ b/pallets/funding/src/lib.rs
@@ -43,7 +43,7 @@
 //!
 //! | Step                      | Description                                                                                                                                                                                                                                                                                                                                                                                                 | Resulting Project State                                             |
 //! |---------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|
-//! | Creation                  | Issuer creates a project with the [`create()`](Pallet::create) extrinsic.                                                                                                                                                                                                                                                                                                                                   | [`Application`](ProjectStatus::Application)                         |
+//! | Creation                  | Issuer creates a project with the [`create()`](Pallet::create_project) extrinsic.                                                                                                                                                                                                                                                                                                                                   | [`Application`](ProjectStatus::Application)                         |
 //! | Evaluation Start          | Issuer starts the evaluation round with the [`start_evaluation()`](Pallet::start_evaluation) extrinsic.                                                                                                                                                                                                                                                                                                     | [`EvaluationRound`](ProjectStatus::EvaluationRound)                 |
 //! | Evaluation Submissions    | Evaluators assess the project information, and if they think it is good enough to get funding, they bond Polimec's native token PLMC with [`bond_evaluation()`](Pallet::evaluate)                                                                                                                                                                                                                    | [`EvaluationRound`](ProjectStatus::EvaluationRound)                 |
 //! | Evaluation End            | Evaluation round ends automatically after the [`Config::EvaluationDuration`] has passed. This is achieved by the [`on_initialize()`](Pallet::on_initialize) function.                                                                                                                                                                                                                                       | [`AuctionInitializePeriod`](ProjectStatus::AuctionInitializePeriod) |
@@ -62,7 +62,7 @@
 //! ## Interface
 //! All users who wish to participate need to have a valid credential, given to them on the KILT parachain, by a KYC/AML provider.
 //! ### Extrinsics
-//! * [`create`](Pallet::create) : Creates a new project.
+//! * [`create`](Pallet::create_project) : Creates a new project.
 //! * [`edit_metadata`](Pallet::edit_metadata) : Submit a new Hash of the project metadata.
 //! * [`start_evaluation`](Pallet::start_evaluation) : Start the Evaluation round of a project.
 //! * [`start_auction`](Pallet::start_auction) : Start the English Auction round of a project.
@@ -994,11 +994,11 @@ pub mod pallet {
 		/// Creates a project and assigns it to the `issuer` account.
 		#[pallet::call_index(0)]
 		#[pallet::weight(WeightInfoOf::<T>::create())]
-		pub fn create(origin: OriginFor<T>, jwt: UntrustedToken, project: ProjectMetadataOf<T>) -> DispatchResult {
+		pub fn create_project(origin: OriginFor<T>, jwt: UntrustedToken, project: ProjectMetadataOf<T>) -> DispatchResult {
 			let (account, did, investor_type) =
 				T::InvestorOrigin::ensure_origin(origin, &jwt, T::VerifierPublicKey::get())?;
 			ensure!(investor_type == InvestorType::Institutional, Error::<T>::NotAllowed);
-			Self::do_create(&account, project, did)
+			Self::do_create_project(&account, project, did)
 		}
 
 		#[pallet::call_index(35)]

--- a/pallets/funding/src/mock.rs
+++ b/pallets/funding/src/mock.rs
@@ -37,6 +37,7 @@ use sp_runtime::{
 	BuildStorage,
 };
 use sp_std::collections::btree_map::BTreeMap;
+use std::cell::RefCell;
 use system::EnsureSigned;
 
 type Block = frame_system::mocking::MockBlock<TestRuntime>;
@@ -45,6 +46,7 @@ pub type AccountId = u32;
 pub type Balance = u128;
 pub type BlockNumber = u64;
 pub type Identifier = u32;
+pub type Price = FixedU128;
 
 pub const PLMC: u128 = 10_000_000_000_u128;
 pub const MILLI_PLMC: Balance = 10u128.pow(7);
@@ -65,6 +67,7 @@ pub const fn free_deposit() -> Balance {
 	0 * MICRO_PLMC
 }
 
+use crate::traits::ProvideAssetPrice;
 use frame_support::traits::{Everything, OriginTrait};
 use frame_system::RawOrigin as SystemRawOrigin;
 use polkadot_parachain_primitives::primitives::Sibling;
@@ -303,14 +306,7 @@ parameter_types! {
 	pub const RemainderFundingDuration: BlockNumber = (1 * HOURS) as BlockNumber;
 	pub const ManualAcceptanceDuration: BlockNumber = (3 * HOURS) as BlockNumber;
 	pub const SuccessToSettlementTime: BlockNumber =(4 * HOURS) as BlockNumber;
-
 	pub const FundingPalletId: PalletId = PalletId(*b"py/cfund");
-	pub PriceMap: BTreeMap<AssetId, FixedU128> = BTreeMap::from_iter(vec![
-		(0u32, FixedU128::from_float(69f64)), // DOT
-		(1337u32, FixedU128::from_float(0.97f64)), // USDC
-		(1984u32, FixedU128::from_float(1.0f64)), // USDT
-		(2069u32, FixedU128::from_float(8.4f64)), // PLMC
-	]);
 	pub FeeBrackets: Vec<(Percent, Balance)> = vec![
 		(Percent::from_percent(10), 1_000_000 * US_DOLLAR),
 		(Percent::from_percent(8), 5_000_000 * US_DOLLAR),
@@ -375,7 +371,31 @@ impl ConvertBack<AccountId, [u8; 32]> for DummyConverter {
 		u32::from_le_bytes(account)
 	}
 }
+thread_local! {
+	pub static PRICE_MAP: RefCell<BTreeMap<AssetId, FixedU128>> = RefCell::new(BTreeMap::from_iter(vec![
+		(0u32, FixedU128::from_float(69f64)), // DOT
+		(1337u32, FixedU128::from_float(0.97f64)), // USDC
+		(1984u32, FixedU128::from_float(1.0f64)), // USDT
+		(2069u32, FixedU128::from_float(8.4f64)), // PLMC
+	]));
+}
+pub struct ConstPriceProvider;
+impl ProvideAssetPrice for ConstPriceProvider {
+	type AssetId = AssetId;
+	type Price = Price;
 
+	fn get_price(asset_id: AssetId) -> Option<Price> {
+		PRICE_MAP.with(|price_map| price_map.borrow().get(&asset_id).cloned())
+	}
+}
+
+impl ConstPriceProvider {
+	pub fn set_price(asset_id: AssetId, price: Price) {
+		PRICE_MAP.with(|price_map| {
+			price_map.borrow_mut().insert(asset_id, price);
+		});
+	}
+}
 impl Config for TestRuntime {
 	type AccountId32Conversion = DummyConverter;
 	type AllPalletsWithoutSystem =
@@ -412,7 +432,7 @@ impl Config for TestRuntime {
 	type PolimecReceiverInfo = PolimecReceiverInfo;
 	type PreImageLimit = ConstU32<1024>;
 	type Price = FixedU128;
-	type PriceProvider = ConstPriceProvider<AssetId, FixedU128, PriceMap>;
+	type PriceProvider = ConstPriceProvider;
 	type ProtocolGrowthTreasury = ProtocolGrowthTreasuryAccount;
 	type Randomness = RandomnessCollectiveFlip;
 	type RemainderFundingDuration = RemainderFundingDuration;

--- a/pallets/funding/src/tests.rs
+++ b/pallets/funding/src/tests.rs
@@ -363,7 +363,7 @@ mod creation {
 		let project_metadata = default_project_metadata(inst.get_new_nonce(), ISSUER_1);
 		inst.mint_plmc_to(default_plmc_balances());
 		let jwt = get_mock_jwt(ISSUER_1, InvestorType::Institutional, generate_did_from_account(ISSUER_1));
-		assert_ok!(inst.execute(|| crate::Pallet::<TestRuntime>::create(
+		assert_ok!(inst.execute(|| crate::Pallet::<TestRuntime>::create_project(
 			RuntimeOrigin::signed(ISSUER_1),
 			jwt,
 			project_metadata
@@ -586,7 +586,7 @@ mod creation {
 		let mut inst = MockInstantiator::new(Some(RefCell::new(new_test_ext())));
 		inst.mint_plmc_to(default_plmc_balances());
 		let project_err = inst.execute(|| {
-			Pallet::<TestRuntime>::do_create(&ISSUER_1, wrong_project, generate_did_from_account(ISSUER_1)).unwrap_err()
+			Pallet::<TestRuntime>::do_create_project(&ISSUER_1, wrong_project, generate_did_from_account(ISSUER_1)).unwrap_err()
 		});
 		assert_eq!(project_err, Error::<TestRuntime>::PriceTooLow.into());
 	}
@@ -667,7 +667,7 @@ mod creation {
 
 		for project in wrong_projects {
 			let project_err = inst.execute(|| {
-				Pallet::<TestRuntime>::do_create(
+				Pallet::<TestRuntime>::do_create_project(
 					&ISSUER_1,
 					with_different_metadata(project),
 					generate_did_from_account(ISSUER_1),
@@ -686,7 +686,7 @@ mod creation {
 
 		inst.mint_plmc_to(vec![UserToPLMCBalance::new(ISSUER_1, ed)]);
 		let project_err = inst.execute(|| {
-			Pallet::<TestRuntime>::do_create(&ISSUER_1, project_metadata, generate_did_from_account(ISSUER_1))
+			Pallet::<TestRuntime>::do_create_project(&ISSUER_1, project_metadata, generate_did_from_account(ISSUER_1))
 				.unwrap_err()
 		});
 		assert_eq!(project_err, Error::<TestRuntime>::NotEnoughFundsForEscrowCreation.into());
@@ -752,7 +752,7 @@ mod creation {
 			let issuer_mint = (issuer, 1000 * PLMC).into();
 			inst.mint_plmc_to(vec![issuer_mint]);
 			assert_ok!(inst.execute(|| {
-				Pallet::<TestRuntime>::do_create(&issuer, project_metadata_new, generate_did_from_account(issuer))
+				Pallet::<TestRuntime>::do_create_project(&issuer, project_metadata_new, generate_did_from_account(issuer))
 			}));
 		}
 
@@ -782,7 +782,7 @@ mod creation {
 			let issuer_mint = (issuer, 1000 * PLMC).into();
 			inst.mint_plmc_to(vec![issuer_mint]);
 			let project_err = inst.execute(|| {
-				Pallet::<TestRuntime>::do_create(
+				Pallet::<TestRuntime>::do_create_project(
 					&issuer,
 					with_different_metadata(project),
 					generate_did_from_account(issuer),
@@ -817,7 +817,7 @@ mod creation {
 
 		// Cannot create 2 projects consecutively
 		inst.execute(|| {
-			assert_ok!(Pallet::<TestRuntime>::create(
+			assert_ok!(Pallet::<TestRuntime>::create_project(
 				RuntimeOrigin::signed(ISSUER_1),
 				jwt.clone(),
 				with_different_hash(project_metadata.clone())
@@ -825,7 +825,7 @@ mod creation {
 		});
 		inst.execute(|| {
 			assert_noop!(
-				Pallet::<TestRuntime>::create(
+				Pallet::<TestRuntime>::create_project(
 					RuntimeOrigin::signed(ISSUER_1),
 					jwt.clone(),
 					with_different_hash(project_metadata.clone())
@@ -838,7 +838,7 @@ mod creation {
 		inst.start_evaluation(0, ISSUER_1).unwrap();
 		inst.execute(|| {
 			assert_noop!(
-				Pallet::<TestRuntime>::create(
+				Pallet::<TestRuntime>::create_project(
 					RuntimeOrigin::signed(ISSUER_1),
 					jwt.clone(),
 					with_different_hash(project_metadata.clone())
@@ -849,7 +849,7 @@ mod creation {
 		inst.advance_time(<TestRuntime as Config>::EvaluationDuration::get() + 1).unwrap();
 		assert_eq!(inst.get_project_details(0).status, ProjectStatus::EvaluationFailed);
 		inst.execute(|| {
-			assert_ok!(Pallet::<TestRuntime>::create(
+			assert_ok!(Pallet::<TestRuntime>::create_project(
 				RuntimeOrigin::signed(ISSUER_1),
 				jwt.clone(),
 				with_different_hash(project_metadata.clone())
@@ -862,7 +862,7 @@ mod creation {
 		inst.start_auction(1, ISSUER_1).unwrap();
 		inst.execute(|| {
 			assert_noop!(
-				Pallet::<TestRuntime>::create(
+				Pallet::<TestRuntime>::create_project(
 					RuntimeOrigin::signed(ISSUER_1),
 					jwt.clone(),
 					with_different_hash(project_metadata.clone())
@@ -874,7 +874,7 @@ mod creation {
 		inst.advance_time(1).unwrap();
 		assert_eq!(inst.get_project_details(1).status, ProjectStatus::FundingFailed);
 		inst.execute(|| {
-			assert_ok!(Pallet::<TestRuntime>::create(
+			assert_ok!(Pallet::<TestRuntime>::create_project(
 				RuntimeOrigin::signed(ISSUER_1),
 				jwt.clone(),
 				with_different_hash(project_metadata.clone())
@@ -889,7 +889,7 @@ mod creation {
 		inst.start_community_funding(2).unwrap();
 		inst.execute(|| {
 			assert_noop!(
-				Pallet::<TestRuntime>::create(
+				Pallet::<TestRuntime>::create_project(
 					RuntimeOrigin::signed(ISSUER_1),
 					jwt.clone(),
 					with_different_hash(project_metadata.clone())
@@ -900,7 +900,7 @@ mod creation {
 		inst.finish_funding(2).unwrap();
 		assert_eq!(inst.get_project_details(2).status, ProjectStatus::FundingFailed);
 		inst.execute(|| {
-			assert_ok!(Pallet::<TestRuntime>::create(
+			assert_ok!(Pallet::<TestRuntime>::create_project(
 				RuntimeOrigin::signed(ISSUER_1),
 				jwt.clone(),
 				with_different_hash(project_metadata.clone())
@@ -918,7 +918,7 @@ mod creation {
 		inst.contribute_for_users(3, default_remainder_buys()).unwrap();
 		inst.finish_funding(3).unwrap();
 		assert_eq!(inst.get_project_details(3).status, ProjectStatus::FundingSuccessful);
-		assert_ok!(inst.execute(|| crate::Pallet::<TestRuntime>::create(
+		assert_ok!(inst.execute(|| crate::Pallet::<TestRuntime>::create_project(
 			RuntimeOrigin::signed(ISSUER_1),
 			jwt.clone(),
 			with_different_hash(project_metadata.clone())

--- a/pallets/funding/src/tests.rs
+++ b/pallets/funding/src/tests.rs
@@ -1115,9 +1115,7 @@ mod evaluation {
 		let target_funding = project_metadata.minimum_price.saturating_mul_int(project_metadata.total_allocation_size);
 		let target_evaluation_usd = Percent::from_percent(10) * target_funding;
 
-		let evaluations = vec![
-			(EVALUATOR_1, target_evaluation_usd).into(),
-		];
+		let evaluations = vec![(EVALUATOR_1, target_evaluation_usd).into()];
 		let evaluation_plmc = MockInstantiator::calculate_evaluation_plmc_spent(evaluations.clone());
 		let evaluation_existential = evaluation_plmc.accounts().existential_deposits();
 		inst.mint_plmc_to(evaluation_plmc);
@@ -1127,14 +1125,12 @@ mod evaluation {
 		inst.evaluate_for_users(project_id, evaluations.clone()).unwrap();
 
 		let old_price = <TestRuntime as Config>::PriceProvider::get_price(PLMC_FOREIGN_ID).unwrap();
-		PRICE_MAP.with_borrow_mut(|map | map.insert(PLMC_FOREIGN_ID, old_price / 2.into()));
+		PRICE_MAP.with_borrow_mut(|map| map.insert(PLMC_FOREIGN_ID, old_price / 2.into()));
 
 		inst.start_auction(project_id, ISSUER_1).unwrap();
 
 		// Increasing the price before the end doesn't make a project under the threshold succeed.
-		let evaluations = vec![
-			(EVALUATOR_1, target_evaluation_usd/2).into(),
-		];
+		let evaluations = vec![(EVALUATOR_1, target_evaluation_usd / 2).into()];
 		let evaluation_plmc = MockInstantiator::calculate_evaluation_plmc_spent(evaluations.clone());
 		let evaluation_existential = evaluation_plmc.accounts().existential_deposits();
 		inst.mint_plmc_to(evaluation_plmc);
@@ -1144,15 +1140,13 @@ mod evaluation {
 		inst.evaluate_for_users(project_id, evaluations.clone()).unwrap();
 
 		let old_price = <TestRuntime as Config>::PriceProvider::get_price(PLMC_FOREIGN_ID).unwrap();
-		PRICE_MAP.with_borrow_mut(|map | map.insert(PLMC_FOREIGN_ID, old_price * 2.into()));
+		PRICE_MAP.with_borrow_mut(|map| map.insert(PLMC_FOREIGN_ID, old_price * 2.into()));
 
 		let update_block = inst.get_update_block(project_id, &UpdateType::EvaluationEnd).unwrap();
 		let now = inst.current_block();
 		inst.advance_time(update_block - now + 1).unwrap();
 		let project_status = inst.get_project_details(project_id).status;
 		assert_eq!(project_status, ProjectStatus::EvaluationFailed);
-
-
 	}
 }
 

--- a/pallets/funding/src/types.rs
+++ b/pallets/funding/src/types.rs
@@ -139,18 +139,6 @@ pub mod config_types {
 		Deserialize,
 	)]
 
-	pub struct ConstPriceProvider<AssetId, Price, Mapping>(PhantomData<(AssetId, Price, Mapping)>);
-	impl<AssetId: Ord, Price: FixedPointNumber + Clone, Mapping: Get<BTreeMap<AssetId, Price>>> ProvideAssetPrice
-		for ConstPriceProvider<AssetId, Price, Mapping>
-	{
-		type AssetId = AssetId;
-		type Price = Price;
-
-		fn get_price(asset_id: AssetId) -> Option<Price> {
-			Mapping::get().get(&asset_id).cloned()
-		}
-	}
-
 	pub struct DaysToBlocks;
 	impl Convert<FixedU128, u64> for DaysToBlocks {
 		fn convert(a: FixedU128) -> u64 {


### PR DESCRIPTION
## What?
use the usd amount bonded at the time of evaluating for calculating if a project reached the threshold for passing to the funding round

## Why?
Using the plmc price at the time of ending the evaluation opens us up for an exploit on the exchanges

## How?
use the field in `ProjectDetails` `evaluation_round_info.total_bonded_usd`

## Testing?
pallet test `plmc_price_change_doesnt_affect_evaluation_end`

## Anything else?
Changed the const price provider to use a `thread_local!` key for the price map so we can change the price.
