### PR TITLE
Reduce fast-mode times to 10min

### DIFF
--- a/runtimes/shared-configuration/src/funding.rs
+++ b/runtimes/shared-configuration/src/funding.rs
@@ -20,6 +20,7 @@ use pallet_funding::types::AcceptedFundingAsset;
 use parachains_common::AssetIdForTrustBackedAssets;
 use sp_arithmetic::{FixedU128, Percent};
 use sp_std::{collections::btree_map::BTreeMap, vec, vec::Vec};
+use crate::governance::MINUTES;
 
 #[cfg(feature = "fast-mode")]
 use parachains_common::HOURS;
@@ -27,63 +28,63 @@ use parachains_common::HOURS;
 #[cfg(feature = "instant-mode")]
 pub const EVALUATION_DURATION: BlockNumber = 3;
 #[cfg(feature = "fast-mode")]
-pub const EVALUATION_DURATION: BlockNumber = 2 * HOURS;
+pub const EVALUATION_DURATION: BlockNumber = 10 * MINUTES;
 #[cfg(not(any(feature = "fast-mode", feature = "instant-mode")))]
 pub const EVALUATION_DURATION: BlockNumber = 28 * crate::DAYS;
 
 #[cfg(feature = "instant-mode")]
 pub const AUCTION_INITIALIZE_PERIOD_DURATION: BlockNumber = 3;
 #[cfg(feature = "fast-mode")]
-pub const AUCTION_INITIALIZE_PERIOD_DURATION: BlockNumber = 1 * HOURS;
+pub const AUCTION_INITIALIZE_PERIOD_DURATION: BlockNumber = 10 * MINUTES;
 #[cfg(not(any(feature = "fast-mode", feature = "instant-mode")))]
 pub const AUCTION_INITIALIZE_PERIOD_DURATION: BlockNumber = 7 * crate::DAYS;
 
 #[cfg(feature = "instant-mode")]
 pub const AUCTION_OPENING_DURATION: BlockNumber = 2;
 #[cfg(feature = "fast-mode")]
-pub const AUCTION_OPENING_DURATION: BlockNumber = 1 * HOURS;
+pub const AUCTION_OPENING_DURATION: BlockNumber = 10 * MINUTES;
 #[cfg(not(any(feature = "fast-mode", feature = "instant-mode")))]
 pub const AUCTION_OPENING_DURATION: BlockNumber = 2 * crate::DAYS;
 
 #[cfg(feature = "instant-mode")]
 pub const AUCTION_CLOSING_DURATION: BlockNumber = 2;
 #[cfg(feature = "fast-mode")]
-pub const AUCTION_CLOSING_DURATION: BlockNumber = 2 * HOURS;
+pub const AUCTION_CLOSING_DURATION: BlockNumber = 10 * MINUTES;
 #[cfg(not(any(feature = "fast-mode", feature = "instant-mode")))]
 pub const AUCTION_CLOSING_DURATION: BlockNumber = 3 * crate::DAYS;
 
 #[cfg(feature = "instant-mode")]
 pub const COMMUNITY_FUNDING_DURATION: BlockNumber = 3;
 #[cfg(feature = "fast-mode")]
-pub const COMMUNITY_FUNDING_DURATION: BlockNumber = 1 * HOURS;
+pub const COMMUNITY_FUNDING_DURATION: BlockNumber = 10 * MINUTES;
 #[cfg(not(any(feature = "fast-mode", feature = "instant-mode")))]
 pub const COMMUNITY_FUNDING_DURATION: BlockNumber = 5 * crate::DAYS;
 
 #[cfg(feature = "instant-mode")]
 pub const REMAINDER_FUNDING_DURATION: BlockNumber = 3;
 #[cfg(feature = "fast-mode")]
-pub const REMAINDER_FUNDING_DURATION: BlockNumber = 1 * HOURS;
+pub const REMAINDER_FUNDING_DURATION: BlockNumber = 10 * MINUTES;
 #[cfg(not(any(feature = "fast-mode", feature = "instant-mode")))]
 pub const REMAINDER_FUNDING_DURATION: BlockNumber = crate::DAYS;
 
 #[cfg(feature = "instant-mode")]
 pub const CONTRIBUTION_VESTING_DURATION: BlockNumber = 5;
 #[cfg(feature = "fast-mode")]
-pub const CONTRIBUTION_VESTING_DURATION: BlockNumber = 3 * crate::DAYS;
+pub const CONTRIBUTION_VESTING_DURATION: BlockNumber = 10 * crate::MINUTES;
 #[cfg(not(any(feature = "fast-mode", feature = "instant-mode")))]
 pub const CONTRIBUTION_VESTING_DURATION: BlockNumber = 365 * crate::DAYS;
 
 #[cfg(feature = "instant-mode")]
 pub const MANUAL_ACCEPTANCE_DURATION: BlockNumber = 3;
 #[cfg(feature = "fast-mode")]
-pub const MANUAL_ACCEPTANCE_DURATION: BlockNumber = 1 * HOURS;
+pub const MANUAL_ACCEPTANCE_DURATION: BlockNumber = 10 * MINUTES;
 #[cfg(not(any(feature = "fast-mode", feature = "instant-mode")))]
 pub const MANUAL_ACCEPTANCE_DURATION: BlockNumber = 3 * crate::DAYS;
 
 #[cfg(feature = "instant-mode")]
 pub const SUCCESS_TO_SETTLEMENT_TIME: BlockNumber = 4;
 #[cfg(feature = "fast-mode")]
-pub const SUCCESS_TO_SETTLEMENT_TIME: BlockNumber = 1 * HOURS;
+pub const SUCCESS_TO_SETTLEMENT_TIME: BlockNumber = 10 * MINUTES;
 #[cfg(not(any(feature = "fast-mode", feature = "instant-mode")))]
 pub const SUCCESS_TO_SETTLEMENT_TIME: BlockNumber = 4 * crate::DAYS;
 


### PR DESCRIPTION
## What?
- Reduce all fast-mode funding timings to 10 minutes

## Why?
Testing round transitions manually on Politest takes forever currently
