### PR TITLE
🏗️ Release migrations

### DIFF
--- a/runtimes/polimec/src/lib.rs
+++ b/runtimes/polimec/src/lib.rs
@@ -146,8 +146,7 @@ pub mod migrations {
 	use crate::Runtime;
 	/// Unreleased migrations. Add new ones here:
 	pub type Unreleased = (
-		cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,
-		pallet_identity::migration::versioned::V0ToV1<Runtime, 1000>,
+		
 	);
 }
 

--- a/runtimes/polimec/src/lib.rs
+++ b/runtimes/polimec/src/lib.rs
@@ -143,10 +143,12 @@ pub type Migrations = migrations::Unreleased;
 /// The runtime migrations per release.
 #[allow(missing_docs)]
 pub mod migrations {
-	use crate::Runtime;
+	use crate::custom_migrations::init_pallet::InitializePallet;
+	use crate::DmpQueue;
 	/// Unreleased migrations. Add new ones here:
+	#[allow(unused_parens)]
 	pub type Unreleased = (
-		
+		InitializePallet<DmpQueue>
 	);
 }
 
@@ -193,7 +195,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("polimec-mainnet"),
 	impl_name: create_runtime_str!("polimec-mainnet"),
 	authoring_version: 1,
-	spec_version: 0_006_000,
+	spec_version: 0_006_001,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
## What?

- Set the `DmpQueue` version to latest (2).
- Remove migrations already released. 
- Bump the `spec-version`, so we can use the `try-runtime-cli` to test the new runtimes.

## Why?

- The `try-runtime-cli` was not working properly in the last upgrade, so we missed this. https://github.com/Polimec/polimec-node/pull/240

## Testing

```
[2024-04-19T14:33:35Z INFO  remote-ext] replacing wss:// in uri with https://: "https://rpc.polimec.org:443" (ws is currently unstable for fetching remote storage, for more see https://github.com/paritytech/jsonrpsee/issues/1086)
[2024-04-19T14:33:36Z INFO  remote-ext] since no at is provided, setting it to latest finalized head, 0x332a6845b06275a10e53d99d3bc0e9e25f041cea283f2d613af3ca94c46c4e97
[2024-04-19T14:33:36Z INFO  remote-ext] since no prefix is filtered, the data for all pallets will be downloaded
[2024-04-19T14:33:36Z INFO  remote-ext] scraping key-pairs from remote at block height 0x332a6845b06275a10e53d99d3bc0e9e25f041cea283f2d613af3ca94c46c4e97
✅ Found 6986 keys (0.24s)
[00:00:00] ✅ Downloaded key values 9,611.6312/s [=====================================================================================================] 6986/6986 (0s)
✅ Inserted keys into DB (0.01s)
[2024-04-19T14:33:37Z INFO  remote-ext] adding data for hashed prefix: , took 1.13s
[2024-04-19T14:33:37Z INFO  remote-ext] adding data for hashed key: 3a636f6465
[2024-04-19T14:33:37Z INFO  remote-ext] adding data for hashed key: 26aa394eea5630e07c48ae0c9558cef7f9cce9c888469bb1a0dceaa129672ef8
[2024-04-19T14:33:37Z INFO  remote-ext] adding data for hashed key: 26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac
[2024-04-19T14:33:37Z INFO  remote-ext] 👩‍👦 no child roots found to scrape
[2024-04-19T14:33:37Z INFO  remote-ext] initialized state externalities with storage root 0x86883dad7cde00321e404d462da78f9130b3bfedca824588046302110d8975a5 and state_version V1
[2024-04-19T14:33:37Z INFO  try-runtime::cli] Original runtime [Name: RuntimeString::Owned("polimec-mainnet")] [Version: 6000] [Code hash: 0x31e2...058d]
[2024-04-19T14:33:37Z INFO  try-runtime::cli] New runtime      [Name: RuntimeString::Owned("polimec-mainnet")] [Version: 6001] [Code hash: 0xd8da...5ec8]
[2024-04-19T14:33:37Z INFO  try-runtime::cli] 🚀 Speed up your workflow by using snapshots instead of live state. See `try-runtime create-snapshot --help`.
[2024-04-19T14:33:37Z INFO  try_runtime_core::misc] ------------------------------------------------------------------


[2024-04-19T14:33:37Z INFO  try_runtime_core::misc] 🔬 Running TryRuntime_on_runtime_upgrade with checks: PreAndPost


[2024-04-19T14:33:37Z INFO  try_runtime_core::misc] ------------------------------------------------------------------


[2024-04-19T14:33:37Z INFO  polimec_runtime::custom_migrations::init_pallet] DmpQueue migrating from StorageVersion(
        0,
    )
[2024-04-19T14:33:37Z INFO  polimec_runtime::custom_migrations::init_pallet] DmpQueue migrated to StorageVersion(
        2,
    )
[2024-04-19T14:33:37Z INFO  runtime::executive] ✅ Entire runtime state decodes without error. 408348 bytes total.
[2024-04-19T14:33:37Z INFO  try_runtime_core::misc] ------------------------------------------------------------------------------------------------------


[2024-04-19T14:33:37Z INFO  try_runtime_core::misc] 🔬 TryRuntime_on_runtime_upgrade succeeded! Running it again without checks for weight measurements.


[2024-04-19T14:33:37Z INFO  try_runtime_core::misc] ------------------------------------------------------------------------------------------------------


[2024-04-19T14:33:37Z INFO  try_runtime_core::misc] ---------------------------------------------------------------------------------


[2024-04-19T14:33:37Z INFO  try_runtime_core::misc] 🔬 Running TryRuntime_on_runtime_upgrade again to check idempotency: PreAndPost


[2024-04-19T14:33:37Z INFO  try_runtime_core::misc] ---------------------------------------------------------------------------------


[2024-04-19T14:33:37Z INFO  polimec_runtime::custom_migrations::init_pallet] DmpQueue migrating from StorageVersion(
        2,
    )
[2024-04-19T14:33:37Z INFO  polimec_runtime::custom_migrations::init_pallet] DmpQueue migrated to StorageVersion(
        2,
    )
[2024-04-19T14:33:37Z INFO  runtime::executive] ✅ Entire runtime state decodes without error. 408348 bytes total.
[2024-04-19T14:33:37Z INFO  try-runtime::cli] PoV size (zstd-compressed compact proof): 5.4 KB. For parachains, it's your responsibility to verify that a PoV of this size fits within any relaychain constraints.
[2024-04-19T14:33:37Z INFO  try-runtime::cli] Consumed ref_time: 0.000925s (0.19% of max 0.5s)
[2024-04-19T14:33:37Z INFO  try-runtime::cli] ✅ No weight safety issues detected. Please note this does not guarantee a successful runtime upgrade. Always test your runtime upgrade with recent state, and ensure that the weight usage of your migrations will not drastically differ between testing and actual on-chain execution.
```