### PR TITLE
✨ Store the DID used in Evaluation or Contribution

### DIFF
--- a/pallets/funding/src/functions.rs
+++ b/pallets/funding/src/functions.rs
@@ -1033,6 +1033,7 @@ impl<T: Config> Pallet<T> {
 
 		let new_evaluation = EvaluationInfoOf::<T> {
 			id: evaluation_id,
+			did: did.clone(),
 			project_id,
 			evaluator: evaluator.clone(),
 			original_plmc_bond: plmc_bond,
@@ -1467,6 +1468,7 @@ impl<T: Config> Pallet<T> {
 
 		let contribution_id = NextContributionId::<T>::get();
 		let new_contribution = ContributionInfoOf::<T> {
+			did: did.clone(),
 			id: contribution_id,
 			project_id,
 			contributor: contributor.clone(),

--- a/pallets/funding/src/lib.rs
+++ b/pallets/funding/src/lib.rs
@@ -175,11 +175,11 @@ pub type ProjectMetadataOf<T> =
 pub type ProjectDetailsOf<T> =
 	ProjectDetails<AccountIdOf<T>, Did, BlockNumberFor<T>, PriceOf<T>, BalanceOf<T>, EvaluationRoundInfoOf<T>>;
 pub type EvaluationRoundInfoOf<T> = EvaluationRoundInfo<BalanceOf<T>>;
-pub type EvaluationInfoOf<T> = EvaluationInfo<u32, ProjectId, AccountIdOf<T>, BalanceOf<T>, BlockNumberFor<T>>;
+pub type EvaluationInfoOf<T> = EvaluationInfo<u32, Did, ProjectId, AccountIdOf<T>, BalanceOf<T>, BlockNumberFor<T>>;
 pub type BidInfoOf<T> =
 	BidInfo<ProjectId, Did, BalanceOf<T>, PriceOf<T>, AccountIdOf<T>, BlockNumberFor<T>, MultiplierOf<T>>;
 
-pub type ContributionInfoOf<T> = ContributionInfo<u32, ProjectId, AccountIdOf<T>, BalanceOf<T>, MultiplierOf<T>>;
+pub type ContributionInfoOf<T> = ContributionInfo<u32, Did, ProjectId, AccountIdOf<T>, BalanceOf<T>, MultiplierOf<T>>;
 
 pub type BucketOf<T> = Bucket<BalanceOf<T>, PriceOf<T>>;
 pub type WeightInfoOf<T> = <T as Config>::WeightInfo;

--- a/pallets/funding/src/tests/2_evaluation.rs
+++ b/pallets/funding/src/tests/2_evaluation.rs
@@ -459,12 +459,14 @@ mod evaluate_extrinsic {
 				assert_eq!(Evaluations::<TestRuntime>::iter_values().collect_vec(), vec![]);
 			});
 
+			let did = generate_did_from_account(evaluation.account);
+
 			assert_ok!(inst.execute(|| PolimecFunding::evaluate(
 				RuntimeOrigin::signed(evaluation.account),
 				get_mock_jwt_with_cid(
 					evaluation.account,
 					InvestorType::Retail,
-					generate_did_from_account(evaluation.account),
+					did.clone(),
 					project_metadata.clone().policy_ipfs_cid.unwrap()
 				),
 				project_id,
@@ -477,6 +479,7 @@ mod evaluate_extrinsic {
 				let stored_evaluation = &evaluations[0];
 				let expected_evaluation_item = EvaluationInfoOf::<TestRuntime> {
 					id: 0,
+					did,
 					project_id: 0,
 					evaluator: EVALUATOR_1,
 					original_plmc_bond: necessary_plmc[0].plmc_amount,

--- a/pallets/funding/src/types.rs
+++ b/pallets/funding/src/types.rs
@@ -315,8 +315,9 @@ pub mod storage_types {
 	}
 
 	#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen, Ord, PartialOrd)]
-	pub struct EvaluationInfo<Id, ProjectId, AccountId, Balance, BlockNumber> {
+	pub struct EvaluationInfo<Id, Did, ProjectId, AccountId, Balance, BlockNumber> {
 		pub id: Id,
+		pub did: Did,
 		pub project_id: ProjectId,
 		pub evaluator: AccountId,
 		pub original_plmc_bond: Balance,
@@ -380,8 +381,9 @@ pub mod storage_types {
 	}
 
 	#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
-	pub struct ContributionInfo<Id, ProjectId, AccountId, Balance, Multiplier> {
+	pub struct ContributionInfo<Id, Did, ProjectId, AccountId, Balance, Multiplier> {
 		pub id: Id,
+		pub did: Did,
 		pub project_id: ProjectId,
 		pub contributor: AccountId,
 		pub ct_amount: Balance,


### PR DESCRIPTION
## What and Why?


This pull request includes Decentralized Identifier (DID) in Evaluation (`EvaluationInfo`) and Contribution (`ContributionInfo`) structs.
