### PR TITLE
Try out AssetHub transfers with chopsticks

### DIFF
--- a/scripts/chopsticks/assethub-transfers/polkadot-assethub.yml
+++ b/scripts/chopsticks/assethub-transfers/polkadot-assethub.yml
@@ -1,0 +1,29 @@
+db: ./db.sqlite
+mock-signature-host: true
+endpoint: wss://statemint-rpc.dwellir.com
+import-storage:
+  System:
+    Account:
+      # Polimec sovereign account (sibling - 3344) 1 DOT
+      - - - "0x7369626c100d0000000000000000000000000000000000000000000000000000"
+        - providers: 1
+          data:
+            free: "10000000000"
+      # Politest Sudo, 1MM DOT
+      - - - "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42"
+        - providers: 1
+          data:
+            free: "10000000000000000"
+  Assets:
+    Account:
+      [
+        [
+          [1984, 15CyvMWHKwbAPQ3ekqRFWLyq3kcjU8ypMuuGfsMnxanW85WZ],
+          { balance: 1000000000 },
+        ],
+        [
+          [1337, 15CyvMWHKwbAPQ3ekqRFWLyq3kcjU8ypMuuGfsMnxanW85WZ],
+          { balance: 1000000000 },
+        ],
+      ]
+

--- a/scripts/chopsticks/assethub-transfers/polkadot-polimec.yml
+++ b/scripts/chopsticks/assethub-transfers/polkadot-polimec.yml
@@ -1,0 +1,91 @@
+db: ./db.sqlite
+mock-signature-host: true
+endpoint: wss://rpc.polimec.org
+import-storage:
+  System:
+    Account:
+      # Politest Sudo
+      [
+        [
+          [
+            "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+          ],
+          { providers: 1, data: { free: "10000000000000000" } },
+        ],
+      ]
+  # This will be deleted once Polimec has all funding assets registered in ForeignAssets pallet
+  ForeignAssets:
+    Asset:
+      [
+        [
+          [1984],
+          {
+            owner: "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+            issuer: "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+            admin: "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+            freezer: "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+            supply: 1000000000,
+            deposit: 10,
+            minBalance: 10,
+            isSufficient: false,
+            accounts: 1,
+            sufficients: 1,
+            approvals: 0,
+            status: Live,
+          },
+        ],
+        [
+          [10],
+          {
+            owner: "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+            issuer: "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+            admin: "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+            freezer: "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+            supply: 1000000000,
+            deposit: 10,
+            minBalance: 10,
+            isSufficient: false,
+            accounts: 1,
+            sufficients: 1,
+            approvals: 0,
+            status: Live,
+          },
+        ],
+        [
+          [1337],
+          {
+            owner: "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+            issuer: "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+            admin: "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+            freezer: "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+            supply: 1000000000,
+            deposit: 10,
+            minBalance: 10,
+            isSufficient: false,
+            accounts: 1,
+            sufficients: 1,
+            approvals: 0,
+            status: Live,
+          },
+        ],
+      ]
+
+    Metadata:
+      [
+        [[1984], { symbol: "USDT", name: USDT, decimals: 6, isFrozen: false }],
+        [[10], { symbol: "DOT", name: DOT, decimals: 10, isFrozen: false }],
+        [[1337], { symbol: "USDC", name: USDC, decimals: 6, isFrozen: false }],
+      ]
+
+    Account:
+      [
+        [
+          [1984, 15CyvMWHKwbAPQ3ekqRFWLyq3kcjU8ypMuuGfsMnxanW85WZ],
+          { balance: 1000000000 },
+        ],
+        [
+          [10, 15CyvMWHKwbAPQ3ekqRFWLyq3kcjU8ypMuuGfsMnxanW85WZ],
+          { balance: 1000000000 },
+        ],
+      ]
+


### PR DESCRIPTION
## What?
- Add chopstick config files to test asset hub transfers to Polimec

## Why?
- To make sure our live Polimec xcm config is correct

## How?
- add balances to the sovereign account and sender in assethub, and create the assets for DOT, USDC, and USDT on Polimec

## Testing?
USDT transfer encoded call to execute on AssetHub:
```
0x1f020101010041340100010100ba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c420104000002043205011f000284d71700000000
```
