### PR TITLE
Politest Upgrade 0.6.3

### DIFF
--- a/justfile
+++ b/justfile
@@ -29,6 +29,14 @@ dry-run-benchmarks:
         --pallet="*" \
         --extrinsic=* \
         --wasm-execution=compiled \
+        --heap-pages=4096 && \
+    cargo run --features runtime-benchmarks --release -p polimec-node benchmark pallet \
+        --chain=polimec-local \
+        --steps=2 \
+        --repeat=1 \
+        --pallet="*" \
+        --extrinsic=* \
+        --wasm-execution=compiled \
         --heap-pages=4096
 
 # src: https://github.com/polkadot-fellows/runtimes/blob/48ccfae6141d2924f579d81e8b1877efd208693f/system-parachains/asset-hubs/asset-hub-polkadot/src/weights/cumulus_pallet_xcmp_queue.rs
@@ -71,6 +79,6 @@ docker-build tag="latest" package="polimec-node":
 create-chainspec-base:
     ./scripts/create_base_chain_spec.sh ./runtimes/base/target/srtool/release/wbuild/polimec-runtime/polimec_runtime.compact.compressed.wasm 2105
 
-# Use zombienet to spawn rococo + polimec testnet
+# Use zombienet to spawn rococo + polimec testnet``
 zombienet path_to_file="scripts/zombienet/native/base-rococo-local.toml":
     zombienet spawn {{ path_to_file }}

--- a/justfile
+++ b/justfile
@@ -79,6 +79,6 @@ docker-build tag="latest" package="polimec-node":
 create-chainspec-base:
     ./scripts/create_base_chain_spec.sh ./runtimes/base/target/srtool/release/wbuild/polimec-runtime/polimec_runtime.compact.compressed.wasm 2105
 
-# Use zombienet to spawn rococo + polimec testnet``
+# Use zombienet to spawn rococo + polimec testnet
 zombienet path_to_file="scripts/zombienet/native/base-rococo-local.toml":
     zombienet spawn {{ path_to_file }}

--- a/pallets/funding/src/lib.rs
+++ b/pallets/funding/src/lib.rs
@@ -117,7 +117,7 @@ pub use crate::weights::WeightInfo;
 use frame_support::{
 	traits::{
 		tokens::{fungible, fungibles, Balance},
-		AccountTouch, ContainsPair, Randomness,
+		AccountTouch, ContainsPair, Randomness, StorageVersion,
 	},
 	BoundedVec, PalletId,
 };
@@ -150,6 +150,7 @@ pub mod tests;
 pub mod benchmarking;
 #[cfg(any(feature = "runtime-benchmarks", feature = "std"))]
 pub mod instantiator;
+pub mod migration;
 pub mod traits;
 
 pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
@@ -209,6 +210,7 @@ pub mod pallet {
 	}
 
 	#[pallet::pallet]
+	#[pallet::storage_version(migration::STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]

--- a/pallets/funding/src/migration.rs
+++ b/pallets/funding/src/migration.rs
@@ -1,0 +1,209 @@
+//! A module that is responsible for migration of storage.
+
+use crate::{
+	types::{HRMPChannelStatus, MigrationReadinessCheck, PhaseTransitionPoints, ProjectStatus},
+	AccountIdOf, BalanceOf, BlockNumberFor, Config, Did, EvaluationRoundInfoOf, Pallet, PriceOf, ProjectId,
+};
+use frame_support::{
+	pallet_prelude::*,
+	traits::{tokens::Balance as BalanceT, OnRuntimeUpgrade, StorageVersion},
+	weights::Weight,
+};
+use parity_scale_codec::{Decode, Encode};
+use polkadot_parachain_primitives::primitives::Id as ParaId;
+use sp_arithmetic::FixedPointNumber;
+use sp_std::marker::PhantomData;
+
+/// The current storage version
+pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+pub const LOG: &str = "runtime::funding::migration";
+
+mod v0 {
+	use super::*;
+	pub use cleaner::*;
+	mod cleaner {
+		use super::*;
+		#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+		pub struct Success;
+		#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+		pub struct Failure;
+		#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+		pub enum CleanerState<T> {
+			Initialized(PhantomData<T>),
+			// Success or Failure
+			EvaluationRewardOrSlash(u64, PhantomData<T>),
+			EvaluationUnbonding(u64, PhantomData<T>),
+			// Branch
+			// A. Success only
+			BidCTMint(u64, PhantomData<T>),
+			ContributionCTMint(u64, PhantomData<T>),
+			StartBidderVestingSchedule(u64, PhantomData<T>),
+			StartContributorVestingSchedule(u64, PhantomData<T>),
+			BidFundingPayout(u64, PhantomData<T>),
+			ContributionFundingPayout(u64, PhantomData<T>),
+			// B. Failure only
+			BidFundingRelease(u64, PhantomData<T>),
+			BidUnbonding(u64, PhantomData<T>),
+			ContributionFundingRelease(u64, PhantomData<T>),
+			ContributionUnbonding(u64, PhantomData<T>),
+			// Merge
+			// Success or Failure
+			Finished(PhantomData<T>),
+		}
+		#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+		pub enum Cleaner {
+			NotReady,
+			Success(CleanerState<Success>),
+			Failure(CleanerState<Failure>),
+		}
+		impl TryFrom<ProjectStatus> for Cleaner {
+			type Error = ();
+
+			fn try_from(value: ProjectStatus) -> Result<Self, ()> {
+				match value {
+					ProjectStatus::FundingSuccessful => Ok(Cleaner::Success(CleanerState::Initialized(PhantomData))),
+					ProjectStatus::FundingFailed | ProjectStatus::EvaluationFailed =>
+						Ok(Cleaner::Failure(CleanerState::Initialized(PhantomData))),
+					_ => Err(()),
+				}
+			}
+		}
+	}
+
+	#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+	pub struct ProjectDetails<
+		AccountId,
+		Did,
+		BlockNumber,
+		Price: FixedPointNumber,
+		Balance: BalanceT,
+		EvaluationRoundInfo,
+	> {
+		pub issuer_account: AccountId,
+		pub issuer_did: Did,
+		/// Whether the project is frozen, so no `metadata` changes are allowed.
+		pub is_frozen: bool,
+		/// The price in USD per token decided after the Auction Round
+		pub weighted_average_price: Option<Price>,
+		/// The current status of the project
+		pub status: ProjectStatus,
+		/// When the different project phases start and end
+		pub phase_transition_points: PhaseTransitionPoints<BlockNumber>,
+		/// Fundraising target amount in USD equivalent
+		pub fundraising_target: Balance,
+		/// The amount of Contribution Tokens that have not yet been sold
+		pub remaining_contribution_tokens: Balance,
+		/// Funding reached amount in USD equivalent
+		pub funding_amount_reached: Balance,
+		/// Cleanup operations remaining
+		pub cleanup: Cleaner,
+		/// Information about the total amount bonded, and the outcome in regards to reward/slash/nothing
+		pub evaluation_round_info: EvaluationRoundInfo,
+		/// When the Funding Round ends
+		pub funding_end_block: Option<BlockNumber>,
+		/// ParaId of project
+		pub parachain_id: Option<ParaId>,
+		/// Migration readiness check
+		pub migration_readiness_check: Option<MigrationReadinessCheck>,
+		/// HRMP Channel status
+		pub hrmp_channel_status: HRMPChannelStatus,
+	}
+	pub type ProjectDetailsOf<T> =
+		ProjectDetails<AccountIdOf<T>, Did, BlockNumberFor<T>, PriceOf<T>, BalanceOf<T>, EvaluationRoundInfoOf<T>>;
+
+	#[frame_support::storage_alias]
+	pub(crate) type ProjectsDetails<T: Config> =
+		StorageMap<Pallet<T>, Blake2_128Concat, ProjectId, ProjectDetailsOf<T>>;
+}
+
+pub mod v1 {
+	use super::*;
+	#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+	pub struct ProjectDetails<
+		AccountId,
+		Did,
+		BlockNumber,
+		Price: FixedPointNumber,
+		Balance: BalanceT,
+		EvaluationRoundInfo,
+	> {
+		pub issuer_account: AccountId,
+		pub issuer_did: Did,
+		/// Whether the project is frozen, so no `metadata` changes are allowed.
+		pub is_frozen: bool,
+		/// The price in USD per token decided after the Auction Round
+		pub weighted_average_price: Option<Price>,
+		/// The current status of the project
+		pub status: ProjectStatus,
+		/// When the different project phases start and end
+		pub phase_transition_points: PhaseTransitionPoints<BlockNumber>,
+		/// Fundraising target amount in USD equivalent
+		pub fundraising_target: Balance,
+		/// The amount of Contribution Tokens that have not yet been sold
+		pub remaining_contribution_tokens: Balance,
+		/// Funding reached amount in USD equivalent
+		pub funding_amount_reached: Balance,
+		/// Information about the total amount bonded, and the outcome in regards to reward/slash/nothing
+		pub evaluation_round_info: EvaluationRoundInfo,
+		/// When the Funding Round ends
+		pub funding_end_block: Option<BlockNumber>,
+		/// ParaId of project
+		pub parachain_id: Option<ParaId>,
+		/// Migration readiness check
+		pub migration_readiness_check: Option<MigrationReadinessCheck>,
+		/// HRMP Channel status
+		pub hrmp_channel_status: HRMPChannelStatus,
+	}
+	pub type ProjectDetailsOf<T> =
+		ProjectDetails<AccountIdOf<T>, Did, BlockNumberFor<T>, PriceOf<T>, BalanceOf<T>, EvaluationRoundInfoOf<T>>;
+
+	#[frame_support::storage_alias]
+	pub(crate) type ProjectsDetails<T: Config> =
+		StorageMap<Pallet<T>, Blake2_128Concat, ProjectId, ProjectDetailsOf<T>>;
+
+	/// Migrates `ProjectDetails` from v0 to v1.
+	pub struct UncheckedMigrationToV1<T>(sp_std::marker::PhantomData<T>);
+
+	impl<T: Config> OnRuntimeUpgrade for UncheckedMigrationToV1<T> {
+		#[allow(deprecated)]
+		fn on_runtime_upgrade() -> Weight {
+			// cleaner field does not exist anymore so we ignore it
+			let mut storage_translations = 0u64;
+			let mut translate = |pre: v0::ProjectDetailsOf<T>| -> Option<v1::ProjectDetailsOf<T>> {
+				storage_translations += 1;
+				Some(v1::ProjectDetailsOf::<T> {
+					issuer_account: pre.issuer_account,
+					issuer_did: pre.issuer_did,
+					is_frozen: pre.is_frozen,
+					weighted_average_price: pre.weighted_average_price,
+					status: pre.status,
+					phase_transition_points: pre.phase_transition_points,
+					fundraising_target: pre.fundraising_target,
+					remaining_contribution_tokens: pre.remaining_contribution_tokens,
+					funding_amount_reached: pre.funding_amount_reached,
+					evaluation_round_info: pre.evaluation_round_info,
+					funding_end_block: pre.funding_end_block,
+					parachain_id: pre.parachain_id,
+					migration_readiness_check: pre.migration_readiness_check,
+					hrmp_channel_status: pre.hrmp_channel_status,
+				})
+			};
+
+			v1::ProjectsDetails::<T>::translate(|_key, pre: v0::ProjectDetailsOf<T>| translate(pre));
+
+			T::DbWeight::get().reads_writes(storage_translations, storage_translations)
+		}
+	}
+
+	/// [`UncheckedMigrationToV1`] wrapped in a
+	/// [`VersionedMigration`](frame_support::migrations::VersionedMigration), ensuring the
+	/// migration is only performed when on-chain version is 0.
+	#[allow(dead_code)]
+	pub type MigrationToV1<T> = frame_support::migrations::VersionedMigration<
+		0,
+		1,
+		UncheckedMigrationToV1<T>,
+		Pallet<T>,
+		<T as frame_system::Config>::DbWeight,
+	>;
+}

--- a/pallets/oracle-ocw/src/types.rs
+++ b/pallets/oracle-ocw/src/types.rs
@@ -323,7 +323,6 @@ impl FetchPrice for MexcFetcher {
 		let maybe_response =
 			serde_json_core::from_str::<HVec<(u64, &str, &str, &str, &str, &str, u64, &str), 10>>(body);
 		if let Err(e) = maybe_response {
-			dbg!(e);
 			log::error!(target: LOG_TARGET, "Error parsing response for BitFinex: {:?}", e);
 			return None;
 		}

--- a/runtimes/politest/src/lib.rs
+++ b/runtimes/politest/src/lib.rs
@@ -163,7 +163,7 @@ pub type Migrations = migrations::Unreleased;
 pub mod migrations {
 	// use crate::Runtime;
 	/// Unreleased migrations. Add new ones here:
-	pub type Unreleased = ();
+	pub type Unreleased = pallet_funding::migration::v1::MigrationToV1<crate::Runtime>;
 }
 
 /// Executive: handles dispatch to the various modules.
@@ -209,7 +209,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("politest"),
 	impl_name: create_runtime_str!("politest"),
 	authoring_version: 1,
-	spec_version: 0_006_000,
+	spec_version: 0_006_003,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
## What?
Include storage migration for politest

## Why?
Politest had projects created already

## How?
New `migration` file on pallet-assets that will hold all future migrations

## Testing?
Did the runtime upgrade already with this code and it worked ok

