### PR TITLE
:sparkles: Allow transfers to HydraDX

### DIFF
--- a/runtimes/polimec/src/xcm_config.rs
+++ b/runtimes/polimec/src/xcm_config.rs
@@ -417,11 +417,10 @@ impl pallet_xcm::Config for Runtime {
 	// ^ Disable dispatchable execute on the XCM pallet.
 	// Needs to be `Everything` for local testing.
 	type XcmExecutor = XcmExecutor<XcmConfig>;
-	// We only allow reserve based transfers of AssetHub reserve assets back to AssetHub.
-	type XcmReserveTransferFilter = AssetHubAssetsAsReserve;
+	// We allow all reserve based transfers from our chain to any other chain.
+	type XcmReserveTransferFilter = Everything;
 	type XcmRouter = XcmRouter;
 	// We do not allow teleportation of PLMC or other assets.
-	// TODO: change this once we enable PLMC teleports
 	type XcmTeleportFilter = Nothing;
 
 	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;

--- a/scripts/chopsticks/hydradx-transfers/hydradx.yml
+++ b/scripts/chopsticks/hydradx-transfers/hydradx.yml
@@ -1,0 +1,19 @@
+endpoint: wss://hydradx-rpc.dwellir.com
+mock-signature-host: true
+db: ./hydradx.db.sqlite
+runtime-log-level: 5
+
+import-storage:
+  System:
+    Account:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+        - providers: 1
+          data:
+            free: 1000000000000000
+     
+  TechnicalCommittee:
+    Members: ["5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"]
+  Council:
+    Members: ["5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"]

--- a/scripts/chopsticks/hydradx-transfers/polimec.yml
+++ b/scripts/chopsticks/hydradx-transfers/polimec.yml
@@ -1,0 +1,16 @@
+db: ./db.sqlite
+mock-signature-host: true
+endpoint: wss://rpc.polimec.org
+runtime-log-level: 5
+# Uncomment if you want to use a custom runtime. Add the runtime to the hydradx-transfers directory.
+# wasm-override: polimec_runtime.compact.compressed.wasm
+
+import-storage:
+  System:
+    Account:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+        - providers: 1
+          data:
+            free: 1000000000000000


### PR DESCRIPTION
## What?
This PR enables the transfer of PLMC to and from HydraDX.

## Why?
We opened a channel with HydraDX and we should now enable PLMC transfers. 

## How?
By setting the `XcmReserveTransferFilter` to `Everything`, meaning that we allow reserve based transfers of all assets on Polimec. This works as we only have PLMC, USDT, USDC and DOT as assets on Polimec. We do not allow users to create their own assets, and new assets can only be added by root. Note that transfers out of Polimec are less of a security concern then transfers in. We still only acknowledge AssetHub as the reserve of USD(T/C) + DOT. Any other asset being send to us from any other Parachain will be rejected. This means that we do not accept USD(T/C) and DOT from HydraDX directly, as we do not recognise HydraDX as a reserve for those currencies.

## Testing?

## Screenshots (optional)

## Anything Else?
