### PR TITLE
bump politest version

### DIFF
--- a/pallets/funding/src/migration.rs
+++ b/pallets/funding/src/migration.rs
@@ -2,5 +2,155 @@
 use frame_support::traits::StorageVersion;
 
 /// The current storage version
-pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
 pub const LOG: &str = "runtime::funding::migration";
+
+pub mod v2 {
+	use super::*;
+	use crate::{AccountIdOf, BalanceOf, Config, ProjectMetadata, ProjectsMetadata};
+	use frame_support::{
+		pallet_prelude::{Decode, Encode, MaxEncodedLen, RuntimeDebug, TypeInfo},
+		traits::{Get, OnRuntimeUpgrade},
+		BoundedVec,
+	};
+	use polimec_common::{USD_DECIMALS, USD_UNIT};
+	use sp_arithmetic::{traits::Zero, FixedPointNumber, Percent};
+	use sp_core::ConstU32;
+	use sp_std::marker::PhantomData;
+	use xcm::v3::Weight;
+
+	#[derive(Clone, Copy, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	pub struct OldTicketSize<Balance: PartialOrd + Copy> {
+		pub usd_minimum_per_participation: Option<Balance>,
+		pub usd_maximum_per_did: Option<Balance>,
+	}
+
+	#[derive(Clone, Copy, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	pub struct OldBiddingTicketSizes<Price: FixedPointNumber, Balance: PartialOrd + Copy> {
+		pub professional: OldTicketSize<Balance>,
+		pub institutional: OldTicketSize<Balance>,
+		pub phantom: PhantomData<(Price, Balance)>,
+	}
+
+	#[derive(Clone, Copy, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	pub struct OldContributingTicketSizes<Price: FixedPointNumber, Balance: PartialOrd + Copy> {
+		pub retail: OldTicketSize<Balance>,
+		pub professional: OldTicketSize<Balance>,
+		pub institutional: OldTicketSize<Balance>,
+		pub phantom: PhantomData<(Price, Balance)>,
+	}
+
+	type OldProjectMetadataOf<T> = OldProjectMetadata<
+		BoundedVec<u8, crate::StringLimitOf<T>>,
+		BalanceOf<T>,
+		crate::PriceOf<T>,
+		AccountIdOf<T>,
+		polimec_common::credentials::Cid,
+	>;
+	#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	pub struct OldProjectMetadata<BoundedString, Balance: PartialOrd + Copy, Price: FixedPointNumber, AccountId, Cid> {
+		/// Token Metadata
+		pub token_information: crate::CurrencyMetadata<BoundedString>,
+		/// Mainnet Token Max Supply
+		pub mainnet_token_max_supply: Balance,
+		/// Total allocation of Contribution Tokens available for the Funding Round.
+		pub total_allocation_size: Balance,
+		/// Percentage of the total allocation of Contribution Tokens available for the Auction Round
+		pub auction_round_allocation_percentage: Percent,
+		/// The minimum price per token in USD, decimal-aware. See [`calculate_decimals_aware_price()`](crate::traits::ProvideAssetPrice::calculate_decimals_aware_price) for more information.
+		pub minimum_price: Price,
+		/// Maximum and minimum ticket sizes for auction round
+		pub bidding_ticket_sizes: OldBiddingTicketSizes<Price, Balance>,
+		/// Maximum and minimum ticket sizes for community/remainder rounds
+		pub contributing_ticket_sizes: OldContributingTicketSizes<Price, Balance>,
+		/// Participation currencies (e.g stablecoin, DOT, KSM)
+		pub participation_currencies:
+			BoundedVec<crate::AcceptedFundingAsset, ConstU32<{ crate::AcceptedFundingAsset::VARIANT_COUNT as u32 }>>,
+		pub funding_destination_account: AccountId,
+		/// Additional metadata
+		pub policy_ipfs_cid: Option<Cid>,
+	}
+
+	pub struct UncheckedMigrationToV2<T: Config>(PhantomData<T>);
+	impl<T: Config> OnRuntimeUpgrade for UncheckedMigrationToV2<T> {
+		fn on_runtime_upgrade() -> frame_support::weights::Weight {
+			let mut items = 0;
+			let mut translate = |_key, item: OldProjectMetadataOf<T>| -> Option<crate::ProjectMetadataOf<T>> {
+				items += 1;
+				let usd_unit = sp_arithmetic::traits::checked_pow(BalanceOf::<T>::from(10u64), USD_DECIMALS as usize)?;
+				Some(crate::ProjectMetadataOf::<T> {
+					token_information: item.token_information,
+					mainnet_token_max_supply: item.mainnet_token_max_supply,
+					total_allocation_size: item.total_allocation_size,
+					auction_round_allocation_percentage: item.auction_round_allocation_percentage,
+					minimum_price: item.minimum_price,
+					bidding_ticket_sizes: crate::BiddingTicketSizes {
+						professional: crate::TicketSize {
+							usd_minimum_per_participation: item
+								.bidding_ticket_sizes
+								.professional
+								.usd_minimum_per_participation
+								.unwrap_or_else(|| usd_unit),
+							usd_maximum_per_did: item.bidding_ticket_sizes.professional.usd_maximum_per_did,
+						},
+						institutional: crate::TicketSize {
+							usd_minimum_per_participation: item
+								.bidding_ticket_sizes
+								.institutional
+								.usd_minimum_per_participation
+								.unwrap_or_else(|| usd_unit),
+							usd_maximum_per_did: item.bidding_ticket_sizes.institutional.usd_maximum_per_did,
+						},
+						phantom: Default::default(),
+					},
+					contributing_ticket_sizes: crate::ContributingTicketSizes {
+						retail: crate::TicketSize {
+							usd_minimum_per_participation: item
+								.contributing_ticket_sizes
+								.retail
+								.usd_minimum_per_participation
+								.unwrap_or_else(|| usd_unit),
+							usd_maximum_per_did: item.contributing_ticket_sizes.retail.usd_maximum_per_did,
+						},
+						professional: crate::TicketSize {
+							usd_minimum_per_participation: item
+								.contributing_ticket_sizes
+								.professional
+								.usd_minimum_per_participation
+								.unwrap_or_else(|| usd_unit),
+							usd_maximum_per_did: item.contributing_ticket_sizes.professional.usd_maximum_per_did,
+						},
+						institutional: crate::TicketSize {
+							usd_minimum_per_participation: item
+								.contributing_ticket_sizes
+								.institutional
+								.usd_minimum_per_participation
+								.unwrap_or_else(|| usd_unit),
+							usd_maximum_per_did: item.contributing_ticket_sizes.institutional.usd_maximum_per_did,
+						},
+						phantom: Default::default(),
+					},
+					participation_currencies: item.participation_currencies,
+					funding_destination_account: item.funding_destination_account,
+					policy_ipfs_cid: item.policy_ipfs_cid,
+				})
+			};
+
+			ProjectsMetadata::<T>::translate(|key, object: OldProjectMetadataOf<T>| translate(key, object));
+
+			T::DbWeight::get().reads_writes(items, items)
+		}
+	}
+
+	pub type MigrationToV2<T> = frame_support::migrations::VersionedMigration<
+		1,
+		2,
+		UncheckedMigrationToV2<T>,
+		crate::Pallet<T>,
+		<T as frame_system::Config>::DbWeight,
+	>;
+}

--- a/runtimes/politest/src/lib.rs
+++ b/runtimes/politest/src/lib.rs
@@ -169,8 +169,10 @@ pub type Migrations = migrations::Unreleased;
 /// The runtime migrations per release.
 #[allow(missing_docs)]
 pub mod migrations {
+	use crate::Runtime;
+
 	/// Unreleased migrations. Add new ones here:
-	pub type Unreleased = ();
+	pub type Unreleased = (pallet_funding::migration::v2::MigrationToV2<Runtime>);
 }
 
 /// Executive: handles dispatch to the various modules.
@@ -216,7 +218,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("politest"),
 	impl_name: create_runtime_str!("politest"),
 	authoring_version: 1,
-	spec_version: 0_007_003,
+	spec_version: 0_007_004,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/scripts/chopsticks/standalone/rococo-politest.yml
+++ b/scripts/chopsticks/standalone/rococo-politest.yml
@@ -1,0 +1,91 @@
+db: ./db.sqlite
+mock-signature-host: true
+endpoint: wss://beta.rolimec.org
+import-storage:
+  System:
+    Account:
+      # Politest Sudo
+      [
+        [
+          [
+            "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+          ],
+          { providers: 1, data: { free: "10000000000000000" } },
+        ],
+      ]
+  # This will be deleted once Polimec has all funding assets registered in ForeignAssets pallet
+  ForeignAssets:
+    Asset:
+      [
+        [
+          [1984],
+          {
+            owner: "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+            issuer: "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+            admin: "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+            freezer: "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+            supply: 1000000000,
+            deposit: 10,
+            minBalance: 10,
+            isSufficient: false,
+            accounts: 1,
+            sufficients: 1,
+            approvals: 0,
+            status: Live,
+          },
+        ],
+        [
+          [10],
+          {
+            owner: "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+            issuer: "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+            admin: "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+            freezer: "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+            supply: 1000000000,
+            deposit: 10,
+            minBalance: 10,
+            isSufficient: false,
+            accounts: 1,
+            sufficients: 1,
+            approvals: 0,
+            status: Live,
+          },
+        ],
+        [
+          [1337],
+          {
+            owner: "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+            issuer: "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+            admin: "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+            freezer: "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+            supply: 1000000000,
+            deposit: 10,
+            minBalance: 10,
+            isSufficient: false,
+            accounts: 1,
+            sufficients: 1,
+            approvals: 0,
+            status: Live,
+          },
+        ],
+      ]
+
+    Metadata:
+      [
+        [[1984], { symbol: "USDT", name: USDT, decimals: 6, isFrozen: false }],
+        [[10], { symbol: "DOT", name: DOT, decimals: 10, isFrozen: false }],
+        [[1337], { symbol: "USDC", name: USDC, decimals: 6, isFrozen: false }],
+      ]
+
+    Account:
+      [
+        [
+          [1984, 15CyvMWHKwbAPQ3ekqRFWLyq3kcjU8ypMuuGfsMnxanW85WZ],
+          { balance: 1000000000 },
+        ],
+        [
+          [10, 15CyvMWHKwbAPQ3ekqRFWLyq3kcjU8ypMuuGfsMnxanW85WZ],
+          { balance: 1000000000 },
+        ],
+      ]
+


### PR DESCRIPTION
- Bump Politest one minor version
- Add migration to v2 for pallet funding

try-runtime output:
```sh
polimec-node on  05-06-bump_politest_version [!] via 🦀 v1.76.0-nightly took 7m50s 
❯ try-runtime --runtime ./target/release/wbuild/politest-runtime/politest_runtime.compact.compressed.wasm on-runtime-upgrade live --uri wss://beta.rolimec.org:443
[2024-05-07T08:05:38Z INFO  remote-ext] replacing wss:// in uri with https://: "https://beta.rolimec.org:443" (ws is currently unstable for fetching remote storage, for more see https://github.com/paritytech/jsonrpsee/issues/1086)
[2024-05-07T08:05:38Z INFO  remote-ext] since no at is provided, setting it to latest finalized head, 0xdd9c9b3ab95fdaca010e4d3819b5b4493175b2cbbf1c4bfaf7d0022a4b6be5e9
[2024-05-07T08:05:38Z INFO  remote-ext] since no prefix is filtered, the data for all pallets will be downloaded
[2024-05-07T08:05:38Z INFO  remote-ext] scraping key-pairs from remote at block height 0xdd9c9b3ab95fdaca010e4d3819b5b4493175b2cbbf1c4bfaf7d0022a4b6be5e9
✅ Found 4744 keys (0.20s)
[00:00:00] ✅ Downloaded key values 4,895.7276/s [=====================================================================================================================================] 4744/4744 (0s)
✅ Inserted keys into DB (0.02s)
[2024-05-07T08:05:39Z INFO  remote-ext] adding data for hashed prefix: , took 1.31s
[2024-05-07T08:05:39Z INFO  remote-ext] adding data for hashed key: 3a636f6465
[2024-05-07T08:05:40Z INFO  remote-ext] adding data for hashed key: 26aa394eea5630e07c48ae0c9558cef7f9cce9c888469bb1a0dceaa129672ef8
[2024-05-07T08:05:40Z INFO  remote-ext] adding data for hashed key: 26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac
[2024-05-07T08:05:40Z INFO  remote-ext] 👩‍👦 no child roots found to scrape
[2024-05-07T08:05:40Z INFO  remote-ext] initialized state externalities with storage root 0xf40ab8b7aeebc42660beb51cd54d165d82c3f3d7670c89627a687d7e4f462566 and state_version V1
[2024-05-07T08:05:40Z INFO  try-runtime::cli] Original runtime [Name: RuntimeString::Owned("politest")] [Version: 7003] [Code hash: 0x3e36...dbe1]
[2024-05-07T08:05:40Z INFO  try-runtime::cli] New runtime      [Name: RuntimeString::Owned("politest")] [Version: 7004] [Code hash: 0xba46...8303]
[2024-05-07T08:05:40Z INFO  try-runtime::cli] 🚀 Speed up your workflow by using snapshots instead of live state. See `try-runtime create-snapshot --help`.
[2024-05-07T08:05:40Z INFO  try_runtime_core::misc] ------------------------------------------------------------------
    
    
[2024-05-07T08:05:40Z INFO  try_runtime_core::misc] 🔬 Running TryRuntime_on_runtime_upgrade with checks: PreAndPost
    
    
[2024-05-07T08:05:40Z INFO  try_runtime_core::misc] ------------------------------------------------------------------
    
    
[2024-05-07T08:05:41Z INFO  frame_support::migrations] 🚚 Pallet "Funding" VersionedMigration migrating storage version from 1 to 2.
[2024-05-07T08:05:41Z INFO  runtime::executive] ✅ Entire runtime state decodes without error. 188158 bytes total.
[2024-05-07T08:05:41Z INFO  try_runtime_core::misc] ------------------------------------------------------------------------------------------------------
    
    
[2024-05-07T08:05:41Z INFO  try_runtime_core::misc] 🔬 TryRuntime_on_runtime_upgrade succeeded! Running it again without checks for weight measurements.
    
    
[2024-05-07T08:05:41Z INFO  try_runtime_core::misc] ------------------------------------------------------------------------------------------------------
    
    
[2024-05-07T08:05:41Z INFO  frame_support::migrations] 🚚 Pallet "Funding" VersionedMigration migrating storage version from 1 to 2.
[2024-05-07T08:05:41Z INFO  try_runtime_core::misc] ---------------------------------------------------------------------------------
    
    
[2024-05-07T08:05:41Z INFO  try_runtime_core::misc] 🔬 Running TryRuntime_on_runtime_upgrade again to check idempotency: PreAndPost
    
    
[2024-05-07T08:05:41Z INFO  try_runtime_core::misc] ---------------------------------------------------------------------------------
    
    
[2024-05-07T08:05:41Z WARN  frame_support::migrations] 🚚 Pallet "Funding" VersionedMigration migration 1->2 can be removed; on-chain is already at StorageVersion(2).
[2024-05-07T08:05:41Z INFO  runtime::executive] ✅ Entire runtime state decodes without error. 188158 bytes total.
[2024-05-07T08:05:41Z INFO  try-runtime::cli] PoV size (zstd-compressed compact proof): 6.0 KB. For parachains, it's your responsibility to verify that a PoV of this size fits within any relaychain constraints.
[2024-05-07T08:05:41Z INFO  try-runtime::cli] Consumed ref_time: 0.004075s (0.81% of max 0.5s)
[2024-05-07T08:05:41Z INFO  try-runtime::cli] ✅ No weight safety issues detected. Please note this does not guarantee a successful runtime upgrade. Always test your runtime upgrade with recent state, and ensure that the weight usage of your migrations will not drastically differ between testing and actual on-chain execution.
```

srtool output:
```sh
   Finished production [optimized] target(s) in 13m 06s
✨ Your Substrate WASM Runtime is ready! ✨
✨ WASM  : runtimes/politest/target/srtool/production/wbuild/politest-runtime/politest_runtime.compact.wasm
✨ Z_WASM: runtimes/politest/target/srtool/production/wbuild/politest-runtime/politest_runtime.compact.compressed.wasm
Summary generated with srtool v0.15.0 using the docker image paritytech/srtool:1.77.0:
 Package     : politest-runtime v0.6.0
 GIT commit  : d60f59c3e8e71d51c80c89fafb4b7f2ef2c44c69
 GIT tag     : v0.6.0
 GIT branch  : 05-06-bump_politest_version
 Rustc       : rustc 1.77.0 (aedd173a2 2024-03-17)
 Time        : 2024-05-07T08:25:04Z

== Compact
 Version          : politest-7004 (politest-0.tx2.au1)
 Metadata         : V14
 Size             : 5.09 MB (5336113 bytes)
 setCode          : 0x3ad17ad33dbdecdc976f9adae113239084e2a57afb257343bd3022bc40f2255c
 authorizeUpgrade : 0x067660dc5e780d1daff9cef3457ef8c3083d74f29aaeee4ef4ed565471f55412
 IPFS             : Qmco6LQejkLzvdKS372Sx7T8TxzUQF3QHE5LvaVvpTjsg9
 BLAKE2_256       : 0xf9cc437f34ed03803391391aa94716e0ac33bbb9527e3de6efda5bc86cdf0eb2
 Wasm             : runtimes/politest/target/srtool/production/wbuild/politest-runtime/politest_runtime.compact.wasm

== Compressed
 Version          : politest-7004 (politest-0.tx2.au1)
 Metadata         : V14
 Size             : 1.27 MB (1327325 bytes)
 Compression      : 75.13%
 setCode          : 0xd2a4ec7cd14f25d33445f88c8252080641c4233026536a266031d793e9bd23ea
 authorizeUpgrade : 0x932c2486e5276b8fff1b0774a80a0644894f350400f17a186f8e23df41b6955c
 IPFS             : QmVWRfc1AWmfPht869NvbY5CLphzdMk9JY6gHpk1uSvdQW
 BLAKE2_256       : 0x464ebe979980b56c85b50ce7e2100670a9d161efff47faf0d4ab5a37d8e67eb6
 Wasm             : runtimes/politest/target/srtool/production/wbuild/politest-runtime/politest_runtime.compact.compressed.wasm


```