### PR TITLE
 ⚡️ Improve phase transition points and fix instant-mode 

### DIFF
--- a/pallets/funding/src/functions.rs
+++ b/pallets/funding/src/functions.rs
@@ -85,9 +85,9 @@ impl<T: Config> Pallet<T> {
 		ensure!(project_metadata.policy_ipfs_cid.is_some(), Error::<T>::CidNotProvided);
 
 		// * Calculate new variables *
-		let evaluation_end_block = now + T::EvaluationDuration::get();
+		let evaluation_end_block = now.saturating_add(T::EvaluationDuration::get()).saturating_sub(One::one());
 		project_details.phase_transition_points.application.update(None, Some(now));
-		project_details.phase_transition_points.evaluation.update(Some(now + 1u32.into()), Some(evaluation_end_block));
+		project_details.phase_transition_points.evaluation.update(Some(now), Some(evaluation_end_block));
 		project_details.is_frozen = true;
 		project_details.status = ProjectStatus::EvaluationRound;
 
@@ -162,9 +162,10 @@ impl<T: Config> Pallet<T> {
 		let usd_total_amount_bonded = project_details.evaluation_round_info.total_bonded_usd;
 		let evaluation_target_usd = <T as Config>::EvaluationSuccessThreshold::get() * fundraising_target_usd;
 
-		let auction_initialize_period_start_block = now + 1u32.into();
-		let auction_initialize_period_end_block =
-			auction_initialize_period_start_block + T::AuctionInitializePeriodDuration::get();
+		let auction_initialize_period_start_block = now;
+		let auction_initialize_period_end_block = auction_initialize_period_start_block
+			.saturating_add(T::AuctionInitializePeriodDuration::get())
+			.saturating_sub(One::one());
 
 		// Check which logic path to follow
 		let is_funded = usd_total_amount_bonded >= evaluation_target_usd;
@@ -267,8 +268,8 @@ impl<T: Config> Pallet<T> {
 		ensure!(project_details.status == ProjectStatus::AuctionInitializePeriod, Error::<T>::IncorrectRound);
 
 		// * Calculate new variables *
-		let opening_start_block = now + 1u32.into();
-		let opening_end_block = now + T::AuctionOpeningDuration::get();
+		let opening_start_block = now;
+		let opening_end_block = now.saturating_add(T::AuctionOpeningDuration::get()).saturating_sub(One::one());
 
 		// * Update Storage *
 		project_details
@@ -340,8 +341,8 @@ impl<T: Config> Pallet<T> {
 		ensure!(project_details.status == ProjectStatus::AuctionOpening, Error::<T>::IncorrectRound);
 
 		// * Calculate new variables *
-		let closing_start_block = now + 1u32.into();
-		let closing_end_block = now + T::AuctionClosingDuration::get();
+		let closing_start_block = now;
+		let closing_end_block = now.saturating_add(T::AuctionClosingDuration::get()).saturating_sub(One::one());
 
 		// * Update Storage *
 		project_details
@@ -407,8 +408,8 @@ impl<T: Config> Pallet<T> {
 
 		// * Calculate new variables *
 		let end_block = Self::select_random_block(auction_closing_start_block, auction_closing_end_block);
-		let community_start_block = now + 1u32.into();
-		let community_end_block = now + T::CommunityFundingDuration::get();
+		let community_start_block = now;
+		let community_end_block = now.saturating_add(T::CommunityFundingDuration::get()).saturating_sub(One::one());
 		// * Update Storage *
 		let calculation_result = Self::calculate_weighted_average_price(
 			project_id,
@@ -495,8 +496,8 @@ impl<T: Config> Pallet<T> {
 		);
 
 		// * Calculate new variables *
-		let remainder_start_block = now + 1u32.into();
-		let remainder_end_block = now + T::RemainderFundingDuration::get();
+		let remainder_start_block = now;
+		let remainder_end_block = now.saturating_add(T::RemainderFundingDuration::get()).saturating_sub(One::one());
 
 		// * Update Storage *
 		project_details

--- a/pallets/funding/src/mock.rs
+++ b/pallets/funding/src/mock.rs
@@ -290,14 +290,15 @@ pub const HOURS: BlockNumber = 300u64;
 
 // REMARK: In the production configuration we use DAYS instead of HOURS.
 parameter_types! {
-	pub const EvaluationDuration: BlockNumber = (28 * HOURS) as BlockNumber;
-	pub const AuctionInitializePeriodDuration: BlockNumber = (7 * HOURS) as BlockNumber;
-	pub const AuctionOpeningDuration: BlockNumber = (2 * HOURS) as BlockNumber;
-	pub const AuctionClosingDuration: BlockNumber = (3 * HOURS) as BlockNumber;
-	pub const CommunityRoundDuration: BlockNumber = (5 * HOURS) as BlockNumber;
-	pub const RemainderFundingDuration: BlockNumber = (1 * HOURS) as BlockNumber;
-	pub const ManualAcceptanceDuration: BlockNumber = (3 * HOURS) as BlockNumber;
-	pub const SuccessToSettlementTime: BlockNumber =(4 * HOURS) as BlockNumber;
+	pub const EvaluationDuration: BlockNumber = 3u64;
+	pub const AuctionInitializePeriodDuration: BlockNumber = 3u64;
+	pub const AuctionOpeningDuration: BlockNumber = 3u64;
+	pub const AuctionClosingDuration: BlockNumber = 3u64;
+	pub const CommunityRoundDuration: BlockNumber = 3u64;
+	pub const RemainderFundingDuration: BlockNumber = 3u64;
+	pub const ManualAcceptanceDuration: BlockNumber = 3u64;
+	pub const SuccessToSettlementTime: BlockNumber = 3u64;
+
 	pub const FundingPalletId: PalletId = PalletId(*b"py/cfund");
 	pub FeeBrackets: Vec<(Percent, Balance)> = vec![
 		(Percent::from_percent(10), 1_000_000 * USD_UNIT),

--- a/pallets/funding/src/tests/2_evaluation.rs
+++ b/pallets/funding/src/tests/2_evaluation.rs
@@ -305,8 +305,8 @@ mod start_evaluation_extrinsic {
 				phase_transition_points: PhaseTransitionPoints {
 					application: BlockNumberPair { start: Some(1u64), end: Some(1u64) },
 					evaluation: BlockNumberPair {
-						start: Some(2u64),
-						end: Some(1u64 + <TestRuntime as Config>::EvaluationDuration::get()),
+						start: Some(1u64),
+						end: Some(<TestRuntime as Config>::EvaluationDuration::get()),
 					},
 					auction_initialize_period: BlockNumberPair { start: None, end: None },
 					auction_opening: BlockNumberPair { start: None, end: None },

--- a/pallets/funding/src/tests/4_community.rs
+++ b/pallets/funding/src/tests/4_community.rs
@@ -760,7 +760,7 @@ mod community_contribute_extrinsic {
 			inst.bid_for_users(project_id, successful_bids).unwrap();
 			inst.advance_time(
 				<TestRuntime as Config>::AuctionOpeningDuration::get() +
-					<TestRuntime as Config>::AuctionClosingDuration::get() +
+					<TestRuntime as Config>::AuctionClosingDuration::get() -
 					1,
 			)
 			.unwrap();

--- a/pallets/funding/src/tests/6_funding_end.rs
+++ b/pallets/funding/src/tests/6_funding_end.rs
@@ -56,6 +56,7 @@ fn automatic_acceptance_on_manual_decision_after_time_delta() {
 	let project_id = project_id;
 	inst.advance_time(1u64 + <TestRuntime as Config>::ManualAcceptanceDuration::get()).unwrap();
 	assert_eq!(inst.get_project_details(project_id).status, ProjectStatus::FundingSuccessful);
+	dbg!(inst.get_project_details(project_id));
 	inst.advance_time(<TestRuntime as Config>::SuccessToSettlementTime::get()).unwrap();
 
 	inst.test_ct_created_for(project_id);


### PR DESCRIPTION
## What?
- Fix instant-mode benchmarks
- Improve dry-run-benches just command
- Improve phase transition points

## Why?
- The calculation on the instantiator was inaccurate because the phase transition points were 1 block off
- Just command can now run for a specific mode and runtime

## How?
- Now the start block of a state is the same block where on_initialize is called. Before it was the next block, even though the current one was still possible to call the extrinsics for that state

## Testing?
`just dry-run-benchmarks instant-mode`

