### PR TITLE
✨ Accept only CT decimals from 4 to 20

### DIFF
--- a/pallets/funding/src/tests/4_community.rs
+++ b/pallets/funding/src/tests/4_community.rs
@@ -292,7 +292,7 @@ mod round_flow {
 			for decimals in 0..25 {
 				decimal_test(decimals);
 			}
-gt
+
 			// Since we use the same original price and allocation size and adjust for decimals,
 			// the USD and PLMC amounts should be the same
 			assert!(total_fundings_usd.iter().all(|x| *x == total_fundings_usd[0]));

--- a/pallets/funding/src/types.rs
+++ b/pallets/funding/src/types.rs
@@ -244,6 +244,10 @@ pub mod storage_types {
 			if target_funding < (1000u64 * 10u64.pow(USD_DECIMALS.into())).into() {
 				return Err(MetadataError::FundingTargetTooLow);
 			}
+
+			if self.token_information.decimals < 4 || self.token_information.decimals > 20 {
+				return Err(MetadataError::BadDecimals);
+			}
 			Ok(())
 		}
 	}
@@ -758,6 +762,8 @@ pub mod inner_types {
 		FundingTargetTooLow,
 		/// The project's metadata hash is not provided while starting the evaluation round.
 		CidNotProvided,
+		/// The ct decimals specified for the CT is outside the 4 to 20 range.
+		BadDecimals,
 	}
 
 	/// Errors related to the project's migration process.


### PR DESCRIPTION
## What?
- The decimals in the token information can now only be a number from 4 to 20 inclusive.

## Why?
- Too low numbers means a very big whole part in the Fixedu128, too high means a very big decimal part in the same type.
- We want to make sure the price is representable

## How?
- add a new check on the metadata validation function

## Testing?
`unaccepted_ct_decimals` on the application test file

## Anything Else?
- We need to also check that the allocation size is big enough to represent the decimals specified by the user. In another PR though
