### PR TITLE
🐛 Promote async-backing feature to production

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8485,6 +8485,7 @@ dependencies = [
  "cumulus-pallet-session-benchmarking",
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
+ "cumulus-primitives-aura",
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
  "frame-benchmarking",

--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ build-rolimec-srtool:
 
 # Build the "Testnet" Runtime using srtool
 build-politest-srtool:
-    srtool build --root -p politest-runtime --profile production --runtime-dir runtimes/politest --build-opts="--features=on-chain-release-build,fast-mode,async-backing" --no-wasm-std
+    srtool build --root -p politest-runtime --profile production --runtime-dir runtimes/politest --build-opts="--features=on-chain-release-build,fast-mode" --no-wasm-std
 
 # Test the runtimes features
 test-runtime-features runtime="polimec-runtime":

--- a/nodes/parachain/Cargo.toml
+++ b/nodes/parachain/Cargo.toml
@@ -127,7 +127,4 @@ on-chain-release-build = [
 	"polimec-runtime/on-chain-release-build",
 	"politest-runtime/on-chain-release-build",
 ]
-async-backing = [ "politest-runtime/async-backing" ]
-development-settings = [
-	"polimec-runtime/development-settings",
-]
+development-settings = [ "polimec-runtime/development-settings" ]

--- a/nodes/parachain/src/command.rs
+++ b/nodes/parachain/src/command.rs
@@ -285,12 +285,11 @@ pub fn run() -> Result<()> {
 				}),
 				#[cfg(not(feature = "runtime-benchmarks"))]
 				BenchmarkCmd::Storage(_) =>
-					return Err(sc_cli::Error::Input(
+					Err(sc_cli::Error::Input(
 						"Compile with --features=runtime-benchmarks \
 						to enable storage benchmarks."
 							.into(),
-					)
-					.into()),
+					)),
 				#[cfg(feature = "runtime-benchmarks")]
 				BenchmarkCmd::Storage(cmd) => runner.sync_run(|config| {
 					let partials = new_partial(&config)?;

--- a/nodes/parachain/src/service.rs
+++ b/nodes/parachain/src/service.rs
@@ -20,15 +20,8 @@
 use std::{sync::Arc, time::Duration};
 
 use cumulus_client_cli::CollatorOptions;
-#[cfg(not(feature = "async-backing"))]
 // Local Runtime Types
 use polimec_runtime::{
-	opaque::{Block, Hash},
-	RuntimeApi,
-};
-
-#[cfg(feature = "async-backing")]
-use politest_runtime::{
 	opaque::{Block, Hash},
 	RuntimeApi,
 };
@@ -41,9 +34,10 @@ use cumulus_client_service::{
 	build_network, build_relay_chain_interface, prepare_node_config, start_relay_chain_tasks, BuildNetworkParams,
 	CollatorSybilResistance, DARecoveryProfile, StartRelayChainTasksParams,
 };
-#[cfg(feature = "async-backing")]
-use cumulus_primitives_core::relay_chain::ValidationCode;
-use cumulus_primitives_core::{relay_chain::CollatorPair, ParaId};
+use cumulus_primitives_core::{
+	relay_chain::{CollatorPair, ValidationCode},
+	ParaId,
+};
 use cumulus_relay_chain_interface::{OverseerHandle, RelayChainInterface};
 
 // Substrate Imports
@@ -238,9 +232,6 @@ async fn start_node_impl(
 		task_manager: &mut task_manager,
 		config: parachain_config,
 		keystore: params.keystore_container.keystore(),
-		#[cfg(not(feature = "async-backing"))]
-		backend,
-		#[cfg(feature = "async-backing")]
 		backend: backend.clone(),
 		network: network.clone(),
 		sync_service: sync_service.clone(),
@@ -297,7 +288,6 @@ async fn start_node_impl(
 	if validator {
 		start_consensus(
 			client.clone(),
-			#[cfg(feature = "async-backing")]
 			backend.clone(),
 			block_import,
 			prometheus_registry.as_ref(),
@@ -352,7 +342,7 @@ fn build_import_queue(
 
 fn start_consensus(
 	client: Arc<ParachainClient>,
-	#[cfg(feature = "async-backing")] backend: Arc<ParachainBackend>,
+	backend: Arc<ParachainBackend>,
 	block_import: ParachainBlockImport,
 	prometheus_registry: Option<&Registry>,
 	telemetry: Option<TelemetryHandle>,
@@ -367,9 +357,6 @@ fn start_consensus(
 	overseer_handle: OverseerHandle,
 	announce_block: Arc<dyn Fn(Hash, Option<Vec<u8>>) + Send + Sync>,
 ) -> Result<(), sc_service::Error> {
-	#[cfg(not(feature = "async-backing"))]
-	use cumulus_client_consensus_aura::collators::basic::{self as basic_aura, Params};
-	#[cfg(feature = "async-backing")]
 	use cumulus_client_consensus_aura::collators::lookahead::{self as aura, Params};
 	// NOTE: because we use Aura here explicitly, we can use
 	// `CollatorSybilResistance::Resistant` when starting the network.
@@ -392,14 +379,9 @@ fn start_consensus(
 	let params = Params {
 		create_inherent_data_providers: move |_, ()| async move { Ok(()) },
 		block_import,
-		#[cfg(not(feature = "async-backing"))]
-		para_client: client,
-		#[cfg(feature = "async-backing")]
 		para_client: client.clone(),
-		#[cfg(feature = "async-backing")]
 		para_backend: backend,
 		relay_client: relay_chain_interface,
-		#[cfg(feature = "async-backing")]
 		code_hash_provider: move |block_hash| client.code_at(block_hash).ok().map(ValidationCode).map(|c| c.hash()),
 		sync_oracle,
 		keystore,
@@ -410,21 +392,13 @@ fn start_consensus(
 		relay_chain_slot_duration,
 		proposer,
 		collator_service,
-		// Very limited proposal time.
-		#[cfg(not(feature = "async-backing"))]
-		authoring_duration: Duration::from_millis(500),
-		#[cfg(feature = "async-backing")]
+		// Very limited proposal time, since we are not allowing async-backing, yet.
 		authoring_duration: Duration::from_millis(500), //  500ms as the not async-backing one at the moment
-		#[cfg(not(feature = "async-backing"))]
-		collation_request_receiver: None,
 		// Added in polkadot-sdk-v1.7.0
 		// #[cfg(feature = "async-backing")]
 		// reinitialize: false,
 	};
 
-	#[cfg(not(feature = "async-backing"))]
-	let fut = basic_aura::run::<Block, sp_consensus_aura::sr25519::AuthorityPair, _, _, _, _, _, _, _>(params);
-	#[cfg(feature = "async-backing")]
 	let fut = aura::run::<Block, sp_consensus_aura::sr25519::AuthorityPair, _, _, _, _, _, _, _, _, _>(params);
 	task_manager.spawn_essential_handle().spawn("aura", None, fut);
 

--- a/pallets/polimec-receiver/Cargo.toml
+++ b/pallets/polimec-receiver/Cargo.toml
@@ -50,6 +50,7 @@ std = [
 	"frame-benchmarking/std",
 	"frame-support/std",
 	"frame-system/std",
+	"log/std",
 	"polimec-common/std",
 	"polkadot-parachain-primitives/std",
 	"polkadot-runtime-parachains/std",

--- a/runtimes/polimec/Cargo.toml
+++ b/runtimes/polimec/Cargo.toml
@@ -94,6 +94,7 @@ cumulus-pallet-session-benchmarking.workspace = true
 cumulus-pallet-xcm.workspace = true
 cumulus-pallet-xcmp-queue.workspace = true
 cumulus-primitives-core.workspace = true
+cumulus-primitives-aura.workspace = true
 cumulus-primitives-utility.workspace = true
 parachain-info.workspace = true
 parachains-common.workspace = true
@@ -116,6 +117,7 @@ std = [
 	"cumulus-pallet-session-benchmarking/std",
 	"cumulus-pallet-xcm/std",
 	"cumulus-pallet-xcmp-queue/std",
+	"cumulus-primitives-aura/std",
 	"cumulus-primitives-core/std",
 	"cumulus-primitives-utility/std",
 	"frame-benchmarking?/std",

--- a/runtimes/politest/Cargo.toml
+++ b/runtimes/politest/Cargo.toml
@@ -294,4 +294,3 @@ try-runtime = [
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller, like logging for example.
 on-chain-release-build = [ "sp-api/disable-logging" ]
-async-backing = []

--- a/runtimes/politest/src/lib.rs
+++ b/runtimes/politest/src/lib.rs
@@ -18,10 +18,7 @@
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
 
-#[cfg(feature = "async-backing")]
 use cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
-#[cfg(not(feature = "async-backing"))]
-use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
 use cumulus_primitives_core::{AggregateMessageOrigin, ChannelStatus, ParaId};
 use frame_support::{
 	construct_runtime,
@@ -433,9 +430,6 @@ type ConsensusHook = cumulus_pallet_aura_ext::FixedVelocityConsensusHook<
 >;
 
 impl cumulus_pallet_parachain_system::Config for Runtime {
-	#[cfg(not(feature = "async-backing"))]
-	type CheckAssociatedRelayNumber = RelayNumberStrictlyIncreases;
-	#[cfg(feature = "async-backing")]
 	type CheckAssociatedRelayNumber = RelayNumberMonotonicallyIncreases;
 	type ConsensusHook = ConsensusHook;
 	type DmpQueue = frame_support::traits::EnqueueWithOrigin<MessageQueue, RelayOrigin>;
@@ -1233,7 +1227,6 @@ impl_runtime_apis! {
 		}
 	}
 
-	#[cfg(feature = "async-backing")]
 	impl cumulus_primitives_aura::AuraUnincludedSegmentApi<Block> for Runtime {
 		fn can_build_upon(
 			included_hash: <Block as BlockT>::Hash,

--- a/runtimes/shared-configuration/Cargo.toml
+++ b/runtimes/shared-configuration/Cargo.toml
@@ -55,6 +55,7 @@ std = [
 	"pallet-treasury?/std",
 	"parachains-common/std",
 	"parity-scale-codec/std",
+	"polimec-common/std",
 	"scale-info/std",
 	"sp-arithmetic/std",
 	"sp-runtime/std",
@@ -69,6 +70,7 @@ runtime-benchmarks = [
 	"pallet-parachain-staking/runtime-benchmarks",
 	"pallet-treasury/runtime-benchmarks",
 	"parachains-common/runtime-benchmarks",
+	"polimec-common/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 ]
 try-runtime = [
@@ -81,5 +83,6 @@ try-runtime = [
 	"pallet-parachain-staking/try-runtime",
 	"pallet-transaction-payment/try-runtime",
 	"pallet-treasury?/try-runtime",
+	"polimec-common/try-runtime",
 	"sp-runtime/try-runtime",
 ]

--- a/scripts/zombienet/native/local-testnet.toml
+++ b/scripts/zombienet/native/local-testnet.toml
@@ -4,7 +4,7 @@ provider = "native"
 
 # Using Rococo 1.7.0 as relay.
 [relaychain]
-default_command = "/usr/local/bin/polkadot"
+default_command = "./bin/polkadot"
 chain = "rococo-local"
 
 [[relaychain.nodes]]
@@ -21,7 +21,7 @@ name = "dave"
 
 [[parachains]]
 id = 3344
-chain = "politest-local"
+chain = "polimec-local"
 
 [[parachains.collators]]
 name = "alice"


### PR DESCRIPTION
## What

Promote the code behind the `async-backing` feature to production. More context [in the wiki](https://wiki.polkadot.network/docs/maintain-guides-async-backing). 

## Why?

After async-backing was enabled on Polkadot ([Referendum 688](https://polkadot.polkassembly.io/referenda/688)), collators began reporting a few instances of panics while collating:

```
polimec-node[739]: ====================
polimec-node[739]: Version: 0.6.0-ced567ba1bb
polimec-node[739]:    0: sp_panic_handler::set::{{closure}}
polimec-node[739]:    1: std::panicking::rust_panic_with_hook
polimec-node[739]:    2: std::panicking::begin_panic_handler::{{closure}}
polimec-node[739]:    3: std::sys_common::backtrace::__rust_end_short_backtrace
polimec-node[739]:    4: rust_begin_unwind
polimec-node[739]:    5: core::panicking::panic_fmt
polimec-node[739]:    6: cumulus_pallet_parachain_system::pallet::Pallet<T>::set_validation_data::{{closure}}
polimec-node[739]:    7: <cumulus_pallet_parachain_system::pallet::Call<T> as frame_support::traits::dispatch::UnfilteredDispatchable>::dispatch_bypass_filter::{{closure}}
polimec-node[739]:    8: <polimec_runtime::RuntimeCall as frame_support::traits::dispatch::UnfilteredDispatchable>::dispatch_bypass_filter
polimec-node[739]:    9: <polimec_runtime::RuntimeCall as sp_runtime::traits::Dispatchable>::dispatch
polimec-node[739]:   10: frame_executive::Executive<System,Block,Context,UnsignedValidator,AllPalletsWithSystem,COnRuntimeUpgrade>::apply_extrinsic
polimec-node[739]:   11: sc_executor::executor::WasmExecutor<H>::with_instance::{{closure}}
polimec-node[739]:   12: <sc_executor::executor::NativeElseWasmExecutor<D> as sp_core::traits::CodeExecutor>::call
polimec-node[739]:   13: sp_state_machine::execution::StateMachine<B,H,Exec>::execute
polimec-node[739]:   14: <sc_service::client::client::Client<B,E,Block,RA> as sp_api::CallApiAt<Block>>::call_api_at
polimec-node[739]:   15: <polimec_runtime::RuntimeApiImpl<__SrApiBlock__,RuntimeApiImplCall> as sp_api::Core<__SrApiBlock__>>::__runtime_api_internal_call_api_at
polimec-node[739]:   16: sp_block_builder::BlockBuilder::apply_extrinsic
polimec-node[739]:   17: sc_block_builder::BlockBuilder<Block,C>::push
polimec-node[739]:   18: sc_basic_authorship::basic_authorship::Proposer<Block,C,A,PR>::propose_with::{{closure}}
polimec-node[739]:   19: <sc_basic_authorship::basic_authorship::Proposer<Block,C,A,PR> as sp_consensus::Proposer<Block>>::propose::{{closure}}
polimec-node[739]:   20: <tracing_futures::Instrumented<T> as core::future::future::Future>::poll
polimec-node[739]:   21: tokio::runtime::task::raw::poll
polimec-node[739]:   22: std::sys_common::backtrace::__rust_begin_short_backtrace
polimec-node[739]:   23: core::ops::function::FnOnce::call_once{{vtable.shim}}
polimec-node[739]:   24: std::sys::unix::thread::Thread::new::thread_start
polimec-node[739]:   25: <unknown>
polimec-node[739]:   26: <unknown>
polimec-node[739]: Thread 'tokio-runtime-worker' panicked at 'no space left for the block in the unincluded segment', /home/admin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cumulus-pallet-parachain-system-0.7.0/src/lib.rs:1339
polimec-node[739]: This is a bug. Please report it at:
polimec-node[739]:         https://github.com/Polimec/polimec-node/issues/new
polimec-node[739]: ====================
polimec-node[739]: Version: 0.6.0-ced567ba1bb
polimec-node[739]:    0: sp_panic_handler::set::{{closure}}
polimec-node[739]:    1: std::panicking::rust_panic_with_hook
polimec-node[739]:    2: std::panicking::begin_panic_handler::{{closure}}
polimec-node[739]:    3: std::sys_common::backtrace::__rust_end_short_backtrace
polimec-node[739]:    4: rust_begin_unwind
polimec-node[739]:    5: core::panicking::panic_fmt
polimec-node[739]:    6: core::option::expect_failed
polimec-node[739]:    7: <cumulus_pallet_parachain_system::pallet::Pallet<T> as frame_support::traits::hooks::Hooks<<<<T as frame_system::pallet::Config>::Block as sp_runtime::traits::HeaderProvider>::HeaderT as sp_runtime::traits::Header>::Number>>::on_finalize
polimec-node[739]:    8: <(TupleElement0,TupleElement1,TupleElement2,TupleElement3,TupleElement4,TupleElement5,TupleElement6,TupleElement7,TupleElement8,TupleElement9,TupleElement10,TupleElement11,TupleElement12,TupleElement13,TupleElement14,TupleElement15,TupleElement16,TupleElement17,TupleElement18,TupleElement19,TupleElement20,TupleElement21,TupleElement22,TupleElement23,TupleElement24,TupleElement25,TupleElement26,TupleElemeTupleElement28,TupleElement29,TupleElement30,TupleElement31) as frame_support::traits::hooks::OnFinalize<BlockNumber>>::on_finalize
polimec-node[739]:    9: <polimec_runtime::Runtime as sp_block_builder::runtime_decl_for_block_builder::BlockBuilderV6<sp_runtime::generic::block::Block<sp_runtime::generic::header::Header<u32,sp_runtime::traits::BlakeTwo256>,sp_runtime::generic::unchecked_extrinsic::UncheckedExtrinsic<sp_runtime::multiaddress::MultiAddress<<<sp_runtime::MultiSignature as sp_runtime::traits::Verify>::Signer as sp_runtime::traits::IdentifyAccountcountId,()>,polimec_runtime::RuntimeCall,sp_runtime::MultiSignature,(frame_system::extensions::check_non_zero_sender::CheckNonZeroSender<polimec_runtime::Runtime>,frame_system::extensions::check_spec_version::CheckSpecVersion<polimec_runtime::Runtime>,frame_system::extensions::check_tx_version::CheckTxVersion<polimec_runtime::Runtime>,frame_system::extensions::check_genesis::CheckGenesis<polimec_runtime::Runtime>,frame_system::extensions::check_mortality::CheckMortalolimec_runtime::Runtime>,frame_system::extensions::check_nonce::CheckNonce<polimec_runtime::Runtime>,frame_system::extensions::check_weight::CheckWeight<polimec_runtime::Runtime>,pallet_transaction_payment::ChargeTransactionPayment<polimec_runtime::Runtime>)>>>>::finalize_block
polimec-node[739]:   10: sc_executor::executor::WasmExecutor<H>::with_instance::{{closure}}
polimec-node[739]:   11: <sc_executor::executor::NativeElseWasmExecutor<D> as sp_core::traits::CodeExecutor>::call
polimec-node[739]:   12: sp_state_machine::execution::StateMachine<B,H,Exec>::execute
polimec-node[739]:   13: <sc_service::client::client::Client<B,E,Block,RA> as sp_api::CallApiAt<Block>>::call_api_at
polimec-node[739]:   14: <polimec_runtime::RuntimeApiImpl<__SrApiBlock__,RuntimeApiImplCall> as sp_api::Core<__SrApiBlock__>>::__runtime_api_internal_call_api_at
polimec-node[739]:   15: sc_basic_authorship::basic_authorship::Proposer<Block,C,A,PR>::propose_with::{{closure}}
polimec-node[739]:   16: <sc_basic_authorship::basic_authorship::Proposer<Block,C,A,PR> as sp_consensus::Proposer<Block>>::propose::{{closure}}
polimec-node[739]:   17: <tracing_futures::Instrumented<T> as core::future::future::Future>::poll
polimec-node[739]:   18: tokio::runtime::task::raw::poll
polimec-node[739]:   19: std::sys_common::backtrace::__rust_begin_short_backtrace
polimec-node[739]:   20: core::ops::function::FnOnce::call_once{{vtable.shim}}
polimec-node[739]:   21: std::sys::unix::thread::Thread::new::thread_start
polimec-node[739]:   22: <unknown>
polimec-node[739]:   23: <unknown>
polimec-node[739]: Thread 'tokio-runtime-worker' panicked at 'set_validation_data inherent needs to be present in every block!', /home/admin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cumulus-pallet-parachain-system-0.7.0/src/lib.rs:265
polimec-node[739]: This is a bug. Please report it at:
polimec-node[739]:         https://github.com/Polimec/polimec-node/issues/new
polimec-node[739]: 2024-05-10 11:22:48 [Relaychain] ✨ Imported #20711607 (0x6b15…9036)
polimec-node[739]: 2024-05-10 11:22:48 [Parachain] 🙌 Starting consensus session on top of parent 0xb5968f4b49e642d8459a23b7eb9ca059d9c7e166e1cda35400b3e4a1da4a2749
polimec-node[739]: 2024-05-10 11:22:48 [Parachain] Evicting failed runtime instance error=Runtime panicked: no space left for the block in the unincluded segment
polimec-node[739]: 2024-05-10 11:22:48 [Parachain] 1 storage transactions are left open by the runtime. Those will be rolled back.
polimec-node[739]: 2024-05-10 11:22:48 [Parachain] 1 storage transactions are left open by the runtime. Those will be rolled back.
polimec-node[739]: 2024-05-10 11:22:48 [Parachain] ❗️ Inherent extrinsic returned unexpected error: Error at calling runtime api: Execution failed: Runtime panicked: no space left for the block in the unincluded segment. Dropping.
```

## Testing

When we released [version 0.6.0](https://github.com/Polimec/polimec-node/releases/tag/v0.6.0), we included an "experimental" version of the node compiled with the `async-backing` feature. Several collators have already used it to produce blocks after the activation of async-backing, and they reported no issues. Additionally, our RPC and the two collators have been compiled with this branch, and they no longer experience any panic after we started using this new version.