### PR TITLE
🐛 Payout funding assets to destination account

### DIFF
--- a/pallets/funding/src/settlement.rs
+++ b/pallets/funding/src/settlement.rs
@@ -102,6 +102,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	pub fn do_settle_successful_bid(bid: BidInfoOf<T>, project_id: ProjectId) -> DispatchResult {
+		let project_metadata = ProjectsMetadata::<T>::get(project_id).ok_or(Error::<T>::ProjectMetadataNotFound)?;
 		let project_details = ProjectsDetails::<T>::get(project_id).ok_or(Error::<T>::ProjectDetailsNotFound)?;
 
 		ensure!(project_details.status == ProjectStatus::FundingSuccessful, Error::<T>::IncorrectRound);
@@ -138,7 +139,7 @@ impl<T: Config> Pallet<T> {
 		// Payout the bid funding asset amount to the project account
 		Self::release_funding_asset(
 			project_id,
-			&project_details.issuer_account,
+			&project_metadata.funding_destination_account,
 			bid.funding_asset_amount_locked,
 			bid.funding_asset,
 		)?;
@@ -188,6 +189,7 @@ impl<T: Config> Pallet<T> {
 		contribution: ContributionInfoOf<T>,
 		project_id: ProjectId,
 	) -> DispatchResult {
+		let project_metadata = ProjectsMetadata::<T>::get(project_id).ok_or(Error::<T>::ProjectMetadataNotFound)?;
 		let project_details = ProjectsDetails::<T>::get(project_id).ok_or(Error::<T>::ProjectDetailsNotFound)?;
 		// Ensure that:
 		// 1. The project is in the FundingSuccessful state
@@ -221,7 +223,7 @@ impl<T: Config> Pallet<T> {
 		// Payout the bid funding asset amount to the project account
 		Self::release_funding_asset(
 			project_id,
-			&project_details.issuer_account,
+			&project_metadata.funding_destination_account,
 			contribution.funding_asset_amount,
 			contribution.funding_asset,
 		)?;

--- a/pallets/funding/src/tests/7_settlement.rs
+++ b/pallets/funding/src/tests/7_settlement.rs
@@ -10,6 +10,7 @@ fn can_settle_accepted_project() {
 
 	inst.settle_project(project_id).unwrap();
 
+	inst.assert_total_funding_paid_out(project_id, bids.clone(), contributions.clone());
 	inst.assert_evaluations_migrations_created(project_id, evaluations, percentage);
 	inst.assert_bids_migrations_created(project_id, bids, true);
 	inst.assert_contributions_migrations_created(project_id, contributions, true);


### PR DESCRIPTION
## What?
- Change account for the payout of funding assets to funding destination account instead of issuer account.

## Why?
- We weren't using the funding destination account as intended

## How?
- on the settle successful bid and successful contribution functions, change the payout account

## Testing?
- Added a new instantiator function `assert_total_funding_paid_out` which is now used on the settlement test `can_settle_accepted_project`