### PR TITLE
chore: use production in Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,12 @@ FROM docker.io/paritytech/ci-linux:production as builder
 ARG PACKAGE
 WORKDIR /polimec
 COPY . /polimec
-RUN cargo build --locked --release -p $PACKAGE 
+RUN cargo build --locked --profile production -p $PACKAGE 
 
 # This is the 2nd stage: a very small image where we copy the Polkadot binary."
 FROM debian:bookworm-slim
 ARG PACKAGE
-COPY --from=builder /polimec/target/release/$PACKAGE /usr/local/bin/polimec
-COPY --from=builder /polimec/chain-specs/polimec-raw-chain-spec.json /data
+COPY --from=builder /polimec/target/production/$PACKAGE /usr/local/bin/polimec
 
 # 30333 for parachain p2p
 # 30334 for relaychain p2p


### PR DESCRIPTION
## What?

+ Use the `production` binary in the Docker Image.
+ The chainspec is not needed anymore since it's part of the node now.