### PR TITLE
✨ Optimize wap calculation

### DIFF
--- a/pallets/funding/src/benchmarking.rs
+++ b/pallets/funding/src/benchmarking.rs
@@ -47,7 +47,7 @@ pub fn usdt_id() -> u32 {
 	AcceptedFundingAsset::USDT.to_assethub_id()
 }
 
-pub fn default_project<T: Config>(issuer: AccountIdOf<T>) -> ProjectMetadataOf<T>
+pub fn default_project_metadata<T: Config>(issuer: AccountIdOf<T>) -> ProjectMetadataOf<T>
 where
 	T::Price: From<u128>,
 	T::Hash: From<H256>,
@@ -105,7 +105,7 @@ where
 {
 	let threshold = <T as Config>::EvaluationSuccessThreshold::get();
 	let default_project_metadata: ProjectMetadataOf<T> =
-		default_project::<T>(account::<AccountIdOf<T>>("issuer", 0, 0));
+		default_project_metadata::<T>(account::<AccountIdOf<T>>("issuer", 0, 0));
 	let funding_target =
 		default_project_metadata.minimum_price.saturating_mul_int(default_project_metadata.total_allocation_size);
 	let evaluation_target = threshold * funding_target;
@@ -132,7 +132,7 @@ where
 	<T as Config>::Balance: From<u128>,
 	T::Hash: From<H256>,
 {
-	let default_project_metadata = default_project::<T>(account::<AccountIdOf<T>>("issuer", 0, 0));
+	let default_project_metadata = default_project_metadata::<T>(account::<AccountIdOf<T>>("issuer", 0, 0));
 	let auction_funding_target = default_project_metadata.minimum_price.saturating_mul_int(
 		default_project_metadata.auction_round_allocation_percentage * default_project_metadata.total_allocation_size,
 	);
@@ -155,7 +155,7 @@ where
 	T::Hash: From<H256>,
 {
 	let inst = BenchInstantiator::<T>::new(None);
-	let default_project = default_project::<T>(account::<AccountIdOf<T>>("issuer", 0, 0));
+	let default_project = default_project_metadata::<T>(account::<AccountIdOf<T>>("issuer", 0, 0));
 	let total_ct_for_bids = default_project.auction_round_allocation_percentage * default_project.total_allocation_size;
 	let total_usd_for_bids = default_project.minimum_price.checked_mul_int(total_ct_for_bids).unwrap();
 	inst.generate_bids_from_total_usd(
@@ -174,7 +174,7 @@ where
 	T::Hash: From<H256>,
 {
 	let inst = BenchInstantiator::<T>::new(None);
-	let default_project_metadata = default_project::<T>(account::<AccountIdOf<T>>("issuer", 0, 0));
+	let default_project_metadata = default_project_metadata::<T>(account::<AccountIdOf<T>>("issuer", 0, 0));
 
 	let funding_target =
 		default_project_metadata.minimum_price.saturating_mul_int(default_project_metadata.total_allocation_size);
@@ -200,7 +200,7 @@ where
 	T::Hash: From<H256>,
 {
 	let inst = BenchInstantiator::<T>::new(None);
-	let default_project_metadata = default_project::<T>(account::<AccountIdOf<T>>("issuer", 0, 0));
+	let default_project_metadata = default_project_metadata::<T>(account::<AccountIdOf<T>>("issuer", 0, 0));
 
 	let funding_target =
 		default_project_metadata.minimum_price.saturating_mul_int(default_project_metadata.total_allocation_size);
@@ -316,7 +316,7 @@ where
 			let issuer = string_account::<AccountIdOf<T>>(issuer_name, 0, 0);
 			TestProjectParams::<T> {
 				expected_state: state,
-				metadata: default_project::<T>(issuer.clone()),
+				metadata: default_project_metadata::<T>(issuer.clone()),
 				issuer: issuer.clone(),
 				evaluations: default_evaluations::<T>(),
 				bids: default_bids::<T>(),
@@ -382,7 +382,7 @@ mod benchmarks {
 
 		let issuer = account::<AccountIdOf<T>>("issuer", 0, 0);
 		whitelist_account!(issuer);
-		let project_metadata = default_project::<T>(issuer.clone());
+		let project_metadata = default_project_metadata::<T>(issuer.clone());
 
 		let metadata_deposit = T::ContributionTokenCurrency::calc_metadata_deposit(
 			project_metadata.token_information.name.as_slice(),
@@ -431,7 +431,7 @@ mod benchmarks {
 		let issuer = account::<AccountIdOf<T>>("issuer", 0, 0);
 		whitelist_account!(issuer);
 
-		let project_metadata = default_project::<T>(issuer.clone());
+		let project_metadata = default_project_metadata::<T>(issuer.clone());
 		let project_id = inst.create_new_project(project_metadata.clone(), issuer.clone());
 		let jwt = get_mock_jwt_with_cid(
 			issuer.clone(),
@@ -464,7 +464,7 @@ mod benchmarks {
 		let issuer_funding = account::<AccountIdOf<T>>("issuer_funding", 0, 0);
 		whitelist_account!(issuer);
 
-		let project_metadata = default_project::<T>(issuer.clone());
+		let project_metadata = default_project_metadata::<T>(issuer.clone());
 		let project_id = inst.create_new_project(project_metadata.clone(), issuer.clone());
 
 		let project_metadata = ProjectMetadataOf::<T> {
@@ -566,7 +566,7 @@ mod benchmarks {
 		let issuer = account::<AccountIdOf<T>>("issuer", 0, 0);
 		whitelist_account!(issuer);
 
-		let project_metadata = default_project::<T>(issuer.clone());
+		let project_metadata = default_project_metadata::<T>(issuer.clone());
 		let project_id = inst.create_new_project(project_metadata.clone(), issuer.clone());
 
 		// start_evaluation fn will try to add an automatic transition 1 block after the last evaluation block
@@ -619,7 +619,7 @@ mod benchmarks {
 		let issuer = account::<AccountIdOf<T>>("issuer", 0, 0);
 		whitelist_account!(issuer);
 
-		let project_metadata = default_project::<T>(issuer.clone());
+		let project_metadata = default_project_metadata::<T>(issuer.clone());
 		let project_id = inst.create_evaluating_project(project_metadata.clone(), issuer.clone());
 
 		let evaluations = default_evaluations();
@@ -679,7 +679,7 @@ mod benchmarks {
 		let test_evaluator = account::<AccountIdOf<T>>("evaluator", 0, 0);
 		whitelist_account!(test_evaluator);
 
-		let project_metadata = default_project::<T>(issuer.clone());
+		let project_metadata = default_project_metadata::<T>(issuer.clone());
 		let project_id = inst.create_evaluating_project(project_metadata.clone(), issuer);
 
 		let existing_evaluation = UserToUSDBalance::new(test_evaluator.clone(), (200 * USD_UNIT).into());
@@ -790,7 +790,7 @@ mod benchmarks {
 		let bidder = account::<AccountIdOf<T>>("bidder", 0, 0);
 		whitelist_account!(bidder);
 
-		let mut project_metadata = default_project::<T>(issuer.clone());
+		let mut project_metadata = default_project_metadata::<T>(issuer.clone());
 		project_metadata.mainnet_token_max_supply =
 			(100_000 * CT_UNIT).try_into().unwrap_or_else(|_| panic!("Failed to create BalanceOf"));
 		project_metadata.total_allocation_size =
@@ -1122,7 +1122,7 @@ mod benchmarks {
 		let contributor = account::<AccountIdOf<T>>("contributor", 0, 0);
 		whitelist_account!(contributor);
 
-		let project_metadata = default_project::<T>(issuer.clone());
+		let project_metadata = default_project_metadata::<T>(issuer.clone());
 
 		let project_id = inst.create_community_contributing_project(
 			project_metadata.clone(),
@@ -1412,7 +1412,7 @@ mod benchmarks {
 		let issuer = account::<AccountIdOf<T>>("issuer", 0, 0);
 		whitelist_account!(issuer);
 
-		let project_metadata = default_project::<T>(issuer.clone());
+		let project_metadata = default_project_metadata::<T>(issuer.clone());
 		let target_funding_amount: BalanceOf<T> =
 			project_metadata.minimum_price.saturating_mul_int(project_metadata.total_allocation_size);
 
@@ -1484,7 +1484,7 @@ mod benchmarks {
 		whitelist_account!(evaluator);
 
 		let project_id = inst.create_finished_project(
-			default_project::<T>(issuer.clone()),
+			default_project_metadata::<T>(issuer.clone()),
 			issuer,
 			evaluations,
 			default_bids::<T>(),
@@ -1546,7 +1546,7 @@ mod benchmarks {
 		let evaluator = evaluations[0].account.clone();
 		whitelist_account!(evaluator);
 
-		let project_metadata = default_project::<T>(issuer.clone());
+		let project_metadata = default_project_metadata::<T>(issuer.clone());
 		let target_funding_amount: BalanceOf<T> =
 			project_metadata.minimum_price.saturating_mul_int(project_metadata.total_allocation_size);
 
@@ -1629,7 +1629,7 @@ mod benchmarks {
 		whitelist_account!(bidder);
 
 		let project_id = inst.create_finished_project(
-			default_project::<T>(issuer.clone()),
+			default_project_metadata::<T>(issuer.clone()),
 			issuer,
 			default_evaluations::<T>(),
 			bids,
@@ -1672,7 +1672,7 @@ mod benchmarks {
 		let issuer = account::<AccountIdOf<T>>("issuer", 0, 0);
 		let evaluations = default_evaluations::<T>();
 
-		let project_metadata = default_project::<T>(issuer.clone());
+		let project_metadata = default_project_metadata::<T>(issuer.clone());
 		let target_funding_amount: BalanceOf<T> =
 			project_metadata.minimum_price.saturating_mul_int(project_metadata.total_allocation_size);
 
@@ -1734,7 +1734,7 @@ mod benchmarks {
 		whitelist_account!(contributor);
 
 		let project_id = inst.create_finished_project(
-			default_project::<T>(issuer.clone()),
+			default_project_metadata::<T>(issuer.clone()),
 			issuer,
 			default_evaluations::<T>(),
 			default_bids::<T>(),
@@ -1788,7 +1788,7 @@ mod benchmarks {
 		let issuer = account::<AccountIdOf<T>>("issuer", 0, 0);
 		let evaluations = default_evaluations::<T>();
 
-		let project_metadata = default_project::<T>(issuer.clone());
+		let project_metadata = default_project_metadata::<T>(issuer.clone());
 		let target_funding_amount: BalanceOf<T> =
 			project_metadata.minimum_price.saturating_mul_int(project_metadata.total_allocation_size);
 
@@ -1864,7 +1864,7 @@ mod benchmarks {
 		let issuer = account::<AccountIdOf<T>>("issuer", 0, 0);
 		whitelist_account!(issuer);
 
-		let project_metadata = default_project::<T>(issuer.clone());
+		let project_metadata = default_project_metadata::<T>(issuer.clone());
 		let project_id = inst.create_evaluating_project(project_metadata, issuer.clone());
 
 		let evaluations = default_evaluations();
@@ -1908,7 +1908,7 @@ mod benchmarks {
 		let issuer = account::<AccountIdOf<T>>("issuer", 0, 0);
 		whitelist_account!(issuer);
 
-		let project_metadata = default_project::<T>(issuer.clone());
+		let project_metadata = default_project_metadata::<T>(issuer.clone());
 		let project_id = inst.create_evaluating_project(project_metadata, issuer.clone());
 		let project_details = inst.get_project_details(project_id);
 
@@ -1969,7 +1969,7 @@ mod benchmarks {
 		let issuer = account::<AccountIdOf<T>>("issuer", 0, 0);
 		whitelist_account!(issuer);
 
-		let project_metadata = default_project::<T>(issuer.clone());
+		let project_metadata = default_project_metadata::<T>(issuer.clone());
 		let project_id = inst.create_auctioning_project(project_metadata, issuer.clone(), default_evaluations());
 
 		let opening_end_block =
@@ -1984,7 +1984,7 @@ mod benchmarks {
 
 		#[block]
 		{
-			Pallet::<T>::do_auction_closing(project_id).unwrap();
+			Pallet::<T>::do_start_auction_closing(project_id).unwrap();
 		}
 		// * validity checks *
 		// Storage
@@ -1997,16 +1997,14 @@ mod benchmarks {
 		);
 	}
 
-	// do_community_funding
-	// Should be complex due to calling `calculate_weighted_average_price`
 	#[benchmark]
-	fn start_community_funding(
+	fn end_auction_closing(
 		// Insertion attempts in add_to_update_store. Total amount of storage items iterated through in `ProjectsToUpdate`. Leave one free to make the fn succeed
 		x: Linear<1, { <T as Config>::MaxProjectsToUpdateInsertionAttempts::get() - 1 }>,
 		// Accepted Bids
-		y: Linear<0, { <T as Config>::MaxBidsPerProject::get() / 2 }>,
+		y: Linear<1, { <T as Config>::MaxBidsPerProject::get() / 2 }>,
 		// Failed Bids
-		z: Linear<0, { <T as Config>::MaxBidsPerProject::get() / 2 }>,
+		z: Linear<1, { <T as Config>::MaxBidsPerProject::get() / 2 }>,
 	) {
 		// * setup *
 		let mut inst = BenchInstantiator::<T>::new(None);
@@ -2015,67 +2013,46 @@ mod benchmarks {
 
 		let issuer = account::<AccountIdOf<T>>("issuer", 0, 0);
 		whitelist_account!(issuer);
-		let bounded_name = BoundedVec::try_from("Contribution Token TEST".as_bytes().to_vec()).unwrap();
-		let bounded_symbol = BoundedVec::try_from("CTEST".as_bytes().to_vec()).unwrap();
-		let metadata_hash = BoundedVec::try_from(IPFS_CID.as_bytes().to_vec()).unwrap();
 
-		let project_metadata = ProjectMetadata {
-			token_information: CurrencyMetadata { name: bounded_name, symbol: bounded_symbol, decimals: CT_DECIMALS },
-			mainnet_token_max_supply: BalanceOf::<T>::try_from(1_000_000 * CT_UNIT)
-				.unwrap_or_else(|_| panic!("Failed to create BalanceOf")),
-			total_allocation_size: BalanceOf::<T>::try_from(1_000_000 * CT_UNIT)
-				.unwrap_or_else(|_| panic!("Failed to create BalanceOf")),
-			auction_round_allocation_percentage: Percent::from_percent(50u8),
-			minimum_price: PriceProviderOf::<T>::calculate_decimals_aware_price(
-				10u128.into(),
-				USD_DECIMALS,
-				CT_DECIMALS,
-			)
-			.unwrap(),
-			bidding_ticket_sizes: BiddingTicketSizes {
-				professional: TicketSize::new(
-					BalanceOf::<T>::try_from(5000 * USD_UNIT).unwrap_or_else(|_| panic!("Failed to create BalanceOf")),
-					None,
-				),
-				institutional: TicketSize::new(
-					BalanceOf::<T>::try_from(5000 * USD_UNIT).unwrap_or_else(|_| panic!("Failed to create BalanceOf")),
-					None,
-				),
-				phantom: Default::default(),
-			},
-			contributing_ticket_sizes: ContributingTicketSizes {
-				retail: TicketSize::new(
-					BalanceOf::<T>::try_from(USD_UNIT).unwrap_or_else(|_| panic!("Failed to create BalanceOf")),
-					None,
-				),
-				professional: TicketSize::new(
-					BalanceOf::<T>::try_from(USD_UNIT).unwrap_or_else(|_| panic!("Failed to create BalanceOf")),
-					None,
-				),
-				institutional: TicketSize::new(
-					BalanceOf::<T>::try_from(USD_UNIT).unwrap_or_else(|_| panic!("Failed to create BalanceOf")),
-					None,
-				),
-				phantom: Default::default(),
-			},
-			participation_currencies: vec![AcceptedFundingAsset::USDT].try_into().unwrap(),
-			funding_destination_account: issuer.clone(),
-			policy_ipfs_cid: Some(metadata_hash.into()),
-		};
-		let project_id =
-			inst.create_auctioning_project(project_metadata.clone(), issuer.clone(), default_evaluations());
+		let mut project_metadata = default_project_metadata::<T>(issuer.clone());
+		project_metadata.mainnet_token_max_supply =
+			BalanceOf::<T>::try_from(10_000_000 * CT_UNIT).unwrap_or_else(|_| panic!("Failed to create BalanceOf"));
+		project_metadata.total_allocation_size =
+			BalanceOf::<T>::try_from(10_000_000 * CT_UNIT).unwrap_or_else(|_| panic!("Failed to create BalanceOf"));
+		project_metadata.auction_round_allocation_percentage = Percent::from_percent(100u8);
 
-		let accepted_bids = (0..y)
+		let project_id = inst.create_auctioning_project(
+			project_metadata.clone(),
+			issuer.clone(),
+			inst.generate_successful_evaluations(
+				project_metadata.clone(),
+				default_evaluators::<T>(),
+				default_weights(),
+			),
+		);
+
+		let auction_allocation =
+			project_metadata.auction_round_allocation_percentage * project_metadata.total_allocation_size;
+		let min_bid_amount = 500u128;
+		let smaller_than_wap_accepted_bid = vec![BidParams::<T>::new(
+			account::<AccountIdOf<T>>("bidder", 0, 0),
+			auction_allocation,
+			1u8,
+			AcceptedFundingAsset::USDT,
+		)];
+		let higher_than_wap_accepted_bids = (1..y)
 			.map(|i| {
 				BidParams::<T>::new(
 					account::<AccountIdOf<T>>("bidder", 0, i),
-					(500 * CT_UNIT).into(),
+					(min_bid_amount * CT_UNIT).into(),
 					1u8,
 					AcceptedFundingAsset::USDT,
 				)
 			})
 			.collect_vec();
 
+		let accepted_bids =
+			vec![smaller_than_wap_accepted_bid, higher_than_wap_accepted_bids].into_iter().flatten().collect_vec();
 		let rejected_bids = (0..z)
 			.map(|i| {
 				BidParams::<T>::new(
@@ -2087,7 +2064,7 @@ mod benchmarks {
 			})
 			.collect_vec();
 
-		let all_bids = accepted_bids.iter().chain(rejected_bids.iter()).cloned().collect_vec();
+		let all_bids = vec![accepted_bids.clone(), rejected_bids.clone()].into_iter().flatten().collect_vec();
 
 		let plmc_needed_for_bids = inst.calculate_auction_plmc_charged_from_all_bids_made_or_with_bucket(
 			&all_bids,
@@ -2112,12 +2089,150 @@ mod benchmarks {
 		inst.jump_to_block(transition_block);
 		let auction_closing_end_block =
 			inst.get_project_details(project_id).phase_transition_points.auction_closing.end().unwrap();
-		// we don't use advance time to avoid triggering on_initialize. This benchmark should only measure the fn
-		// weight and not the whole on_initialize call weight
-		frame_system::Pallet::<T>::set_block_number(auction_closing_end_block + One::one());
-		let now = inst.current_block();
+		// Go to the last block of closing auction, to make bids fail
+		frame_system::Pallet::<T>::set_block_number(auction_closing_end_block);
+		inst.bid_for_users(project_id, rejected_bids).unwrap();
 
-		let community_end_block = now + T::CommunityFundingDuration::get();
+		let now = inst.current_block();
+		let transition_block = now + One::one();
+		frame_system::Pallet::<T>::set_block_number(transition_block);
+
+		fill_projects_to_update::<T>(x, transition_block);
+
+		#[block]
+		{
+			Pallet::<T>::do_end_auction_closing(project_id).unwrap();
+		}
+
+		// * validity checks *
+		// Storage
+		let stored_details = ProjectsDetails::<T>::get(project_id).unwrap();
+		assert_eq!(stored_details.status, ProjectStatus::CalculatingWAP);
+		assert!(
+			stored_details.phase_transition_points.random_closing_ending.unwrap() <
+				stored_details.phase_transition_points.auction_closing.end().unwrap()
+		);
+		let accepted_bids_count = Bids::<T>::iter_prefix_values((project_id,))
+			.filter(|b| matches!(b.status, BidStatus::Accepted | BidStatus::PartiallyAccepted(..)))
+			.count();
+		let rejected_bids_count =
+			Bids::<T>::iter_prefix_values((project_id,)).filter(|b| matches!(b.status, BidStatus::Rejected(_))).count();
+		assert_eq!(rejected_bids_count, 0);
+		assert_eq!(accepted_bids_count, y as usize);
+
+		// Events
+		frame_system::Pallet::<T>::assert_last_event(
+			Event::<T>::ProjectPhaseTransition { project_id, phase: ProjectPhases::CalculatingWAP }.into(),
+		);
+	}
+
+	// do_community_funding
+	// Should be complex due to calling `calculate_weighted_average_price`
+	#[benchmark]
+	fn start_community_funding(
+		// Insertion attempts in add_to_update_store. Total amount of storage items iterated through in `ProjectsToUpdate`. Leave one free to make the fn succeed
+		x: Linear<1, { <T as Config>::MaxProjectsToUpdateInsertionAttempts::get() - 1 }>,
+		// Accepted Bids
+		y: Linear<1, { <T as Config>::MaxBidsPerProject::get() / 2 }>,
+		// Rejected Bids
+		z: Linear<1, { <T as Config>::MaxBidsPerProject::get() / 2 }>,
+	) {
+		// * setup *
+		let mut inst = BenchInstantiator::<T>::new(None);
+		// real benchmark starts at block 0, and we can't call `events()` at block 0
+		inst.advance_time(1u32.into()).unwrap();
+
+		let issuer = account::<AccountIdOf<T>>("issuer", 0, 0);
+		whitelist_account!(issuer);
+		let mut project_metadata = default_project_metadata::<T>(issuer.clone());
+
+		project_metadata.mainnet_token_max_supply =
+			BalanceOf::<T>::try_from(10_000_000 * CT_UNIT).unwrap_or_else(|_| panic!("Failed to create BalanceOf"));
+		project_metadata.total_allocation_size =
+			BalanceOf::<T>::try_from(10_000_000 * CT_UNIT).unwrap_or_else(|_| panic!("Failed to create BalanceOf"));
+		project_metadata.auction_round_allocation_percentage = Percent::from_percent(100u8);
+
+		let project_id = inst.create_auctioning_project(
+			project_metadata.clone(),
+			issuer.clone(),
+			inst.generate_successful_evaluations(
+				project_metadata.clone(),
+				default_evaluators::<T>(),
+				default_weights(),
+			),
+		);
+
+		let auction_allocation =
+			project_metadata.auction_round_allocation_percentage * project_metadata.total_allocation_size;
+		let min_bid_amount = 500u128;
+		let smaller_than_wap_accepted_bid = vec![BidParams::<T>::new(
+			account::<AccountIdOf<T>>("bidder", 0, 0),
+			auction_allocation,
+			1u8,
+			AcceptedFundingAsset::USDT,
+		)];
+		let higher_than_wap_accepted_bids = (1..y)
+			.map(|i| {
+				BidParams::<T>::new(
+					account::<AccountIdOf<T>>("bidder", 0, i),
+					(min_bid_amount * CT_UNIT).into(),
+					1u8,
+					AcceptedFundingAsset::USDT,
+				)
+			})
+			.collect_vec();
+
+		let accepted_bids =
+			vec![smaller_than_wap_accepted_bid, higher_than_wap_accepted_bids].into_iter().flatten().collect_vec();
+
+		let rejected_bids = (0..z)
+			.map(|i| {
+				BidParams::<T>::new(
+					account::<AccountIdOf<T>>("bidder", 0, i),
+					(500 * CT_UNIT).into(),
+					1u8,
+					AcceptedFundingAsset::USDT,
+				)
+			})
+			.collect_vec();
+
+		let all_bids = vec![accepted_bids.clone(), rejected_bids.clone()].into_iter().flatten().collect_vec();
+
+		let plmc_needed_for_bids = inst.calculate_auction_plmc_charged_from_all_bids_made_or_with_bucket(
+			&all_bids,
+			project_metadata.clone(),
+			None,
+		);
+		let plmc_ed = all_bids.accounts().existential_deposits();
+		let funding_asset_needed_for_bids = inst
+			.calculate_auction_funding_asset_charged_from_all_bids_made_or_with_bucket(
+				&all_bids,
+				project_metadata.clone(),
+				None,
+			);
+
+		inst.mint_plmc_to(plmc_needed_for_bids);
+		inst.mint_plmc_to(plmc_ed);
+		inst.mint_foreign_asset_to(funding_asset_needed_for_bids);
+
+		inst.bid_for_users(project_id, accepted_bids).unwrap();
+
+		let transition_block = inst.get_update_block(project_id, &UpdateType::AuctionClosingStart).unwrap();
+		inst.jump_to_block(transition_block);
+		let auction_closing_end_block =
+			inst.get_project_details(project_id).phase_transition_points.auction_closing.end().unwrap();
+		// Go to the last block of closing auction, to make bids fail
+		frame_system::Pallet::<T>::set_block_number(auction_closing_end_block);
+		inst.bid_for_users(project_id, rejected_bids).unwrap();
+
+		let transition_block = inst.get_update_block(project_id, &UpdateType::AuctionClosingEnd).unwrap();
+		inst.jump_to_block(transition_block);
+		let transition_block = inst.get_update_block(project_id, &UpdateType::CommunityFundingStart).unwrap();
+		// Block is at automatic transition, but it's not run with on_initialize, we do it manually
+		frame_system::Pallet::<T>::set_block_number(transition_block);
+
+		let now = inst.current_block();
+		let community_end_block = now + T::CommunityFundingDuration::get() - One::one();
 
 		let insertion_block_number = community_end_block + One::one();
 		fill_projects_to_update::<T>(x, insertion_block_number);
@@ -2131,15 +2246,7 @@ mod benchmarks {
 		// Storage
 		let stored_details = ProjectsDetails::<T>::get(project_id).unwrap();
 		assert_eq!(stored_details.status, ProjectStatus::CommunityRound);
-		assert!(
-			stored_details.phase_transition_points.random_closing_ending.unwrap() <
-				stored_details.phase_transition_points.auction_closing.end().unwrap()
-		);
-		let accepted_bids_count =
-			Bids::<T>::iter_prefix_values((project_id,)).filter(|b| matches!(b.status, BidStatus::Accepted)).count();
-		let rejected_bids_count =
-			Bids::<T>::iter_prefix_values((project_id,)).filter(|b| matches!(b.status, BidStatus::Rejected(_))).count();
-		assert_eq!(rejected_bids_count, 0);
+		let accepted_bids_count = Bids::<T>::iter_prefix_values((project_id,)).count();
 		assert_eq!(accepted_bids_count, y as usize);
 
 		// Events
@@ -2163,7 +2270,7 @@ mod benchmarks {
 		let issuer = account::<AccountIdOf<T>>("issuer", 0, 0);
 		whitelist_account!(issuer);
 
-		let project_metadata = default_project::<T>(issuer.clone());
+		let project_metadata = default_project_metadata::<T>(issuer.clone());
 		let project_id = inst.create_community_contributing_project(
 			project_metadata,
 			issuer.clone(),
@@ -2210,7 +2317,7 @@ mod benchmarks {
 
 		let issuer = account::<AccountIdOf<T>>("issuer", 0, 0);
 
-		let project_metadata = default_project::<T>(issuer.clone());
+		let project_metadata = default_project_metadata::<T>(issuer.clone());
 		let target_funding_amount: BalanceOf<T> =
 			project_metadata.minimum_price.saturating_mul_int(project_metadata.total_allocation_size);
 
@@ -2267,7 +2374,7 @@ mod benchmarks {
 
 		let issuer = account::<AccountIdOf<T>>("issuer", 0, 0);
 
-		let project_metadata = default_project::<T>(issuer.clone());
+		let project_metadata = default_project_metadata::<T>(issuer.clone());
 		let target_funding_amount: BalanceOf<T> =
 			project_metadata.minimum_price.saturating_mul_int(project_metadata.total_allocation_size);
 
@@ -2325,7 +2432,7 @@ mod benchmarks {
 
 		let issuer = account::<AccountIdOf<T>>("issuer", 0, 0);
 
-		let project_metadata = default_project::<T>(issuer.clone());
+		let project_metadata = default_project_metadata::<T>(issuer.clone());
 		let target_funding_amount: BalanceOf<T> =
 			project_metadata.minimum_price.saturating_mul_int(project_metadata.total_allocation_size);
 
@@ -2385,7 +2492,7 @@ mod benchmarks {
 
 		let issuer = account::<AccountIdOf<T>>("issuer", 0, 0);
 
-		let project_metadata = default_project::<T>(issuer.clone());
+		let project_metadata = default_project_metadata::<T>(issuer.clone());
 		let target_funding_amount: BalanceOf<T> =
 			project_metadata.minimum_price.saturating_mul_int(project_metadata.total_allocation_size);
 
@@ -2459,7 +2566,7 @@ mod benchmarks {
 
 		let issuer = account::<AccountIdOf<T>>("issuer", 0, 0);
 
-		let project_metadata = default_project::<T>(issuer.clone());
+		let project_metadata = default_project_metadata::<T>(issuer.clone());
 		let target_funding_amount: BalanceOf<T> =
 			project_metadata.minimum_price.saturating_mul_int(project_metadata.total_allocation_size);
 		let manual_outcome_threshold = Percent::from_percent(50);
@@ -2508,7 +2615,7 @@ mod benchmarks {
 
 		let issuer = account::<AccountIdOf<T>>("issuer", 0, 0);
 
-		let project_metadata = default_project::<T>(issuer.clone());
+		let project_metadata = default_project_metadata::<T>(issuer.clone());
 		let project_id = inst.create_finished_project(
 			project_metadata,
 			issuer.clone(),
@@ -2538,7 +2645,7 @@ mod benchmarks {
 
 		let issuer = account::<AccountIdOf<T>>("issuer", 0, 0);
 
-		let project_metadata = default_project::<T>(issuer.clone());
+		let project_metadata = default_project_metadata::<T>(issuer.clone());
 		let target_funding_amount: BalanceOf<T> =
 			project_metadata.minimum_price.saturating_mul_int(project_metadata.total_allocation_size);
 
@@ -2708,6 +2815,13 @@ mod benchmarks {
 		fn bench_start_auction_closing_phase() {
 			new_test_ext().execute_with(|| {
 				assert_ok!(PalletFunding::<TestRuntime>::test_start_auction_closing_phase());
+			});
+		}
+
+		#[test]
+		fn bench_end_auction_closing() {
+			new_test_ext().execute_with(|| {
+				assert_ok!(PalletFunding::<TestRuntime>::test_end_auction_closing());
 			});
 		}
 

--- a/pallets/funding/src/functions/1_application.rs
+++ b/pallets/funding/src/functions/1_application.rs
@@ -44,6 +44,7 @@ impl<T: Config> Pallet<T> {
 				total_bonded_plmc: Zero::zero(),
 				evaluators_outcome: EvaluatorsOutcome::Unchanged,
 			},
+			usd_bid_on_oversubscription: None,
 			funding_end_block: None,
 			parachain_id: None,
 			migration_readiness_check: None,

--- a/pallets/funding/src/functions/misc.rs
+++ b/pallets/funding/src/functions/misc.rs
@@ -1,4 +1,5 @@
 use super::*;
+use itertools::Itertools;
 
 // Helper functions
 // ATTENTION: if this is called directly, it will not be transactional
@@ -69,8 +70,7 @@ impl<T: Config> Pallet<T> {
 		Ok(VestingInfo { total_amount: bonded_amount, amount_per_block, duration })
 	}
 
-	/// Calculates the price (in USD) of contribution tokens for the Community and Remainder Rounds
-	pub fn calculate_weighted_average_price(
+	pub fn decide_winning_bids(
 		project_id: ProjectId,
 		end_block: BlockNumberFor<T>,
 		auction_allocation_size: BalanceOf<T>,
@@ -82,8 +82,6 @@ impl<T: Config> Pallet<T> {
 		// temp variable to store the total value of the bids (i.e price * amount = Cumulative Ticket Size)
 		let mut bid_usd_value_sum = BalanceOf::<T>::zero();
 		let project_account = Self::fund_account_id(project_id);
-		let plmc_price = T::PriceProvider::get_decimals_aware_price(PLMC_FOREIGN_ID, USD_DECIMALS, PLMC_DECIMALS)
-			.ok_or(Error::<T>::PriceNotFound)?;
 
 		let project_metadata = ProjectsMetadata::<T>::get(project_id).ok_or(Error::<T>::ProjectMetadataNotFound)?;
 		let mut highest_accepted_price = project_metadata.minimum_price;
@@ -122,20 +120,43 @@ impl<T: Config> Pallet<T> {
 					bid.final_ct_amount = buyable_amount;
 					highest_accepted_price = highest_accepted_price.max(bid.original_ct_usd_price);
 				}
+				Bids::<T>::insert((project_id, &bid.bidder, &bid.id), &bid);
 				bid
 			})
 			.partition(|bid| matches!(bid.status, BidStatus::Accepted | BidStatus::PartiallyAccepted(..)));
 
-		// Weight calculation variables
-		let accepted_bids_count = accepted_bids.len() as u32;
-		let rejected_bids_count = rejected_bids.len() as u32;
-
 		// Refund rejected bids. We do it here, so we don't have to calculate all the project
 		// prices and then fail to refund the bids.
+		let total_rejected_bids = rejected_bids.len() as u32;
 		for bid in rejected_bids.into_iter() {
 			Self::refund_bid(&bid, project_id, &project_account)?;
 			Bids::<T>::remove((project_id, &bid.bidder, &bid.id));
 		}
+
+		ProjectsDetails::<T>::mutate(project_id, |maybe_info| -> DispatchResult {
+			if let Some(info) = maybe_info {
+				info.remaining_contribution_tokens.saturating_reduce(bid_token_amount_sum);
+				if highest_accepted_price > project_metadata.minimum_price {
+					info.usd_bid_on_oversubscription = Some(bid_usd_value_sum);
+				}
+				Ok(())
+			} else {
+				Err(Error::<T>::ProjectDetailsNotFound.into())
+			}
+		})?;
+
+		Ok((accepted_bids.len() as u32, total_rejected_bids))
+	}
+
+	/// Calculates the price (in USD) of contribution tokens for the Community and Remainder Rounds
+	pub fn calculate_weighted_average_price(project_id: ProjectId) -> Result<u32, DispatchError> {
+		let project_metadata = ProjectsMetadata::<T>::get(project_id).ok_or(Error::<T>::ProjectMetadataNotFound)?;
+		let project_details = ProjectsDetails::<T>::get(project_id).ok_or(Error::<T>::ProjectDetailsNotFound)?;
+		// Rejected bids were deleted in the previous block.
+		let accepted_bids = Bids::<T>::iter_prefix_values((project_id,)).collect_vec();
+		let project_account = Self::fund_account_id(project_id);
+		let plmc_price = T::PriceProvider::get_decimals_aware_price(PLMC_FOREIGN_ID, USD_DECIMALS, PLMC_DECIMALS)
+			.ok_or(Error::<T>::PriceNotFound)?;
 
 		// Calculate the weighted price of the token for the next funding rounds, using winning bids.
 		// for example: if there are 3 winning bids,
@@ -155,31 +176,34 @@ impl<T: Config> Pallet<T> {
 
 		// lastly, sum all the weighted prices to get the final weighted price for the next funding round
 		// 3 + 10.6 + 2.6 = 16.333...
-		let calc_weighted_price_fn = |bid: &BidInfoOf<T>| -> PriceOf<T> {
-			let ticket_size = bid.original_ct_usd_price.saturating_mul_int(bid.final_ct_amount);
-			let bid_weight = <T::Price as FixedPointNumber>::saturating_from_rational(ticket_size, bid_usd_value_sum);
-			let weighted_price = bid.original_ct_usd_price.saturating_mul(bid_weight);
-			weighted_price
-		};
-		let mut weighted_token_price = if highest_accepted_price == project_metadata.minimum_price {
-			project_metadata.minimum_price
-		} else {
+
+		// After reading from storage all accepted bids when calculating the weighted price of each bid, we store them here
+		let mut weighted_token_price = if let Some(total_usd_bid) = project_details.usd_bid_on_oversubscription {
+			let calc_weighted_price_fn = |bid: &BidInfoOf<T>| -> PriceOf<T> {
+				let ticket_size = bid.original_ct_usd_price.saturating_mul_int(bid.final_ct_amount);
+				let bid_weight = <T::Price as FixedPointNumber>::saturating_from_rational(ticket_size, total_usd_bid);
+				let weighted_price = bid.original_ct_usd_price.saturating_mul(bid_weight);
+				weighted_price
+			};
+
 			accepted_bids
 				.iter()
 				.map(calc_weighted_price_fn)
-				.fold(Zero::zero(), |a: T::Price, b: T::Price| a.saturating_add(b))
+				.fold(Zero::zero(), |a: PriceOf<T>, b: PriceOf<T>| a.saturating_add(b))
+		} else {
+			project_metadata.minimum_price
 		};
-		// We are 99% sure that the price cannot be less than minimum if some accepted bids have higher price, but rounding
+
+		// We are 99% sure that the price cannot be less than the minimum if some accepted bids have higher price, but rounding
 		// errors are strange, so we keep this just in case.
 		if weighted_token_price < project_metadata.minimum_price {
 			weighted_token_price = project_metadata.minimum_price;
-		}
+		};
 
 		let mut final_total_funding_reached_by_bids = BalanceOf::<T>::zero();
 
-		// Update storage
-		// Update the bid in the storage
-		for mut bid in accepted_bids.into_iter() {
+		let total_accepted_bids = accepted_bids.len() as u32;
+		for mut bid in accepted_bids {
 			if bid.final_ct_usd_price > weighted_token_price || matches!(bid.status, BidStatus::PartiallyAccepted(..)) {
 				if bid.final_ct_usd_price > weighted_token_price {
 					bid.final_ct_usd_price = weighted_token_price;
@@ -247,7 +271,6 @@ impl<T: Config> Pallet<T> {
 		ProjectsDetails::<T>::mutate(project_id, |maybe_info| -> DispatchResult {
 			if let Some(info) = maybe_info {
 				info.weighted_average_price = Some(weighted_token_price);
-				info.remaining_contribution_tokens.saturating_reduce(bid_token_amount_sum);
 				info.funding_amount_reached_usd.saturating_accrue(final_total_funding_reached_by_bids);
 				Ok(())
 			} else {
@@ -255,7 +278,7 @@ impl<T: Config> Pallet<T> {
 			}
 		})?;
 
-		Ok((accepted_bids_count, rejected_bids_count))
+		Ok(total_accepted_bids)
 	}
 
 	/// Refund a bid because of `reason`.

--- a/pallets/funding/src/instantiator/async_features.rs
+++ b/pallets/funding/src/instantiator/async_features.rs
@@ -203,7 +203,7 @@ pub async fn async_start_auction<
 
 	assert_eq!(inst.get_project_details(project_id).status, ProjectStatus::AuctionInitializePeriod);
 
-	inst.execute(|| crate::Pallet::<T>::do_auction_opening(caller.clone(), project_id).unwrap());
+	inst.execute(|| crate::Pallet::<T>::do_start_auction_opening(caller.clone(), project_id).unwrap());
 
 	assert_eq!(inst.get_project_details(project_id).status, ProjectStatus::AuctionOpening);
 
@@ -280,35 +280,32 @@ pub async fn async_start_community_funding<
 	project_id: ProjectId,
 ) -> Result<(), DispatchError> {
 	let mut inst = instantiator.lock().await;
+	if let Some(update_block) = inst.get_update_block(project_id, &UpdateType::AuctionClosingStart) {
+		let notify = Arc::new(Notify::new());
+		block_orchestrator.add_awaiting_project(update_block, notify.clone()).await;
+		drop(inst);
+		notify.notified().await;
+	}
+	let mut inst = instantiator.lock().await;
+	if let Some(update_block) = inst.get_update_block(project_id, &UpdateType::AuctionClosingEnd) {
+		let notify = Arc::new(Notify::new());
+		block_orchestrator.add_awaiting_project(update_block, notify.clone()).await;
+		drop(inst);
+		notify.notified().await;
+	}
+	let mut inst = instantiator.lock().await;
+	if let Some(update_block) = inst.get_update_block(project_id, &UpdateType::CommunityFundingStart) {
+		let notify = Arc::new(Notify::new());
+		block_orchestrator.add_awaiting_project(update_block, notify.clone()).await;
+		drop(inst);
+		notify.notified().await;
+	}
+	let mut inst = instantiator.lock().await;
 
-	let update_block = inst.get_update_block(project_id, &UpdateType::AuctionClosingStart).unwrap();
-	let closing_start = update_block;
-
-	let notify = Arc::new(Notify::new());
-
-	block_orchestrator.add_awaiting_project(closing_start, notify.clone()).await;
-
-	// Wait for the notification that our desired block was reached to continue
-
-	drop(inst);
-
-	notify.notified().await;
-
-	inst = instantiator.lock().await;
-	let update_block = inst.get_update_block(project_id, &UpdateType::CommunityFundingStart).unwrap();
-	let community_start = update_block;
-
-	let notify = Arc::new(Notify::new());
-
-	block_orchestrator.add_awaiting_project(community_start, notify.clone()).await;
-
-	drop(inst);
-
-	notify.notified().await;
-
-	inst = instantiator.lock().await;
-
-	assert_eq!(inst.get_project_details(project_id).status, ProjectStatus::CommunityRound);
+	ensure!(
+		inst.get_project_details(project_id).status == ProjectStatus::CommunityRound,
+		DispatchError::from("Auction failed")
+	);
 
 	Ok(())
 }
@@ -765,14 +762,16 @@ pub async fn async_create_project_at<
 ) -> ProjectId {
 	let time_to_new_project: BlockNumberFor<T> = Zero::zero();
 	let time_to_evaluation: BlockNumberFor<T> = time_to_new_project + Zero::zero();
-	// we immediately start the auction, so we dont wait for T::AuctionInitializePeriodDuration.
+	// we immediately start the auction, so we don't wait for T::AuctionInitializePeriodDuration.
 	let time_to_auction: BlockNumberFor<T> = time_to_evaluation + <T as Config>::EvaluationDuration::get();
-	let time_to_community: BlockNumberFor<T> =
-		time_to_auction + <T as Config>::AuctionOpeningDuration::get() + <T as Config>::AuctionClosingDuration::get();
+	let wap_calculation_duration: BlockNumberFor<T> = 2u32.into();
+	let time_to_community: BlockNumberFor<T> = time_to_auction +
+		<T as Config>::AuctionOpeningDuration::get() +
+		<T as Config>::AuctionClosingDuration::get() +
+		wap_calculation_duration;
 	let time_to_remainder: BlockNumberFor<T> = time_to_community + <T as Config>::CommunityFundingDuration::get();
-	let time_to_finish: BlockNumberFor<T> = time_to_remainder +
-		<T as Config>::RemainderFundingDuration::get() +
-		<T as Config>::SuccessToSettlementTime::get();
+	let time_to_finish: BlockNumberFor<T> = time_to_remainder + <T as Config>::RemainderFundingDuration::get();
+
 	let mut inst = mutex_inst.lock().await;
 	let now = inst.current_block();
 	drop(inst);

--- a/pallets/funding/src/mock.rs
+++ b/pallets/funding/src/mock.rs
@@ -290,14 +290,14 @@ pub const HOURS: BlockNumber = 300u64;
 
 // REMARK: In the production configuration we use DAYS instead of HOURS.
 parameter_types! {
-	pub const EvaluationDuration: BlockNumber = 3u64;
-	pub const AuctionInitializePeriodDuration: BlockNumber = 3u64;
-	pub const AuctionOpeningDuration: BlockNumber = 3u64;
-	pub const AuctionClosingDuration: BlockNumber = 3u64;
-	pub const CommunityRoundDuration: BlockNumber = 3u64;
-	pub const RemainderFundingDuration: BlockNumber = 3u64;
-	pub const ManualAcceptanceDuration: BlockNumber = 3u64;
-	pub const SuccessToSettlementTime: BlockNumber = 3u64;
+	pub const EvaluationDuration: BlockNumber = 10u64;
+	pub const AuctionInitializePeriodDuration: BlockNumber = 10u64;
+	pub const AuctionOpeningDuration: BlockNumber = 10u64;
+	pub const AuctionClosingDuration: BlockNumber = 10u64;
+	pub const CommunityRoundDuration: BlockNumber = 10u64;
+	pub const RemainderFundingDuration: BlockNumber = 10u64;
+	pub const ManualAcceptanceDuration: BlockNumber = 10u64;
+	pub const SuccessToSettlementTime: BlockNumber = 10u64;
 
 	pub const FundingPalletId: PalletId = PalletId(*b"py/cfund");
 	pub FeeBrackets: Vec<(Percent, Balance)> = vec![

--- a/pallets/funding/src/tests/2_evaluation.rs
+++ b/pallets/funding/src/tests/2_evaluation.rs
@@ -325,6 +325,7 @@ mod start_evaluation_extrinsic {
 					total_bonded_plmc: 0u128,
 					evaluators_outcome: EvaluatorsOutcome::Unchanged,
 				},
+				usd_bid_on_oversubscription: None,
 				funding_end_block: None,
 				parachain_id: None,
 				migration_readiness_check: None,

--- a/pallets/funding/src/tests/4_community.rs
+++ b/pallets/funding/src/tests/4_community.rs
@@ -765,8 +765,7 @@ mod community_contribute_extrinsic {
 			)
 			.unwrap();
 			inst.bid_for_users(project_id, failing_bids_after_random_end).unwrap();
-			inst.advance_time(2).unwrap();
-			assert_eq!(inst.get_project_details(project_id).status, ProjectStatus::CommunityRound);
+			inst.start_community_funding(project_id).unwrap();
 
 			// Some low amount of plmc and usdt to cover a purchase of 10CTs.
 			let plmc_mints = vec![

--- a/pallets/funding/src/tests/misc.rs
+++ b/pallets/funding/src/tests/misc.rs
@@ -412,14 +412,6 @@ mod async_tests {
 		];
 
 		let (project_ids, mut inst) = create_multiple_projects_at(inst, project_params);
-		let now = inst.current_block();
-
-		dbg!(inst.get_project_details(project_ids[0]).status);
-		dbg!(inst.get_project_details(project_ids[1]).status);
-		dbg!(inst.get_project_details(project_ids[2]).status);
-		dbg!(inst.get_project_details(project_ids[3]).status);
-		dbg!(inst.get_project_details(project_ids[4]).status);
-		dbg!(inst.get_project_details(project_ids[5]).status);
 
 		assert_eq!(inst.get_project_details(project_ids[0]).status, ProjectStatus::Application);
 		assert_eq!(inst.get_project_details(project_ids[1]).status, ProjectStatus::EvaluationRound);
@@ -548,13 +540,6 @@ mod async_tests {
 
 		let ext = sp_io::TestExternalities::new(t);
 		let mut inst = MockInstantiator::new(Some(RefCell::new(ext)));
-
-		dbg!(inst.get_project_details(0).status);
-		dbg!(inst.get_project_details(1).status);
-		dbg!(inst.get_project_details(2).status);
-		dbg!(inst.get_project_details(3).status);
-		dbg!(inst.get_project_details(4).status);
-		dbg!(inst.get_project_details(5).status);
 
 		assert_eq!(inst.get_project_details(0).status, ProjectStatus::FundingSuccessful);
 		assert_eq!(inst.get_project_details(1).status, ProjectStatus::RemainderRound);

--- a/pallets/funding/src/types.rs
+++ b/pallets/funding/src/types.rs
@@ -322,6 +322,8 @@ pub mod storage_types {
 		pub funding_amount_reached_usd: Balance,
 		/// Information about the total amount bonded, and the outcome in regards to reward/slash/nothing
 		pub evaluation_round_info: EvaluationRoundInfo,
+		/// If the auction was oversubscribed, how much USD was raised across all winning bids
+		pub usd_bid_on_oversubscription: Option<Balance>,
 		/// When the Funding Round ends
 		pub funding_end_block: Option<BlockNumber>,
 		/// ParaId of project
@@ -337,6 +339,7 @@ pub mod storage_types {
 		EvaluationEnd,
 		AuctionOpeningStart,
 		AuctionClosingStart,
+		AuctionClosingEnd,
 		CommunityFundingStart,
 		RemainderFundingStart,
 		FundingEnd,
@@ -639,6 +642,7 @@ pub mod inner_types {
 		AuctionInitializePeriod,
 		AuctionOpening,
 		AuctionClosing,
+		CalculatingWAP,
 		CommunityRound,
 		RemainderRound,
 		FundingFailed,
@@ -745,6 +749,7 @@ pub mod inner_types {
 		AuctionInitializePeriod,
 		AuctionOpening,
 		AuctionClosing,
+		CalculatingWAP,
 		CommunityFunding,
 		RemainderFunding,
 		DecisionPeriod,


### PR DESCRIPTION
## What?
- Spread out the WAP on_initialize calculation into 2 blocks

## Why?
- Because the ref time was too close to the block limit

## How?
- Create a do_end_auction_closing function that does the deciding of which bids are successful, and refunds/deletes failed ones
- do_start_community now does the WAP calculation only

## Testing?
- Run normal tests, all logic should be maintained
