### PR TITLE
chore: add missing pallets in define_benchmarks!

### DIFF
--- a/runtimes/polimec/src/lib.rs
+++ b/runtimes/polimec/src/lib.rs
@@ -957,10 +957,13 @@ mod benches {
 		[pallet_utility, Utility]
 		[pallet_multisig, Multisig]
 		[pallet_proxy, Proxy]
+		[cumulus_pallet_parachain_system, ParachainSystem]
+		[pallet_identity, Identity]
 
 		// Monetary stuff.
 		[pallet_balances, Balances]
 		[pallet_vesting, Vesting]
+		[pallet_assets, ForeignAssets]
 
 		// Collator support.
 		[pallet_session, SessionBench::<Runtime>]
@@ -969,6 +972,8 @@ mod benches {
 		// XCM helpers.
 		[cumulus_pallet_xcmp_queue, XcmpQueue]
 		[pallet_xcm, PalletXcmExtrinsiscsBenchmark::<Runtime>]
+		[cumulus_pallet_dmp_queue, DmpQueue]
+		[pallet_message_queue, MessageQueue]
 
 		// Governance
 		[pallet_treasury, Treasury]
@@ -981,7 +986,7 @@ mod benches {
 
 		// Oracle
 		[pallet_membership, OracleProvidersMembership]
-		//[orml_oracle, Oracle]
+		// [orml_oracle, Oracle]
 	);
 }
 

--- a/runtimes/politest/src/lib.rs
+++ b/runtimes/politest/src/lib.rs
@@ -1146,10 +1146,15 @@ mod benches {
 		[pallet_utility, Utility]
 		[pallet_multisig, Multisig]
 		[pallet_proxy, Proxy]
+		[cumulus_pallet_parachain_system, ParachainSystem]
+		[pallet_identity, Identity]
+		[pallet_sudo, Sudo]
 
 		// Monetary stuff.
 		[pallet_balances, Balances]
 		[pallet_vesting, Vesting]
+		[pallet_assets, ForeignAssets]
+		[pallet_assets, ContributionTokens]
 		[pallet_dispenser, Dispenser]
 
 		// Collator support.
@@ -1159,6 +1164,8 @@ mod benches {
 		// XCM helpers.
 		[cumulus_pallet_xcmp_queue, XcmpQueue]
 		[pallet_xcm, PalletXcmExtrinsiscsBenchmark::<Runtime>]
+		[cumulus_pallet_dmp_queue, DmpQueue]
+		[pallet_message_queue, MessageQueue]
 
 		// Governance
 		[pallet_treasury, Treasury]
@@ -1171,7 +1178,8 @@ mod benches {
 
 		// Oracle
 		[pallet_membership, OracleProvidersMembership]
-		//[orml_oracle, Oracle]
+		// [orml_oracle, Oracle]
+
 		// Funding
 		[pallet_funding, Funding]
 		[pallet_linear_release, LinearRelease]


### PR DESCRIPTION
## What?

Few pallets were missing in the `define_benchmarks!` macro.