### PR TITLE
🧑‍💻 Optional ED inclusion on inst PLMC calculations

### DIFF
--- a/pallets/funding/src/benchmarking.rs
+++ b/pallets/funding/src/benchmarking.rs
@@ -623,10 +623,8 @@ mod benchmarks {
 		let project_id = inst.create_evaluating_project(project_metadata.clone(), issuer.clone());
 
 		let evaluations = default_evaluations();
-		let plmc_for_evaluating = inst.calculate_evaluation_plmc_spent(evaluations.clone());
-		let existential_plmc: Vec<UserToPLMCBalance<T>> = plmc_for_evaluating.accounts().existential_deposits();
+		let plmc_for_evaluating = inst.calculate_evaluation_plmc_spent(evaluations.clone(), true);
 
-		inst.mint_plmc_to(existential_plmc);
 		inst.mint_plmc_to(plmc_for_evaluating);
 
 		inst.advance_time(One::one()).unwrap();
@@ -686,8 +684,9 @@ mod benchmarks {
 		let extrinsic_evaluation = UserToUSDBalance::new(test_evaluator.clone(), (1_000 * USD_UNIT).into());
 		let existing_evaluations = vec![existing_evaluation; x as usize];
 
-		let plmc_for_existing_evaluations = inst.calculate_evaluation_plmc_spent(existing_evaluations.clone());
-		let plmc_for_extrinsic_evaluation = inst.calculate_evaluation_plmc_spent(vec![extrinsic_evaluation.clone()]);
+		let plmc_for_existing_evaluations = inst.calculate_evaluation_plmc_spent(existing_evaluations.clone(), false);
+		let plmc_for_extrinsic_evaluation =
+			inst.calculate_evaluation_plmc_spent(vec![extrinsic_evaluation.clone()], false);
 		let existential_plmc: Vec<UserToPLMCBalance<T>> =
 			plmc_for_extrinsic_evaluation.accounts().existential_deposits();
 
@@ -819,6 +818,7 @@ mod benchmarks {
 			&existing_bids,
 			project_metadata.clone(),
 			None,
+			false,
 		);
 
 		let existential_deposits: Vec<UserToPLMCBalance<T>> = vec![bidder.clone()].existential_deposits();
@@ -860,6 +860,7 @@ mod benchmarks {
 			let plmc_for_new_bidder = inst.calculate_auction_plmc_charged_with_given_price(
 				&vec![bid_params.clone()],
 				current_bucket.current_price,
+				false,
 			);
 			let plmc_ed = plmc_for_new_bidder.accounts().existential_deposits();
 			let usdt_for_new_bidder = inst.calculate_auction_funding_asset_charged_with_given_price(
@@ -895,6 +896,7 @@ mod benchmarks {
 				&vec![extrinsic_bid.clone()],
 				project_metadata.clone(),
 				Some(current_bucket),
+				false,
 			);
 		let usdt_for_extrinsic_bids: Vec<UserToForeignAssets<T>> = inst
 			.calculate_auction_funding_asset_charged_from_all_bids_made_or_with_bucket(
@@ -1149,9 +1151,9 @@ mod benchmarks {
 		let mut total_ct_sold: BalanceOf<T> = existing_amount * (x as u128).into() + extrinsic_amount;
 
 		let plmc_for_existing_contributions =
-			inst.calculate_contributed_plmc_spent(existing_contributions.clone(), price);
+			inst.calculate_contributed_plmc_spent(existing_contributions.clone(), price, false);
 		let plmc_for_extrinsic_contribution =
-			inst.calculate_contributed_plmc_spent(vec![extrinsic_contribution.clone()], price);
+			inst.calculate_contributed_plmc_spent(vec![extrinsic_contribution.clone()], price, false);
 		let usdt_for_existing_contributions =
 			inst.calculate_contributed_funding_asset_spent(existing_contributions.clone(), price);
 		let usdt_for_extrinsic_contribution =
@@ -1868,10 +1870,8 @@ mod benchmarks {
 		let project_id = inst.create_evaluating_project(project_metadata, issuer.clone());
 
 		let evaluations = default_evaluations();
-		let plmc_for_evaluating = inst.calculate_evaluation_plmc_spent(evaluations.clone());
-		let existential_plmc: Vec<UserToPLMCBalance<T>> = plmc_for_evaluating.accounts().existential_deposits();
+		let plmc_for_evaluating = inst.calculate_evaluation_plmc_spent(evaluations.clone(), true);
 
-		inst.mint_plmc_to(existential_plmc);
 		inst.mint_plmc_to(plmc_for_evaluating);
 
 		inst.advance_time(One::one()).unwrap();
@@ -1929,10 +1929,8 @@ mod benchmarks {
 				(Percent::from_percent(25) * evaluation_usd_target).into(),
 			),
 		];
-		let plmc_for_evaluating = inst.calculate_evaluation_plmc_spent(evaluations.clone());
-		let existential_plmc: Vec<UserToPLMCBalance<T>> = plmc_for_evaluating.accounts().existential_deposits();
+		let plmc_for_evaluating = inst.calculate_evaluation_plmc_spent(evaluations.clone(), true);
 
-		inst.mint_plmc_to(existential_plmc);
 		inst.mint_plmc_to(plmc_for_evaluating);
 
 		inst.advance_time(One::one()).unwrap();
@@ -2070,6 +2068,7 @@ mod benchmarks {
 			&all_bids,
 			project_metadata.clone(),
 			None,
+			false,
 		);
 		let plmc_ed = all_bids.accounts().existential_deposits();
 		let funding_asset_needed_for_bids = inst
@@ -2202,6 +2201,7 @@ mod benchmarks {
 			&all_bids,
 			project_metadata.clone(),
 			None,
+			false,
 		);
 		let plmc_ed = all_bids.accounts().existential_deposits();
 		let funding_asset_needed_for_bids = inst
@@ -2510,11 +2510,9 @@ mod benchmarks {
 			evaluation_target_usd,
 		));
 
-		let plmc_needed_for_evaluating = inst.calculate_evaluation_plmc_spent(evaluations.clone());
-		let plmc_ed = evaluations.accounts().existential_deposits();
+		let plmc_needed_for_evaluating = inst.calculate_evaluation_plmc_spent(evaluations.clone(), true);
 
 		inst.mint_plmc_to(plmc_needed_for_evaluating);
-		inst.mint_plmc_to(plmc_ed);
 
 		let bids: Vec<BidParams<T>> = inst.generate_bids_from_total_usd(
 			(automatically_rejected_threshold * target_funding_amount) / 2.into(),

--- a/pallets/funding/src/instantiator/async_features.rs
+++ b/pallets/funding/src/instantiator/async_features.rs
@@ -231,7 +231,8 @@ pub async fn async_create_auctioning_project<
 	let prev_supply = inst.get_plmc_total_supply();
 	let prev_plmc_balances = inst.get_free_plmc_balances_for(evaluators.clone());
 
-	let plmc_eval_deposits: Vec<UserToPLMCBalance<T>> = inst.calculate_evaluation_plmc_spent(evaluations.clone());
+	let plmc_eval_deposits: Vec<UserToPLMCBalance<T>> =
+		inst.calculate_evaluation_plmc_spent(evaluations.clone(), false);
 	let plmc_existential_deposits: Vec<UserToPLMCBalance<T>> = evaluators.existential_deposits();
 
 	let expected_remaining_plmc: Vec<UserToPLMCBalance<T>> =
@@ -254,8 +255,12 @@ pub async fn async_create_auctioning_project<
 	async_start_auction(instantiator.clone(), block_orchestrator, project_id, issuer).await.unwrap();
 
 	inst = instantiator.lock().await;
-	let plmc_for_bids =
-		inst.calculate_auction_plmc_charged_from_all_bids_made_or_with_bucket(&bids, project_metadata.clone(), None);
+	let plmc_for_bids = inst.calculate_auction_plmc_charged_from_all_bids_made_or_with_bucket(
+		&bids,
+		project_metadata.clone(),
+		None,
+		false,
+	);
 	let plmc_existential_deposits: Vec<UserToPLMCBalance<T>> = bids.accounts().existential_deposits();
 	let usdt_for_bids =
 		inst.calculate_auction_funding_asset_charged_from_all_bids_made_or_with_bucket(&bids, project_metadata, None);
@@ -342,9 +347,9 @@ pub async fn async_create_community_contributing_project<
 	let asset_id = bids[0].asset.to_assethub_id();
 	let prev_plmc_balances = inst.get_free_plmc_balances_for(bidders.clone());
 	let prev_funding_asset_balances = inst.get_free_foreign_asset_balances_for(asset_id, bidders.clone());
-	let plmc_evaluation_deposits: Vec<UserToPLMCBalance<T>> = inst.calculate_evaluation_plmc_spent(evaluations);
-	let plmc_bid_deposits: Vec<UserToPLMCBalance<T>> =
-		inst.calculate_auction_plmc_charged_from_all_bids_made_or_with_bucket(&bids, project_metadata.clone(), None);
+	let plmc_evaluation_deposits: Vec<UserToPLMCBalance<T>> = inst.calculate_evaluation_plmc_spent(evaluations, false);
+	let plmc_bid_deposits: Vec<UserToPLMCBalance<T>> = inst
+		.calculate_auction_plmc_charged_from_all_bids_made_or_with_bucket(&bids, project_metadata.clone(), None, false);
 	let participation_usable_evaluation_deposits = plmc_evaluation_deposits
 		.into_iter()
 		.map(|mut x| {
@@ -489,10 +494,10 @@ pub async fn async_create_remainder_contributing_project<
 	let prev_plmc_balances = inst.get_free_plmc_balances_for(contributors.clone());
 	let prev_funding_asset_balances = inst.get_free_foreign_asset_balances_for(asset_id, contributors.clone());
 
-	let plmc_evaluation_deposits = inst.calculate_evaluation_plmc_spent(evaluations);
-	let plmc_bid_deposits = inst.calculate_auction_plmc_charged_with_given_price(&accepted_bids, ct_price);
+	let plmc_evaluation_deposits = inst.calculate_evaluation_plmc_spent(evaluations, false);
+	let plmc_bid_deposits = inst.calculate_auction_plmc_charged_with_given_price(&accepted_bids, ct_price, false);
 
-	let plmc_contribution_deposits = inst.calculate_contributed_plmc_spent(contributions.clone(), ct_price);
+	let plmc_contribution_deposits = inst.calculate_contributed_plmc_spent(contributions.clone(), ct_price, false);
 
 	let necessary_plmc_mint = inst.generic_map_operation(
 		vec![plmc_contribution_deposits.clone(), plmc_evaluation_deposits],
@@ -610,16 +615,17 @@ pub async fn async_create_finished_project<
 	let prev_plmc_balances = inst.get_free_plmc_balances_for(contributors.clone());
 	let prev_funding_asset_balances = inst.get_free_foreign_asset_balances_for(asset_id, contributors.clone());
 
-	let plmc_evaluation_deposits = inst.calculate_evaluation_plmc_spent(evaluations);
+	let plmc_evaluation_deposits = inst.calculate_evaluation_plmc_spent(evaluations, false);
 	let plmc_bid_deposits = inst.calculate_auction_plmc_charged_from_all_bids_made_or_with_bucket(
 		&accepted_bids,
 		project_metadata.clone(),
 		None,
+		false,
 	);
 	let plmc_community_contribution_deposits =
-		inst.calculate_contributed_plmc_spent(community_contributions.clone(), ct_price);
+		inst.calculate_contributed_plmc_spent(community_contributions.clone(), ct_price, false);
 	let plmc_remainder_contribution_deposits =
-		inst.calculate_contributed_plmc_spent(remainder_contributions.clone(), ct_price);
+		inst.calculate_contributed_plmc_spent(remainder_contributions.clone(), ct_price, false);
 
 	let necessary_plmc_mint = inst.generic_map_operation(
 		vec![plmc_remainder_contribution_deposits.clone(), plmc_evaluation_deposits],

--- a/pallets/funding/src/instantiator/chain_interactions.rs
+++ b/pallets/funding/src/instantiator/chain_interactions.rs
@@ -491,7 +491,8 @@ impl<
 		let prev_supply = self.get_plmc_total_supply();
 		let prev_plmc_balances = self.get_free_plmc_balances_for(evaluators.clone());
 
-		let plmc_eval_deposits: Vec<UserToPLMCBalance<T>> = self.calculate_evaluation_plmc_spent(evaluations.clone());
+		let plmc_eval_deposits: Vec<UserToPLMCBalance<T>> =
+			self.calculate_evaluation_plmc_spent(evaluations.clone(), false);
 		let plmc_existential_deposits: Vec<UserToPLMCBalance<T>> = evaluators.existential_deposits();
 
 		let expected_remaining_plmc: Vec<UserToPLMCBalance<T>> = self
@@ -570,9 +571,15 @@ impl<
 		let asset_id = bids[0].asset.to_assethub_id();
 		let prev_plmc_balances = self.get_free_plmc_balances_for(bidders.clone());
 		let prev_funding_asset_balances = self.get_free_foreign_asset_balances_for(asset_id, bidders.clone());
-		let plmc_evaluation_deposits: Vec<UserToPLMCBalance<T>> = self.calculate_evaluation_plmc_spent(evaluations);
+		let plmc_evaluation_deposits: Vec<UserToPLMCBalance<T>> =
+			self.calculate_evaluation_plmc_spent(evaluations, false);
 		let plmc_bid_deposits: Vec<UserToPLMCBalance<T>> = self
-			.calculate_auction_plmc_charged_from_all_bids_made_or_with_bucket(&bids, project_metadata.clone(), None);
+			.calculate_auction_plmc_charged_from_all_bids_made_or_with_bucket(
+				&bids,
+				project_metadata.clone(),
+				None,
+				false,
+			);
 		let participation_usable_evaluation_deposits = plmc_evaluation_deposits
 			.into_iter()
 			.map(|mut x| {
@@ -962,9 +969,9 @@ impl<
 		let prev_plmc_balances = self.get_free_plmc_balances_for(contributors.clone());
 		let prev_funding_asset_balances = self.get_free_foreign_asset_balances_for(asset_id, contributors.clone());
 
-		let plmc_evaluation_deposits = self.calculate_evaluation_plmc_spent(evaluations.clone());
+		let plmc_evaluation_deposits = self.calculate_evaluation_plmc_spent(evaluations.clone(), false);
 		let plmc_bid_deposits = self.calculate_auction_plmc_spent_post_wap(&bids, project_metadata.clone(), ct_price);
-		let plmc_contribution_deposits = self.calculate_contributed_plmc_spent(contributions.clone(), ct_price);
+		let plmc_contribution_deposits = self.calculate_contributed_plmc_spent(contributions.clone(), ct_price, false);
 
 		let reducible_evaluator_balances = self.slash_evaluator_balances(plmc_evaluation_deposits.clone());
 		let necessary_plmc_mint = self.generic_map_operation(
@@ -1039,12 +1046,12 @@ impl<
 		let prev_plmc_balances = self.get_free_plmc_balances_for(contributors.clone());
 		let prev_funding_asset_balances = self.get_free_foreign_asset_balances_for(asset_id, contributors.clone());
 
-		let plmc_evaluation_deposits = self.calculate_evaluation_plmc_spent(evaluations);
+		let plmc_evaluation_deposits = self.calculate_evaluation_plmc_spent(evaluations, false);
 		let plmc_bid_deposits = self.calculate_auction_plmc_spent_post_wap(&bids, project_metadata.clone(), ct_price);
 		let plmc_community_contribution_deposits =
-			self.calculate_contributed_plmc_spent(community_contributions.clone(), ct_price);
+			self.calculate_contributed_plmc_spent(community_contributions.clone(), ct_price, false);
 		let plmc_remainder_contribution_deposits =
-			self.calculate_contributed_plmc_spent(remainder_contributions.clone(), ct_price);
+			self.calculate_contributed_plmc_spent(remainder_contributions.clone(), ct_price, false);
 
 		let necessary_plmc_mint = self.generic_map_operation(
 			vec![plmc_remainder_contribution_deposits.clone(), plmc_evaluation_deposits],

--- a/pallets/funding/src/tests/4_community.rs
+++ b/pallets/funding/src/tests/4_community.rs
@@ -77,7 +77,7 @@ mod round_flow {
 			let ct_price = inst.get_project_details(project_id).weighted_average_price.expect("CT Price should exist");
 
 			let contributions = vec![ContributionParams::new(BOB, remaining_ct, 1u8, AcceptedFundingAsset::USDT)];
-			let plmc_fundings = inst.calculate_contributed_plmc_spent(contributions.clone(), ct_price);
+			let plmc_fundings = inst.calculate_contributed_plmc_spent(contributions.clone(), ct_price, false);
 			let plmc_existential_deposits = plmc_fundings.accounts().existential_deposits();
 			let foreign_asset_fundings =
 				inst.calculate_contributed_funding_asset_spent(contributions.clone(), ct_price);
@@ -139,6 +139,7 @@ mod round_flow {
 			let plmc_contribution_funding = inst.calculate_contributed_plmc_spent(
 				contributions.clone(),
 				project_details.weighted_average_price.unwrap(),
+				false,
 			);
 			let plmc_existential_deposits = plmc_contribution_funding.accounts().existential_deposits();
 			inst.mint_plmc_to(plmc_contribution_funding.clone());
@@ -442,10 +443,9 @@ mod community_contribute_extrinsic {
 				&all_bids,
 				project_metadata.clone(),
 				None,
+				true,
 			);
-			let bids_existential_deposits = bids_plmc.accounts().existential_deposits();
 			inst.mint_plmc_to(bids_plmc.clone());
-			inst.mint_plmc_to(bids_existential_deposits.clone());
 
 			let bids_foreign = inst.calculate_auction_funding_asset_charged_from_all_bids_made_or_with_bucket(
 				&all_bids,
@@ -520,6 +520,7 @@ mod community_contribute_extrinsic {
 			let plmc_fundings = inst.calculate_contributed_plmc_spent(
 				vec![usdt_contribution.clone(), usdc_contribution.clone(), dot_contribution.clone()],
 				wap,
+				false,
 			);
 			let plmc_existential_deposits = plmc_fundings.accounts().existential_deposits();
 
@@ -565,7 +566,7 @@ mod community_contribute_extrinsic {
 					asset: AcceptedFundingAsset::USDT,
 				};
 
-				let necessary_plmc = inst.calculate_contributed_plmc_spent(vec![contribution.clone()], wap);
+				let necessary_plmc = inst.calculate_contributed_plmc_spent(vec![contribution.clone()], wap, false);
 				let plmc_existential_amounts = necessary_plmc.accounts().existential_deposits();
 				let necessary_usdt = inst.calculate_contributed_funding_asset_spent(vec![contribution.clone()], wap);
 
@@ -745,10 +746,9 @@ mod community_contribute_extrinsic {
 				&all_bids.clone(),
 				project_metadata.clone(),
 				None,
+				true,
 			);
-			let plmc_existential_deposits = plmc_fundings.accounts().existential_deposits();
 			inst.mint_plmc_to(plmc_fundings.clone());
-			inst.mint_plmc_to(plmc_existential_deposits.clone());
 
 			let foreign_funding = inst.calculate_auction_funding_asset_charged_from_all_bids_made_or_with_bucket(
 				&all_bids.clone(),
@@ -858,7 +858,7 @@ mod community_contribute_extrinsic {
 			let wap = inst.get_project_details(project_id).weighted_average_price.unwrap();
 
 			let contribution = ContributionParams::new(BUYER_4, 500 * CT_UNIT, 1u8, AcceptedFundingAsset::USDT);
-			let plmc_required = inst.calculate_contributed_plmc_spent(vec![contribution.clone()], wap);
+			let plmc_required = inst.calculate_contributed_plmc_spent(vec![contribution.clone()], wap, false);
 			let frozen_amount = plmc_required[0].plmc_amount;
 			let plmc_existential_deposits = plmc_required.accounts().existential_deposits();
 
@@ -938,7 +938,7 @@ mod community_contribute_extrinsic {
 			let wap = inst.get_project_details(project_id).weighted_average_price.unwrap();
 
 			let contribution = ContributionParams::new(BUYER_4, 500 * CT_UNIT, 5u8, AcceptedFundingAsset::USDT);
-			let plmc_required = inst.calculate_contributed_plmc_spent(vec![contribution.clone()], wap);
+			let plmc_required = inst.calculate_contributed_plmc_spent(vec![contribution.clone()], wap, false);
 			let frozen_amount = plmc_required[0].plmc_amount;
 			let plmc_existential_deposits = plmc_required.accounts().existential_deposits();
 
@@ -1070,7 +1070,7 @@ mod community_contribute_extrinsic {
 				.map(|_| ContributionParams::new(CONTRIBUTOR, token_amount, 1u8, AcceptedFundingAsset::USDT))
 				.collect();
 
-			let plmc_funding = inst.calculate_contributed_plmc_spent(contributions.clone(), token_price);
+			let plmc_funding = inst.calculate_contributed_plmc_spent(contributions.clone(), token_price, false);
 			let plmc_existential_deposits = plmc_funding.accounts().existential_deposits();
 
 			let foreign_funding = inst.calculate_contributed_funding_asset_spent(contributions.clone(), token_price);
@@ -1504,7 +1504,7 @@ mod community_contribute_extrinsic {
 			let wap = inst.get_project_details(project_id).weighted_average_price.unwrap();
 
 			// 1 unit less native asset than needed
-			let plmc_funding = inst.calculate_contributed_plmc_spent(vec![contribution.clone()], wap);
+			let plmc_funding = inst.calculate_contributed_plmc_spent(vec![contribution.clone()], wap, false);
 			let plmc_existential_deposits = plmc_funding.accounts().existential_deposits();
 			inst.mint_plmc_to(plmc_funding.clone());
 			inst.mint_plmc_to(plmc_existential_deposits.clone());
@@ -1527,7 +1527,7 @@ mod community_contribute_extrinsic {
 			});
 
 			// 1 unit less funding asset than needed
-			let plmc_funding = inst.calculate_contributed_plmc_spent(vec![contribution.clone()], wap);
+			let plmc_funding = inst.calculate_contributed_plmc_spent(vec![contribution.clone()], wap, false);
 			let plmc_existential_deposits = plmc_funding.accounts().existential_deposits();
 			inst.mint_plmc_to(plmc_funding.clone());
 			inst.mint_plmc_to(plmc_existential_deposits.clone());
@@ -1712,13 +1712,13 @@ mod community_contribute_extrinsic {
 			let wap = inst.get_project_details(project_id_2).weighted_average_price.unwrap();
 
 			// Necessary Mints
-			let already_bonded_plmc =
-				inst.calculate_evaluation_plmc_spent(vec![(evaluator_contributor, evaluation_amount).into()])[0]
-					.plmc_amount;
+			let already_bonded_plmc = inst
+				.calculate_evaluation_plmc_spent(vec![(evaluator_contributor, evaluation_amount).into()], false)[0]
+				.plmc_amount;
 			let usable_evaluation_plmc =
 				already_bonded_plmc - <TestRuntime as Config>::EvaluatorSlash::get() * already_bonded_plmc;
 			let necessary_plmc_for_contribution =
-				inst.calculate_contributed_plmc_spent(vec![evaluator_contribution.clone()], wap)[0].plmc_amount;
+				inst.calculate_contributed_plmc_spent(vec![evaluator_contribution.clone()], wap, false)[0].plmc_amount;
 			let necessary_usdt_for_contribution =
 				inst.calculate_contributed_funding_asset_spent(vec![evaluator_contribution.clone()], wap);
 			inst.mint_plmc_to(vec![UserToPLMCBalance::new(

--- a/pallets/funding/src/tests/5_remainder.rs
+++ b/pallets/funding/src/tests/5_remainder.rs
@@ -82,7 +82,7 @@ mod round_flow {
 			let ct_price = inst.get_project_details(project_id).weighted_average_price.expect("CT Price should exist");
 
 			let contributions = vec![ContributionParams::new(BOB, remaining_ct, 1u8, AcceptedFundingAsset::USDT)];
-			let plmc_fundings = inst.calculate_contributed_plmc_spent(contributions.clone(), ct_price);
+			let plmc_fundings = inst.calculate_contributed_plmc_spent(contributions.clone(), ct_price, false);
 			let plmc_existential_deposits = contributions.accounts().existential_deposits();
 			let foreign_asset_fundings =
 				inst.calculate_contributed_funding_asset_spent(contributions.clone(), ct_price);
@@ -148,6 +148,7 @@ mod round_flow {
 			let plmc_contribution_funding = inst.calculate_contributed_plmc_spent(
 				contributions.clone(),
 				project_details.weighted_average_price.unwrap(),
+				false,
 			);
 			let plmc_existential_deposits = plmc_contribution_funding.accounts().existential_deposits();
 			inst.mint_plmc_to(plmc_contribution_funding.clone());
@@ -457,10 +458,9 @@ mod remaining_contribute_extrinsic {
 				&all_bids,
 				project_metadata.clone(),
 				None,
+				true,
 			);
-			let bids_existential_deposits = bids_plmc.accounts().existential_deposits();
 			inst.mint_plmc_to(bids_plmc.clone());
-			inst.mint_plmc_to(bids_existential_deposits.clone());
 
 			let bids_foreign = inst.calculate_auction_funding_asset_charged_from_all_bids_made_or_with_bucket(
 				&all_bids,
@@ -611,6 +611,7 @@ mod remaining_contribute_extrinsic {
 			let plmc_fundings = inst.calculate_contributed_plmc_spent(
 				vec![usdt_contribution.clone(), usdc_contribution.clone(), dot_contribution.clone()],
 				wap,
+				false,
 			);
 			let plmc_existential_deposits = plmc_fundings.accounts().existential_deposits();
 
@@ -690,7 +691,7 @@ mod remaining_contribute_extrinsic {
 					asset: AcceptedFundingAsset::USDT,
 				};
 
-				let necessary_plmc = inst.calculate_contributed_plmc_spent(vec![contribution.clone()], wap);
+				let necessary_plmc = inst.calculate_contributed_plmc_spent(vec![contribution.clone()], wap, false);
 				let plmc_existential_amounts = necessary_plmc.accounts().existential_deposits();
 				let necessary_usdt = inst.calculate_contributed_funding_asset_spent(vec![contribution.clone()], wap);
 
@@ -876,10 +877,9 @@ mod remaining_contribute_extrinsic {
 				&all_bids.clone(),
 				project_metadata.clone(),
 				None,
+				true,
 			);
-			let plmc_existential_deposits = plmc_fundings.accounts().existential_deposits();
 			inst.mint_plmc_to(plmc_fundings.clone());
-			inst.mint_plmc_to(plmc_existential_deposits.clone());
 
 			let foreign_funding = inst.calculate_auction_funding_asset_charged_from_all_bids_made_or_with_bucket(
 				&all_bids.clone(),
@@ -992,7 +992,7 @@ mod remaining_contribute_extrinsic {
 			let wap = inst.get_project_details(project_id).weighted_average_price.unwrap();
 
 			let contribution = ContributionParams::new(BUYER_4, 500 * CT_UNIT, 1u8, AcceptedFundingAsset::USDT);
-			let plmc_required = inst.calculate_contributed_plmc_spent(vec![contribution.clone()], wap);
+			let plmc_required = inst.calculate_contributed_plmc_spent(vec![contribution.clone()], wap, false);
 			let frozen_amount = plmc_required[0].plmc_amount;
 			let plmc_existential_deposits = plmc_required.accounts().existential_deposits();
 
@@ -1089,7 +1089,7 @@ mod remaining_contribute_extrinsic {
 			let wap = inst.get_project_details(project_id).weighted_average_price.unwrap();
 
 			let contribution = ContributionParams::new(BUYER_4, 500 * CT_UNIT, 5u8, AcceptedFundingAsset::USDT);
-			let plmc_required = inst.calculate_contributed_plmc_spent(vec![contribution.clone()], wap);
+			let plmc_required = inst.calculate_contributed_plmc_spent(vec![contribution.clone()], wap, false);
 			let frozen_amount = plmc_required[0].plmc_amount;
 			let plmc_existential_deposits = plmc_required.accounts().existential_deposits();
 
@@ -1250,7 +1250,7 @@ mod remaining_contribute_extrinsic {
 				.map(|_| ContributionParams::new(CONTRIBUTOR, token_amount, 1u8, AcceptedFundingAsset::USDT))
 				.collect();
 
-			let plmc_funding = inst.calculate_contributed_plmc_spent(contributions.clone(), token_price);
+			let plmc_funding = inst.calculate_contributed_plmc_spent(contributions.clone(), token_price, false);
 			let plmc_existential_deposits = plmc_funding.accounts().existential_deposits();
 
 			let foreign_funding = inst.calculate_contributed_funding_asset_spent(contributions.clone(), token_price);
@@ -1647,7 +1647,7 @@ mod remaining_contribute_extrinsic {
 			let wap = inst.get_project_details(project_id).weighted_average_price.unwrap();
 
 			// 1 unit less native asset than needed
-			let plmc_funding = inst.calculate_contributed_plmc_spent(vec![contribution.clone()], wap);
+			let plmc_funding = inst.calculate_contributed_plmc_spent(vec![contribution.clone()], wap, false);
 			let plmc_existential_deposits = plmc_funding.accounts().existential_deposits();
 			inst.mint_plmc_to(plmc_funding.clone());
 			inst.mint_plmc_to(plmc_existential_deposits.clone());
@@ -1670,7 +1670,7 @@ mod remaining_contribute_extrinsic {
 			});
 
 			// 1 unit less funding asset than needed
-			let plmc_funding = inst.calculate_contributed_plmc_spent(vec![contribution.clone()], wap);
+			let plmc_funding = inst.calculate_contributed_plmc_spent(vec![contribution.clone()], wap, false);
 			let plmc_existential_deposits = plmc_funding.accounts().existential_deposits();
 			inst.mint_plmc_to(plmc_funding.clone());
 			inst.mint_plmc_to(plmc_existential_deposits.clone());
@@ -1840,13 +1840,13 @@ mod remaining_contribute_extrinsic {
 			let wap = inst.get_project_details(project_id_2).weighted_average_price.unwrap();
 
 			// Necessary Mints
-			let already_bonded_plmc =
-				inst.calculate_evaluation_plmc_spent(vec![(evaluator_contributor, evaluation_amount).into()])[0]
-					.plmc_amount;
+			let already_bonded_plmc = inst
+				.calculate_evaluation_plmc_spent(vec![(evaluator_contributor, evaluation_amount).into()], false)[0]
+				.plmc_amount;
 			let usable_evaluation_plmc =
 				already_bonded_plmc - <TestRuntime as Config>::EvaluatorSlash::get() * already_bonded_plmc;
 			let necessary_plmc_for_contribution =
-				inst.calculate_contributed_plmc_spent(vec![evaluator_contribution.clone()], wap)[0].plmc_amount;
+				inst.calculate_contributed_plmc_spent(vec![evaluator_contribution.clone()], wap, false)[0].plmc_amount;
 			let necessary_usdt_for_contribution =
 				inst.calculate_contributed_funding_asset_spent(vec![evaluator_contribution.clone()], wap);
 			inst.mint_plmc_to(vec![UserToPLMCBalance::new(

--- a/pallets/funding/src/tests/7_settlement.rs
+++ b/pallets/funding/src/tests/7_settlement.rs
@@ -478,6 +478,7 @@ mod settle_successful_bid_extrinsic {
 				&bids,
 				project_metadata.clone(),
 				None,
+                true
 			);
 			let bidders_existential_deposits = bidders_plmc.accounts().existential_deposits();
 			inst.mint_plmc_to(bidders_plmc.clone());
@@ -496,7 +497,8 @@ mod settle_successful_bid_extrinsic {
 
 			// Mint the necessary community contribution balances
 			let final_price = inst.get_project_details(project_id).weighted_average_price.unwrap();
-			let contributors_plmc = inst.calculate_contributed_plmc_spent(community_contributions.clone(), final_price);
+			let contributors_plmc =
+				inst.calculate_contributed_plmc_spent(community_contributions.clone(), final_price, false);
 			let contributors_existential_deposits = contributors_plmc.accounts().existential_deposits();
 			inst.mint_plmc_to(contributors_plmc.clone());
 			inst.mint_plmc_to(contributors_existential_deposits);
@@ -513,9 +515,9 @@ mod settle_successful_bid_extrinsic {
 			inst.settle_project(project_id).unwrap();
 
 			let plmc_locked_for_accepted_bid =
-				inst.calculate_auction_plmc_charged_with_given_price(&accepted_bid, final_price);
+				inst.calculate_auction_plmc_charged_with_given_price(&accepted_bid, final_price, false);
 			let plmc_locked_for_rejected_bid =
-				inst.calculate_auction_plmc_charged_with_given_price(&rejected_bid, final_price);
+				inst.calculate_auction_plmc_charged_with_given_price(&rejected_bid, final_price, false);
 
 			let UserToPLMCBalance { account: accepted_user, plmc_amount: accepted_plmc_amount } =
 				plmc_locked_for_accepted_bid[0];
@@ -638,7 +640,7 @@ mod settle_successful_contribution_extrinsic {
 			);
 			let wap = inst.get_project_details(project_id).weighted_average_price.unwrap();
 
-			let plmc_required = inst.calculate_contributed_plmc_spent(vec![contribution_mul_2.clone()], wap);
+			let plmc_required = inst.calculate_contributed_plmc_spent(vec![contribution_mul_2.clone()], wap, false);
 			let plmc_ed = plmc_required.accounts().existential_deposits();
 			inst.mint_plmc_to(plmc_required.clone());
 			inst.mint_plmc_to(plmc_ed);
@@ -1209,7 +1211,7 @@ mod settle_failed_contribution_extrinsic {
 			);
 			let wap = inst.get_project_details(project_id).weighted_average_price.unwrap();
 
-			let plmc_required = inst.calculate_contributed_plmc_spent(vec![contribution_mul_2.clone()], wap);
+			let plmc_required = inst.calculate_contributed_plmc_spent(vec![contribution_mul_2.clone()], wap, false);
 			let plmc_ed = plmc_required.accounts().existential_deposits();
 			inst.mint_plmc_to(plmc_required.clone());
 			inst.mint_plmc_to(plmc_ed);

--- a/pallets/funding/src/tests/misc.rs
+++ b/pallets/funding/src/tests/misc.rs
@@ -112,7 +112,7 @@ mod helper_functions {
 		];
 
 		let calculated_plmc_spent = inst
-			.calculate_evaluation_plmc_spent(evaluations)
+			.calculate_evaluation_plmc_spent(evaluations, false)
 			.into_iter()
 			.sorted_by(|a, b| a.account.cmp(&b.account))
 			.map(|map| map.plmc_amount)
@@ -287,6 +287,7 @@ mod helper_functions {
 					CT_DECIMALS,
 				)
 				.unwrap(),
+				false,
 			)
 			.into_iter()
 			.sorted_by(|a, b| a.account.cmp(&b.account))


### PR DESCRIPTION
## What?
- Make it possible to add the ED amount to PLMC calculations on evaluations/auctions/contributions

## Why?
- To avoid having to calculate and mint the ED separately

## How?
- Add a new bool `with_ed` to the functions

## Testing?
Existing tests should pass, now that a lot of them were updated
