### PR TITLE
⚡️ Add check for allocation smaller than decimals

### DIFF
--- a/pallets/funding/src/types.rs
+++ b/pallets/funding/src/types.rs
@@ -225,7 +225,9 @@ pub mod storage_types {
 				return Err(MetadataError::AllocationSizeError);
 			}
 
-			if self.total_allocation_size <= 0u64.into() {
+			if self.total_allocation_size <= 0u64.into() ||
+				self.total_allocation_size < 10u64.pow(self.token_information.decimals as u32).into()
+			{
 				return Err(MetadataError::AllocationSizeError);
 			}
 


### PR DESCRIPTION
## What?
- Reject project metadatas on creation and edit where the allocation size is smaller than the specified decimals.

## Why?
- It introduces memory leaks, which would behave the same as panics and stall our chain

## How?
- add a new check on the metadata validation function

## Testing?
`allocation_smaller_than_decimals` on application test file