### PR TITLE
Politest v0.7.1: reduce evaluation+auction durations by 50%

### DIFF
--- a/runtimes/politest/src/lib.rs
+++ b/runtimes/politest/src/lib.rs
@@ -215,7 +215,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("politest"),
 	impl_name: create_runtime_str!("politest"),
 	authoring_version: 1,
-	spec_version: 0_007_000,
+	spec_version: 0_007_001,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtimes/shared-configuration/src/funding.rs
+++ b/runtimes/shared-configuration/src/funding.rs
@@ -27,28 +27,28 @@ use parachains_common::MINUTES;
 #[cfg(feature = "instant-mode")]
 pub const EVALUATION_DURATION: BlockNumber = 3;
 #[cfg(feature = "fast-mode")]
-pub const EVALUATION_DURATION: BlockNumber = 10 * MINUTES;
+pub const EVALUATION_DURATION: BlockNumber = 5 * MINUTES;
 #[cfg(not(any(feature = "fast-mode", feature = "instant-mode")))]
 pub const EVALUATION_DURATION: BlockNumber = 28 * crate::DAYS;
 
 #[cfg(feature = "instant-mode")]
 pub const AUCTION_INITIALIZE_PERIOD_DURATION: BlockNumber = 3;
 #[cfg(feature = "fast-mode")]
-pub const AUCTION_INITIALIZE_PERIOD_DURATION: BlockNumber = 10 * MINUTES;
+pub const AUCTION_INITIALIZE_PERIOD_DURATION: BlockNumber = 5 * MINUTES;
 #[cfg(not(any(feature = "fast-mode", feature = "instant-mode")))]
 pub const AUCTION_INITIALIZE_PERIOD_DURATION: BlockNumber = 7 * crate::DAYS;
 
 #[cfg(feature = "instant-mode")]
 pub const AUCTION_OPENING_DURATION: BlockNumber = 2;
 #[cfg(feature = "fast-mode")]
-pub const AUCTION_OPENING_DURATION: BlockNumber = 10 * MINUTES;
+pub const AUCTION_OPENING_DURATION: BlockNumber = 5 * MINUTES;
 #[cfg(not(any(feature = "fast-mode", feature = "instant-mode")))]
 pub const AUCTION_OPENING_DURATION: BlockNumber = 2 * crate::DAYS;
 
 #[cfg(feature = "instant-mode")]
 pub const AUCTION_CLOSING_DURATION: BlockNumber = 2;
 #[cfg(feature = "fast-mode")]
-pub const AUCTION_CLOSING_DURATION: BlockNumber = 10 * MINUTES;
+pub const AUCTION_CLOSING_DURATION: BlockNumber = 5 * MINUTES;
 #[cfg(not(any(feature = "fast-mode", feature = "instant-mode")))]
 pub const AUCTION_CLOSING_DURATION: BlockNumber = 3 * crate::DAYS;
 


### PR DESCRIPTION
This also includes evaluation fix.

```sh
polimec-node on  04-23-politest_v0.7.1_reduce_evaluation_auction_durations_by_50_ via 🦀 v1.76.0-nightly took 1m27s 
❯ try-runtime --runtime ./target/release/wbuild/politest-runtime/politest_runtime.compact.compressed.wasm on-runtime-upgrade live --uri wss://beta.rolimec.org:443
[2024-04-23T11:28:04Z INFO  remote-ext] replacing wss:// in uri with https://: "https://beta.rolimec.org:443" (ws is currently unstable for fetching remote storage, for more see https://github.com/paritytech/jsonrpsee/issues/1086)
[2024-04-23T11:28:04Z INFO  remote-ext] since no at is provided, setting it to latest finalized head, 0x6dfb43932d7944c22efe00a72274baa803a14e6e36b774b76872b3a99d2a7fcf
[2024-04-23T11:28:04Z INFO  remote-ext] since no prefix is filtered, the data for all pallets will be downloaded
[2024-04-23T11:28:04Z INFO  remote-ext] scraping key-pairs from remote at block height 0x6dfb43932d7944c22efe00a72274baa803a14e6e36b774b76872b3a99d2a7fcf
✅ Found 4834 keys (0.21s)
[00:00:00] ✅ Downloaded key values 6,096.7743/s [==============================================================] 4834/4834 (0s)
✅ Inserted keys into DB (0.02s)
[2024-04-23T11:28:05Z INFO  remote-ext] adding data for hashed prefix: , took 1.13s
[2024-04-23T11:28:05Z INFO  remote-ext] adding data for hashed key: 3a636f6465
[2024-04-23T11:28:05Z INFO  remote-ext] adding data for hashed key: 26aa394eea5630e07c48ae0c9558cef7f9cce9c888469bb1a0dceaa129672ef8
[2024-04-23T11:28:05Z INFO  remote-ext] adding data for hashed key: 26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac
[2024-04-23T11:28:05Z INFO  remote-ext] 👩‍👦 no child roots found to scrape
[2024-04-23T11:28:05Z INFO  remote-ext] initialized state externalities with storage root 0xa4fee1c502478ad1856ff015e51f06b39bdc65dc6f13404fa2894d3e108c9f40 and state_version V1
[2024-04-23T11:28:05Z INFO  try-runtime::cli] Original runtime [Name: RuntimeString::Owned("politest")] [Version: 7000] [Code hash: 0xaae2...f5f8]
[2024-04-23T11:28:06Z INFO  try-runtime::cli] New runtime      [Name: RuntimeString::Owned("politest")] [Version: 7001] [Code hash: 0xea00...6297]
[2024-04-23T11:28:06Z INFO  try-runtime::cli] 🚀 Speed up your workflow by using snapshots instead of live state. See `try-runtime create-snapshot --help`.
[2024-04-23T11:28:06Z INFO  try_runtime_core::commands::on_runtime_upgrade] -------------------------------------------------------------------
    
    
[2024-04-23T11:28:06Z INFO  try_runtime_core::commands::on_runtime_upgrade] 🔬 Running TryRuntime_on_runtime_upgrade with checks: PreAndPost
    
    
[2024-04-23T11:28:06Z INFO  try_runtime_core::commands::on_runtime_upgrade] -------------------------------------------------------------------
[2024-04-23T11:28:06Z INFO  runtime::executive] ✅ Entire runtime state decodes without error. 202628 bytes total.
[2024-04-23T11:28:06Z INFO  try_runtime_core::commands::on_runtime_upgrade] -------------------------------------------------------------------
    
    
[2024-04-23T11:28:06Z INFO  try_runtime_core::commands::on_runtime_upgrade] 🔬 TryRuntime_on_runtime_upgrade succeeded! Running it again without checks for weight measurements.
    
    
[2024-04-23T11:28:06Z INFO  try_runtime_core::commands::on_runtime_upgrade] -------------------------------------------------------------------
[2024-04-23T11:28:06Z INFO  try_runtime_core::commands::on_runtime_upgrade] -------------------------------------------------------------------
    
    
[2024-04-23T11:28:06Z INFO  try_runtime_core::commands::on_runtime_upgrade] 🔬 Running TryRuntime_on_runtime_upgrade again to check idempotency: PreAndPost
    
    
[2024-04-23T11:28:06Z INFO  try_runtime_core::commands::on_runtime_upgrade] -------------------------------------------------------------------
[2024-04-23T11:28:06Z INFO  runtime::executive] ✅ Entire runtime state decodes without error. 202628 bytes total.
[2024-04-23T11:28:06Z INFO  try-runtime::cli] PoV size (zstd-compressed compact proof): 3.4 KB. For parachains, it's your responsibility to verify that a PoV of this size fits within any relaychain constraints.
[2024-04-23T11:28:06Z INFO  try-runtime::cli] Consumed ref_time: 0.00095s (0.19% of max 0.5s)
[2024-04-23T11:28:06Z INFO  try-runtime::cli] ✅ No weight safety issues detected. Please note this does not guarantee a successful runtime upgrade. Always test your runtime upgrade with recent state, and ensure that the weight usage of your migrations will not drastically differ between testing and actual on-chain execution.

```