### PR TITLE
fix live node storage

### DIFF
--- a/pallets/oracle-ocw/src/lib.rs
+++ b/pallets/oracle-ocw/src/lib.rs
@@ -151,6 +151,10 @@ pub mod pallet {
 							(AssetName::PLMC, Zero::zero()),
 						]),
 					};
+					// Fix for missing PLMC in last_send_for_assets for old nodes, that did not have PLMC in the list.
+					if !last_send_for_assets.contains_key(&AssetName::PLMC) {
+						last_send_for_assets.insert(AssetName::PLMC, Zero::zero());
+					};
 					let assets = last_send_for_assets
 						.iter()
 						.filter_map(|(asset_name, last_send)| {


### PR DESCRIPTION
## What?
Fix for live oracle storage. Current storage should only have three assets in store while new nodes generate a 4 asset storage. So we have to insert the missing asset (PLMC) into the live storage if it isn't inserted yet. 

## Why?

## How?

## Testing?

## Screenshots (optional)

## Anything Else?
