### PR TITLE
✅ test evaluation bond cannot be used on another project participation

### DIFF
--- a/pallets/funding/src/tests/4_community.rs
+++ b/pallets/funding/src/tests/4_community.rs
@@ -1250,5 +1250,66 @@ mod community_contribute_extrinsic {
 				Error::<TestRuntime>::ParticipationFailed(ParticipationError::FundingAssetNotAccepted)
 			);
 		}
+
+		#[test]
+		fn cannot_use_evaluation_bond_on_another_project_contribution() {
+			let mut inst = MockInstantiator::new(Some(RefCell::new(new_test_ext())));
+			let project_metadata_1 = default_project_metadata(ISSUER_1);
+			let project_metadata_2 = default_project_metadata(ISSUER_2);
+
+
+			let mut evaluations_1 = default_evaluations();
+			let evaluations_2 = default_evaluations();
+
+			let evaluator_contributor = 69;
+			let evaluation_amount = 420 * US_DOLLAR;
+			let evaluator_contribution = ContributionParams::new(evaluator_contributor, 600 * ASSET_UNIT, 1u8, AcceptedFundingAsset::USDT);
+			evaluations_1.push((evaluator_contributor, evaluation_amount).into());
+
+			let project_id_1 = inst.create_community_contributing_project(project_metadata_1.clone(), ISSUER_1, evaluations_1, default_bids());
+			let project_id_2 = inst.create_community_contributing_project(project_metadata_2.clone(), ISSUER_2, evaluations_2, default_bids());
+
+			let wap = inst.get_project_details(project_id_2).weighted_average_price.unwrap();
+
+			// Necessary Mints
+			let already_bonded_plmc =
+				MockInstantiator::calculate_evaluation_plmc_spent(vec![(evaluator_contributor, evaluation_amount).into()])
+					[0]
+					.plmc_amount;
+			let usable_evaluation_plmc =
+				already_bonded_plmc - <TestRuntime as Config>::EvaluatorSlash::get() * already_bonded_plmc;
+			let necessary_plmc_for_contribution = MockInstantiator::calculate_contributed_plmc_spent(
+				vec![evaluator_contribution.clone()],
+				wap,
+			)[0]
+				.plmc_amount;
+			let necessary_usdt_for_contribution = MockInstantiator::calculate_contributed_funding_asset_spent(
+				vec![evaluator_contribution.clone()],
+				wap,
+			);
+			inst.mint_plmc_to(vec![UserToPLMCBalance::new(
+				evaluator_contributor,
+				necessary_plmc_for_contribution - usable_evaluation_plmc,
+			)]);
+			inst.mint_foreign_asset_to(necessary_usdt_for_contribution);
+
+			inst.execute(|| {
+				assert_noop!(
+					PolimecFunding::community_contribute(
+						RuntimeOrigin::signed(evaluator_contributor),
+						get_mock_jwt(
+							evaluator_contributor,
+							InvestorType::Retail,
+							generate_did_from_account(evaluator_contributor)
+						),
+						project_id_2,
+						evaluator_contribution.amount,
+						evaluator_contribution.multiplier,
+						evaluator_contribution.asset
+					),
+					Error::<TestRuntime>::ParticipationFailed(ParticipationError::NotEnoughFunds)
+				);
+			});
+		}
 	}
 }

--- a/pallets/funding/src/tests/5_remainder.rs
+++ b/pallets/funding/src/tests/5_remainder.rs
@@ -910,5 +910,66 @@ mod remaining_contribute_extrinsic {
 				));
 			});
 		}
+
+		#[test]
+		fn cannot_use_evaluation_bond_on_another_project_contribution() {
+			let mut inst = MockInstantiator::new(Some(RefCell::new(new_test_ext())));
+			let project_metadata_1 = default_project_metadata(ISSUER_1);
+			let project_metadata_2 = default_project_metadata(ISSUER_2);
+
+
+			let mut evaluations_1 = default_evaluations();
+			let evaluations_2 = default_evaluations();
+
+			let evaluator_contributor = 69;
+			let evaluation_amount = 420 * US_DOLLAR;
+			let evaluator_contribution = ContributionParams::new(evaluator_contributor, 600 * ASSET_UNIT, 1u8, AcceptedFundingAsset::USDT);
+			evaluations_1.push((evaluator_contributor, evaluation_amount).into());
+
+			let project_id_1 = inst.create_remainder_contributing_project(project_metadata_1.clone(), ISSUER_1, evaluations_1, default_bids(), vec![]);
+			let project_id_2 = inst.create_remainder_contributing_project(project_metadata_2.clone(), ISSUER_2, evaluations_2, default_bids(), vec![]);
+
+			let wap = inst.get_project_details(project_id_2).weighted_average_price.unwrap();
+
+			// Necessary Mints
+			let already_bonded_plmc =
+				MockInstantiator::calculate_evaluation_plmc_spent(vec![(evaluator_contributor, evaluation_amount).into()])
+					[0]
+					.plmc_amount;
+			let usable_evaluation_plmc =
+				already_bonded_plmc - <TestRuntime as Config>::EvaluatorSlash::get() * already_bonded_plmc;
+			let necessary_plmc_for_contribution = MockInstantiator::calculate_contributed_plmc_spent(
+				vec![evaluator_contribution.clone()],
+				wap,
+			)[0]
+				.plmc_amount;
+			let necessary_usdt_for_contribution = MockInstantiator::calculate_contributed_funding_asset_spent(
+				vec![evaluator_contribution.clone()],
+				wap,
+			);
+			inst.mint_plmc_to(vec![UserToPLMCBalance::new(
+				evaluator_contributor,
+				necessary_plmc_for_contribution - usable_evaluation_plmc,
+			)]);
+			inst.mint_foreign_asset_to(necessary_usdt_for_contribution);
+
+			inst.execute(|| {
+				assert_noop!(
+					PolimecFunding::remaining_contribute(
+						RuntimeOrigin::signed(evaluator_contributor),
+						get_mock_jwt(
+							evaluator_contributor,
+							InvestorType::Retail,
+							generate_did_from_account(evaluator_contributor)
+						),
+						project_id_2,
+						evaluator_contribution.amount,
+						evaluator_contribution.multiplier,
+						evaluator_contribution.asset
+					),
+					Error::<TestRuntime>::ParticipationFailed(ParticipationError::NotEnoughFunds)
+				);
+			});
+		}
 	}
 }


### PR DESCRIPTION
## What?
- Add test that we cannot use evaluation bond of project x for project y

## How?
- One test in each bids,community, and remainder modules

