### PR TITLE
Make sure USD is representable with CT decimal/price combo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12538,6 +12538,7 @@ dependencies = [
  "pallet-treasury",
  "parachains-common",
  "parity-scale-codec",
+ "polimec-common",
  "scale-info",
  "smallvec",
  "sp-arithmetic",

--- a/integration-tests/src/tests/basic_comms.rs
+++ b/integration-tests/src/tests/basic_comms.rs
@@ -133,8 +133,6 @@ fn xcmp() {
 
 	let penpal_account = PolimecNet::sovereign_account_id_of((Parent, Parachain(PenNet::para_id().into())).into());
 	let penpal_balance = PolimecNet::account_data_of(penpal_account.clone()).free;
-	dbg!(penpal_account.clone());
-	dbg!(penpal_balance);
 
 	PolimecNet::execute_with(|| {
 		assert_expected_events!(

--- a/integration-tests/src/tests/defaults.rs
+++ b/integration-tests/src/tests/defaults.rs
@@ -24,8 +24,8 @@ use sp_arithmetic::{FixedPointNumber, Percent};
 
 use macros::generate_accounts;
 use pallet_funding::traits::ProvideAssetPrice;
-use polimec_common::USD_DECIMALS;
-use polimec_runtime::{PLMC, USD_UNIT};
+use polimec_common::{USD_DECIMALS, USD_UNIT};
+use polimec_runtime::PLMC;
 use politest_runtime::AccountId;
 use sp_runtime::{traits::ConstU32, Perquintill};
 

--- a/integration-tests/src/tests/governance.rs
+++ b/integration-tests/src/tests/governance.rs
@@ -21,7 +21,6 @@ use polimec_runtime::{
 	Balances, Council, Democracy, Elections, ParachainStaking, Preimage, RuntimeOrigin, TechnicalCommittee, Treasury,
 	Vesting, PLMC,
 };
-use tests::defaults::*;
 use xcm_emulator::helpers::get_account_id_from_seed;
 generate_accounts!(PEPE, CARLOS,);
 

--- a/integration-tests/src/tests/vest.rs
+++ b/integration-tests/src/tests/vest.rs
@@ -25,7 +25,6 @@ use pallet_funding::assert_close_enough;
 use pallet_vesting::VestingInfo;
 use polimec_runtime::{Balances, ParachainStaking, PayMaster, RuntimeOrigin, Vesting, PLMC};
 use sp_runtime::Perquintill;
-use tests::defaults::*;
 use xcm_emulator::helpers::get_account_id_from_seed;
 
 generate_accounts!(PEPE, CARLOS,);

--- a/pallets/funding/src/mock.rs
+++ b/pallets/funding/src/mock.rs
@@ -30,7 +30,7 @@ use frame_support::{
 };
 use frame_system as system;
 use frame_system::{EnsureRoot, RawOrigin as SystemRawOrigin};
-use polimec_common::{credentials::EnsureInvestor, USD_DECIMALS};
+use polimec_common::{credentials::EnsureInvestor, USD_UNIT};
 use polkadot_parachain_primitives::primitives::Sibling;
 use sp_arithmetic::Percent;
 use sp_core::H256;
@@ -48,7 +48,6 @@ pub const PLMC: Balance = 10u128.pow(PLMC_DECIMALS as u32);
 pub const MILLI_PLMC: Balance = PLMC / 10u128.pow(3);
 pub const MICRO_PLMC: Balance = PLMC / 10u128.pow(6);
 pub const EXISTENTIAL_DEPOSIT: Balance = 10 * MILLI_PLMC;
-pub const USD_UNIT: Balance = 10u128.pow(USD_DECIMALS as u32);
 
 pub type Block = frame_system::mocking::MockBlock<TestRuntime>;
 pub type AccountId = u32;

--- a/pallets/funding/src/tests/2_evaluation.rs
+++ b/pallets/funding/src/tests/2_evaluation.rs
@@ -187,7 +187,7 @@ mod round_flow {
 				inst.start_auction(project_id, issuer).unwrap();
 			};
 
-			for decimals in 0..25 {
+			for decimals in 6..=18 {
 				decimal_test(decimals);
 			}
 

--- a/pallets/funding/src/tests/3_auction.rs
+++ b/pallets/funding/src/tests/3_auction.rs
@@ -631,7 +631,6 @@ mod round_flow {
 					funding_asset.to_assethub_id(),
 				)]);
 
-
 				assert_ok!(inst.execute(|| PolimecFunding::bid(
 					RuntimeOrigin::signed(BIDDER_1),
 					get_mock_jwt_with_cid(
@@ -651,7 +650,7 @@ mod round_flow {
 				assert_eq!(bucket.amount_left, 500_000u128 * 10u128.pow(decimals as u32) - min_professional_bid_ct);
 			};
 
-			for decimals in 0..25 {
+			for decimals in 6..=18 {
 				decimal_test(decimals);
 			}
 

--- a/pallets/funding/src/tests/4_community.rs
+++ b/pallets/funding/src/tests/4_community.rs
@@ -289,7 +289,7 @@ mod round_flow {
 				inst.finish_funding(project_id).unwrap();
 			};
 
-			for decimals in 0..25 {
+			for decimals in 6..=18 {
 				decimal_test(decimals);
 			}
 

--- a/pallets/funding/src/tests/5_remainder.rs
+++ b/pallets/funding/src/tests/5_remainder.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::instantiator::async_features::create_multiple_projects_at;
-use std::collections::HashSet;
 use frame_support::traits::fungibles::metadata::Inspect;
 use sp_runtime::bounded_vec;
+use std::collections::HashSet;
 
 #[cfg(test)]
 mod round_flow {
@@ -136,14 +136,14 @@ mod round_flow {
 				USD_DECIMALS,
 				default_project_metadata.token_information.decimals,
 			)
-				.unwrap();
+			.unwrap();
 			let usable_plmc_price = inst.execute(|| {
 				<TestRuntime as Config>::PriceProvider::get_decimals_aware_price(
 					PLMC_FOREIGN_ID,
 					USD_DECIMALS,
 					PLMC_DECIMALS,
 				)
-					.unwrap()
+				.unwrap()
 			});
 			let usdt_price = inst.execute(|| {
 				<TestRuntime as Config>::PriceProvider::get_decimals_aware_price(
@@ -151,7 +151,7 @@ mod round_flow {
 					USD_DECIMALS,
 					ForeignAssets::decimals(AcceptedFundingAsset::USDT.to_assethub_id()),
 				)
-					.unwrap()
+				.unwrap()
 			});
 			let usdc_price = inst.execute(|| {
 				<TestRuntime as Config>::PriceProvider::get_decimals_aware_price(
@@ -159,7 +159,7 @@ mod round_flow {
 					USD_DECIMALS,
 					ForeignAssets::decimals(AcceptedFundingAsset::USDC.to_assethub_id()),
 				)
-					.unwrap()
+				.unwrap()
 			});
 			let dot_price = inst.execute(|| {
 				<TestRuntime as Config>::PriceProvider::get_decimals_aware_price(
@@ -167,7 +167,7 @@ mod round_flow {
 					USD_DECIMALS,
 					ForeignAssets::decimals(AcceptedFundingAsset::DOT.to_assethub_id()),
 				)
-					.unwrap()
+				.unwrap()
 			});
 
 			let mut funding_assets_cycle =
@@ -195,7 +195,7 @@ mod round_flow {
 						USD_DECIMALS,
 						decimals,
 					)
-						.unwrap();
+					.unwrap();
 
 				project_metadata.total_allocation_size = 1_000_000 * 10u128.pow(decimals as u32);
 				project_metadata.mainnet_token_max_supply = project_metadata.total_allocation_size;
@@ -263,7 +263,7 @@ mod round_flow {
 				inst.finish_funding(project_id).unwrap();
 			};
 
-			for decimals in 0..25 {
+			for decimals in 6..=18 {
 				decimal_test(decimals);
 			}
 
@@ -487,10 +487,15 @@ mod remaining_contribute_extrinsic {
 			let mut inst = MockInstantiator::new(Some(RefCell::new(new_test_ext())));
 			let project_metadata = ProjectMetadata {
 				token_information: default_token_information(),
-				mainnet_token_max_supply: 80_000_000 * CT_UNIT,
-				total_allocation_size: 10_000_000 * CT_UNIT,
+				mainnet_token_max_supply: 100_000 * CT_UNIT,
+				total_allocation_size: 100_000 * CT_UNIT,
 				auction_round_allocation_percentage: Percent::from_percent(50u8),
-				minimum_price: PriceOf::<TestRuntime>::from_float(10.0),
+				minimum_price: PriceProviderOf::<TestRuntime>::calculate_decimals_aware_price(
+					PriceOf::<TestRuntime>::from_float(10.0),
+					USD_DECIMALS,
+					CT_DECIMALS,
+				)
+				.unwrap(),
 				bidding_ticket_sizes: BiddingTicketSizes {
 					professional: TicketSize::new(Some(5000 * USD_UNIT), None),
 					institutional: TicketSize::new(Some(5000 * USD_UNIT), None),

--- a/pallets/funding/src/tests/mod.rs
+++ b/pallets/funding/src/tests/mod.rs
@@ -15,7 +15,7 @@ use frame_support::{
 };
 use itertools::Itertools;
 use parachains_common::DAYS;
-use polimec_common::{ReleaseSchedule, USD_DECIMALS};
+use polimec_common::{ReleaseSchedule, USD_DECIMALS, USD_UNIT};
 use polimec_common_test_utils::{generate_did_from_account, get_mock_jwt_with_cid};
 use sp_arithmetic::{traits::Zero, Percent, Perquintill};
 use sp_runtime::{BuildStorage, TokenError};
@@ -23,10 +23,9 @@ use sp_std::{cell::RefCell, marker::PhantomData};
 use std::iter::zip;
 type MockInstantiator =
 	Instantiator<TestRuntime, <TestRuntime as crate::Config>::AllPalletsWithoutSystem, RuntimeEvent>;
-const USD_UNIT: u128 = 10u128.pow(USD_DECIMALS as u32);
-const USDT_UNIT: u128 = USD_UNIT;
 const CT_DECIMALS: u8 = 15;
 const CT_UNIT: u128 = 10_u128.pow(CT_DECIMALS as u32);
+const USDT_UNIT: u128 = USD_UNIT;
 
 const IPFS_CID: &str = "QmeuJ24ffwLAZppQcgcggJs3n689bewednYkuc8Bx5Gngz";
 const ISSUER_1: AccountId = 11;

--- a/pallets/funding/src/traits.rs
+++ b/pallets/funding/src/traits.rs
@@ -49,6 +49,7 @@ pub trait ProvideAssetPrice {
 		let usd_unit = 10u128.checked_pow(usd_decimals.into())?;
 		let usd_price_with_decimals = original_price.checked_mul_int(usd_unit)?;
 		let asset_unit = 10u128.checked_pow(asset_decimals.into())?;
+
 		Self::Price::checked_from_rational(usd_price_with_decimals, asset_unit)
 	}
 
@@ -58,7 +59,7 @@ pub trait ProvideAssetPrice {
 		asset_decimals: u8,
 	) -> Option<Self::Price> {
 		let abs_diff: u32 = asset_decimals.abs_diff(usd_decimals).into();
-		let abs_diff_unit = 10u128.pow(abs_diff);
+		let abs_diff_unit = 10u128.checked_pow(abs_diff)?;
 		// We are pretty sure this is going to be representable because the number size is not the size of the asset decimals, but the difference between the asset and usd decimals
 		let abs_diff_fixed = Self::Price::checked_from_rational(abs_diff_unit, 1)?;
 		if usd_decimals > asset_decimals {

--- a/polimec-common/common/src/lib.rs
+++ b/polimec-common/common/src/lib.rs
@@ -213,3 +213,4 @@ pub mod migration_types {
 }
 
 pub const USD_DECIMALS: u8 = 6;
+pub const USD_UNIT: u128 = 10u128.pow(USD_DECIMALS as u32);

--- a/runtimes/polimec/src/lib.rs
+++ b/runtimes/polimec/src/lib.rs
@@ -80,6 +80,7 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 
+use polimec_common::USD_UNIT;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
 

--- a/runtimes/politest/src/lib.rs
+++ b/runtimes/politest/src/lib.rs
@@ -94,6 +94,7 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 
+use polimec_common::USD_UNIT;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
 

--- a/runtimes/shared-configuration/Cargo.toml
+++ b/runtimes/shared-configuration/Cargo.toml
@@ -20,6 +20,7 @@ parity-scale-codec = { workspace = true , default-features = false, features = [
 scale-info = { workspace = true , default-features = false, features = [
 	"derive",
 ] }
+polimec-common.workspace = true
 
 # FRAME
 frame-system.workspace = true

--- a/runtimes/shared-configuration/src/currency.rs
+++ b/runtimes/shared-configuration/src/currency.rs
@@ -36,8 +36,6 @@ pub const EXISTENTIAL_DEPOSIT: Balance = 10 * MILLI_PLMC;
 pub const DEPOSIT_STORAGE_ITEM: Balance = 56 * MILLI_PLMC;
 /// Deposit that must be provided for each occupied storage byte.
 pub const DEPOSIT_STORAGE_BYTE: Balance = 100 * MICRO_PLMC;
-pub const USD_DECIMALS: u8 = 6;
-pub const USD_UNIT: Balance = 10u128.pow(USD_DECIMALS as u32);
 
 pub const fn deposit(items: u32, bytes: u32) -> Balance {
 	(items as Balance * DEPOSIT_STORAGE_ITEM + (bytes as Balance) * DEPOSIT_STORAGE_BYTE) / 100

--- a/runtimes/shared-configuration/src/funding.rs
+++ b/runtimes/shared-configuration/src/funding.rs
@@ -14,10 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{currency::USD_UNIT, Balance, BlockNumber};
+use crate::{Balance, BlockNumber};
 use frame_support::{parameter_types, PalletId};
 use pallet_funding::types::AcceptedFundingAsset;
 use parachains_common::AssetIdForTrustBackedAssets;
+use polimec_common::USD_UNIT;
 use sp_arithmetic::{FixedU128, Percent};
 use sp_std::{collections::btree_map::BTreeMap, vec, vec::Vec};
 


### PR DESCRIPTION
## What?
- Find ways to avoid unrepresentability of issuer-set tokenomics on our own types

## Why?
- We let issuers choose whatever price, allocation, and decimals they want, but we still need to convert those into our own FixedU128 price, and 6 decimal USD amounts. 
- This could potentially lead to some issuer-set tokenomics being unrepresentable with our own types, For example due to their CT being too high in value, and we couldn't represent 1 US cent with their lowest possible CT amount, or their price decimals having more decimals than our Price type, and it saturating to 0.

## How?
- Limit the decimals to 6-18 range, and price to 0.00001-1000
- After experimenting some on the misc tests, I came to the conclusion that the best course now is to severely restrict the decimals and price that the issuer can put. 
- We will need a lot more testing and consultation with other experts if we want to increase those limits. 
- A potential solution would be to change how we handle prices and decimals, like using for example something like  https://github.com/sam0x17/currencies/tree/main

## Testing?
- New tests were written on the application file to check for the different decimals and price limits

## Anything else?
- Also fixed broken tests from main
- We need another PR were we replace all unsafe `pow` with safe `checked_pow`