### PR TITLE
 🔖  Release Politest v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8484,7 +8484,6 @@ dependencies = [
  "cumulus-pallet-session-benchmarking",
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
- "cumulus-primitives-aura",
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
  "frame-benchmarking",

--- a/runtimes/politest/src/lib.rs
+++ b/runtimes/politest/src/lib.rs
@@ -215,7 +215,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("politest"),
 	impl_name: create_runtime_str!("politest"),
 	authoring_version: 1,
-	spec_version: 0_006_005,
+	spec_version: 0_007_000,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
Check title.

For some reason cargo lock was updated too

try-runtime cli:
![CleanShot 2024-04-22 at 16 18 32](https://github.com/Polimec/polimec-node/assets/54085674/34553188-701b-41de-9432-3ce9a83b065c)

srtool output:
```
✨ Your Substrate WASM Runtime is ready! ✨
✨ WASM  : runtimes/politest/target/srtool/production/wbuild/politest-runtime/politest_runtime.compact.wasm
✨ Z_WASM: runtimes/politest/target/srtool/production/wbuild/politest-runtime/politest_runtime.compact.compressed.wasm
Summary generated with srtool v0.15.0 using the docker image paritytech/srtool:1.77.0:
 Package     : politest-runtime v0.6.0
 GIT commit  : 66910d4190014f8b4ac600fde9b046d160727e59
 GIT tag     : v0.6.0
 GIT branch  : 04-22-bump_politest_runtime_to_v0.7
 Rustc       : rustc 1.77.0 (aedd173a2 2024-03-17)
 Time        : 2024-04-22T14:36:14Z

== Compact
 Version          : politest-7000 (politest-0.tx2.au1)
 Metadata         : V14
 Size             : 5.07 MB (5312623 bytes)
 setCode          : 0xb0182ac83d6580871b4148a231d1411fb0c1f1e0d1d20fc2ccdbbf2dd152f4e2
 authorizeUpgrade : 0x35459dabe36660215b8744f1db19fe53529a21c517869ba2963dbd699658a244
 IPFS             : QmSZGHMz7dXxGdSHnELMfytHc5KEEPsL4TuCnMJnZN2RQB
 BLAKE2_256       : 0x8a32abaa8bd7d96b2dc8743348134b6580778c6d91bb4d1855d355c51d8529da
 Wasm             : runtimes/politest/target/srtool/production/wbuild/politest-runtime/politest_runtime.compact.wasm

== Compressed
 Version          : politest-7000 (politest-0.tx2.au1)
 Metadata         : V14
 Size             : 1.26 MB (1323737 bytes)
 Compression      : 75.09%
 setCode          : 0x18f5d6e16ec79dc887bf0b7f080471f47d132bc19342ced3e30598e2f2068b12
 authorizeUpgrade : 0xd5c022dcb5cc9aa0f51f56236513f8de0ef6b795f63643928b1ad906a2d47728
 IPFS             : QmfREdFhWHTGfh1LpNLED1L3QpVbj98qMG99ouPTUbAMTV
 BLAKE2_256       : 0xaae21d69957ac61a582ee7573d5e41d5741da62620b08d754f7bc1789026f5f8
 Wasm             : runtimes/politest/target/srtool/production/wbuild/politest-runtime/politest_runtime.compact.compressed.wasm

```
