### PR TITLE
🐛 Fix benchmarks

### DIFF
--- a/justfile
+++ b/justfile
@@ -22,7 +22,8 @@ test-integration:
     cargo test -p integration-tests
 
 dry-run-benchmarks pallet="*" extrinsic="*":
-    cargo run --features runtime-benchmarks --release -p polimec-node benchmark pallet \
+    cargo build --features runtime-benchmarks --release && \
+    ./target/release/polimec-node  benchmark pallet \
         --chain=politest-local \
         --steps=2 \
         --repeat=1 \
@@ -30,7 +31,7 @@ dry-run-benchmarks pallet="*" extrinsic="*":
         --extrinsic={{ extrinsic }} \
         --wasm-execution=compiled \
         --heap-pages=4096 && \
-    cargo run --features runtime-benchmarks --release -p polimec-node benchmark pallet \
+    ./target/release/polimec-node benchmark pallet \
         --chain=polimec-local \
         --steps=2 \
         --repeat=1 \

--- a/justfile
+++ b/justfile
@@ -21,13 +21,13 @@ test-runtime-features runtime="polimec-runtime":
 test-integration:
     cargo test -p integration-tests
 
-dry-run-benchmarks pallet="*":
+dry-run-benchmarks pallet="*" extrinsic="*":
     cargo run --features runtime-benchmarks --release -p polimec-node benchmark pallet \
         --chain=politest-local \
         --steps=2 \
         --repeat=1 \
         --pallet={{ pallet }} \
-        --extrinsic=* \
+        --extrinsic={{ extrinsic }} \
         --wasm-execution=compiled \
         --heap-pages=4096 && \
     cargo run --features runtime-benchmarks --release -p polimec-node benchmark pallet \
@@ -35,7 +35,7 @@ dry-run-benchmarks pallet="*":
         --steps=2 \
         --repeat=1 \
         --pallet={{ pallet }} \
-        --extrinsic=* \
+        --extrinsic={{ extrinsic }} \
         --wasm-execution=compiled \
         --heap-pages=4096
 

--- a/nodes/parachain/src/chain_spec/politest.rs
+++ b/nodes/parachain/src/chain_spec/politest.rs
@@ -19,6 +19,7 @@
 //! Polimec Testnet chain specification
 
 use cumulus_primitives_core::ParaId;
+use frame_benchmarking::__private::traits::fungible::Inspect;
 use politest_runtime::{
 	pallet_parachain_staking::{
 		inflation::{perbill_annual_to_perbill_round, BLOCKS_PER_YEAR},
@@ -201,8 +202,9 @@ fn testnet_genesis(
 	let accounts = endowed_accounts.iter().map(|(account, _)| account.clone()).collect::<Vec<_>>();
 
 	let funding_accounts = vec![
-		(<Runtime as pallet_funding::Config>::PalletId::get().into_account_truncating(), EXISTENTIAL_DEPOSIT),
-		(politest_runtime::TreasuryAccount::get(), EXISTENTIAL_DEPOSIT),
+		(<Runtime as pallet_funding::Config>::PalletId::get().into_account_truncating(), <Runtime as pallet_funding::Config>::NativeCurrency::minimum_balance()),
+		(<Runtime as pallet_funding::Config>::ProtocolGrowthTreasury::get(), <Runtime as pallet_funding::Config>::NativeCurrency::minimum_balance()),
+		(<Runtime as pallet_funding::Config>::ContributionTreasury::get(), <Runtime as pallet_funding::Config>::NativeCurrency::minimum_balance()),
 	];
 	endowed_accounts.append(&mut funding_accounts.clone());
 

--- a/pallets/funding/src/benchmarking.rs
+++ b/pallets/funding/src/benchmarking.rs
@@ -1636,6 +1636,10 @@ mod benchmarks {
 		let evaluation_to_settle =
 			inst.execute(|| Evaluations::<T>::iter_prefix_values((project_id, evaluator.clone())).next().unwrap());
 
+		let treasury_account = T::ProtocolGrowthTreasury::get();
+		let free_treasury_plmc = inst.get_free_plmc_balances_for(vec![treasury_account])[0].plmc_amount;
+		assert_eq!(free_treasury_plmc, BenchInstantiator::<T>::get_ed());
+
 		#[extrinsic_call]
 		settle_failed_evaluation(
 			RawOrigin::Signed(evaluator.clone()),

--- a/pallets/linear-release/src/benchmarking.rs
+++ b/pallets/linear-release/src/benchmarking.rs
@@ -207,11 +207,11 @@ mod benches {
 	#[benchmark]
 	fn vested_transfer(l: Linear<0, 9>, s: Linear<1, { T::MAX_VESTING_SCHEDULES - 1 }>) -> Result<(), BenchmarkError> {
 		let caller: T::AccountId = whitelisted_caller();
-		T::Currency::set_balance(&caller, T::Currency::minimum_balance().saturating_mul(1024u32.into()));
+		T::Currency::set_balance(&caller, T::Currency::minimum_balance() + T::MinVestedTransfer::get());
 
 		let target: T::AccountId = account("target", 0, SEED);
 		// Give target existing locks
-		T::Currency::set_balance(&target, T::Currency::minimum_balance().saturating_mul(1024u32.into()));
+		T::Currency::set_balance(&target, T::Currency::minimum_balance() + (256 * l).into());
 		add_holds::<T>(&target, l);
 
 		// Add one vesting schedules.

--- a/runtimes/politest/src/lib.rs
+++ b/runtimes/politest/src/lib.rs
@@ -528,6 +528,7 @@ impl tokens::imbalance::OnUnbalanced<CreditOf<Runtime>> for ToTreasury {
 
 parameter_types! {
 	pub TreasuryAccount: AccountId = Treasury::account_id();
+	pub ContributionTreasuryAccount: AccountId = hex_literal::hex!["ba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42"].into();
 }
 
 impl pallet_treasury::Config for Runtime {
@@ -998,7 +999,7 @@ impl pallet_funding::Config for Runtime {
 	type BlockNumberToBalance = ConvertInto;
 	type CommunityFundingDuration = CommunityFundingDuration;
 	type ContributionTokenCurrency = ContributionTokens;
-	type ContributionTreasury = TreasuryAccount;
+	type ContributionTreasury = ContributionTreasuryAccount;
 	type DaysToBlocks = DaysToBlocks;
 	type EvaluationDuration = EvaluationDuration;
 	type EvaluationSuccessThreshold = EarlyEvaluationThreshold;


### PR DESCRIPTION
## What?
- fix all benchmarks that errored out when running `just dry-run-benchmarks`

## How?
- Pallet funding required funding the ct treasury account with ed on the chain spec
- Linear release required using config types in the benchmark code instead of hardcoded values

## Testing?
- Run `just dry-run-benchmarks` and see if no errors pops up