### PR TITLE
feat: enable http requests

### DIFF
--- a/nodes/parachain/src/service.rs
+++ b/nodes/parachain/src/service.rs
@@ -212,7 +212,7 @@ async fn start_node_impl(
 				transaction_pool: Some(OffchainTransactionPoolFactory::new(transaction_pool.clone())),
 				network_provider: network.clone(),
 				is_validator: parachain_config.role.is_authority(),
-				enable_http_requests: false,
+				enable_http_requests: true,
 				custom_extensions: move |_| vec![],
 			})
 			.run(client.clone(), task_manager.spawn_handle())


### PR DESCRIPTION
## What?

Enable HTTP requests from offchain workers.

## Why?

When we merged https://github.com/Polimec/polimec-node/commit/0f4573ca66b73cd9ee1750463dfcf2909d7a70d8 we accidentally forbid the HTTP requests from the offchain workers. This feature is needed since otherwise the selected nodes cannot fetch and submit the prices.