### PR TITLE
:sparkles: add policy check to dispenser pallet

### DIFF
--- a/pallets/dispenser/src/benchmarking.rs
+++ b/pallets/dispenser/src/benchmarking.rs
@@ -23,7 +23,7 @@ use crate::Pallet as Dispenser;
 use frame_benchmarking::v2::*;
 use frame_support::traits::{EnsureOrigin, Get};
 use frame_system::RawOrigin;
-use polimec_common_test_utils::{generate_did_from_account, get_mock_jwt};
+use polimec_common_test_utils::{generate_did_from_account, get_mock_jwt_with_cid};
 use sp_runtime::traits::One;
 
 fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
@@ -40,7 +40,7 @@ mod benchmarks {
 		assert_eq!(Dispensed::<T>::get(did.clone()), None);
 		CurrencyOf::<T>::deposit_creating(&Dispenser::<T>::dispense_account(), T::InitialDispenseAmount::get());
 
-		let jwt = get_mock_jwt(caller.clone(), InvestorType::Retail, did.clone());
+		let jwt = get_mock_jwt_with_cid(caller.clone(), InvestorType::Retail, did.clone(), T::WhitelistedPolicy::get());
 		#[extrinsic_call]
 		dispense(RawOrigin::Signed(caller.clone()), jwt);
 

--- a/pallets/dispenser/src/mock.rs
+++ b/pallets/dispenser/src/mock.rs
@@ -19,7 +19,8 @@
 use frame_support::{derive_impl, ord_parameter_types, parameter_types, traits::tokens::WithdrawReasons, PalletId};
 use frame_system as system;
 use frame_system::EnsureSignedBy;
-use polimec_common::credentials::EnsureInvestor;
+use polimec_common::credentials::{Cid, EnsureInvestor};
+use polimec_common_test_utils::generate_cid_from_string;
 use sp_runtime::{traits::ConvertInto, BuildStorage};
 
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -69,6 +70,7 @@ impl pallet_vesting::Config for Test {
 	const MAX_VESTING_SCHEDULES: u32 = 28;
 }
 
+const IPFS_CID: &str = "QmeuJ24ffwLAZppQcgcggJs3n689bewednYkuc8Bx5Gngz";
 parameter_types! {
 	pub const InitialDispenseAmount: u64 = 100;
 	pub const FreeDispenseAmount: u64 = 5;
@@ -79,6 +81,7 @@ parameter_types! {
 		32, 118, 30, 171, 58, 212, 197, 27, 146, 122, 255, 243, 34, 245, 90, 244, 221, 37, 253,
 		195, 18, 202, 111, 55, 39, 48, 123, 17, 101, 78, 215, 94,
 	];
+	pub WhitelistedPolicy: Cid = generate_cid_from_string(IPFS_CID);
 }
 
 ord_parameter_types! {
@@ -98,6 +101,7 @@ impl crate::Config for Test {
 	type VestPeriod = VestPeriod;
 	type VestingSchedule = Vesting;
 	type WeightInfo = ();
+	type WhitelistedPolicy = WhitelistedPolicy;
 }
 
 pub(crate) struct ExtBuilder {

--- a/polimec-common/test-utils/src/lib.rs
+++ b/polimec-common/test-utils/src/lib.rs
@@ -130,6 +130,10 @@ pub fn generate_did_from_account(account_id: impl Parameter) -> Did {
 	hex_account.into_bytes().try_into().unwrap()
 }
 
+pub fn generate_cid_from_string(cid: &str) -> BoundedVec<u8, ConstU32<96>> {
+	BoundedVec::try_from(cid.as_bytes().to_vec()).unwrap()
+}
+
 #[cfg(feature = "std")]
 pub fn do_request(url: &str) -> String {
 	reqwest::blocking::Client::builder()

--- a/runtimes/polimec/src/lib.rs
+++ b/runtimes/polimec/src/lib.rs
@@ -1125,6 +1125,7 @@ impl pallet_dispenser::Config for Runtime {
 	type VestPeriod = DispenserVestPeriod;
 	type VestingSchedule = Vesting;
 	type WeightInfo = weights::pallet_dispenser::WeightInfo<Runtime>;
+	type WhitelistedPolicy = DispenserWhitelistedPolicy;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.

--- a/runtimes/politest/src/lib.rs
+++ b/runtimes/politest/src/lib.rs
@@ -1107,6 +1107,7 @@ impl pallet_dispenser::Config for Runtime {
 	type VestPeriod = DispenserVestPeriod;
 	type VestingSchedule = Vesting;
 	type WeightInfo = ();
+	type WhitelistedPolicy = DispenserWhitelistedPolicy;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.

--- a/runtimes/shared-configuration/src/assets.rs
+++ b/runtimes/shared-configuration/src/assets.rs
@@ -23,6 +23,7 @@ use frame_support::{parameter_types, PalletId};
 use orml_traits::DataProvider;
 use pallet_funding::traits::ProvideAssetPrice;
 use parachains_common::DAYS;
+use polimec_common::credentials::Cid;
 use sp_arithmetic::FixedPointNumber;
 
 parameter_types! {
@@ -58,5 +59,5 @@ parameter_types! {
 	pub const DispenserId: PalletId = PalletId(*b"plmc/fct");
 	pub const DispenserLockPeriod: u32 = DAYS * 365 * 2; // 2 years
 	pub const DispenserVestPeriod: u32 = DAYS * 365 * 2; // 2 years
-
+	pub DispenserWhitelistedPolicy: Cid = (*b"QmVdGSxuWcamYEmYJjR3gvZucqQpp4Jnf6tqJABHwKZVo3").to_vec().try_into().unwrap();
 }


### PR DESCRIPTION
## What?

Add a policy check to the dispenser pallet

## Why?

We need to filter user credentials based on a specified policy. Policy can be found at https://cloudflare-ipfs.com/ipfs/QmVdGSxuWcamYEmYJjR3gvZucqQpp4Jnf6tqJABHwKZVo3

## How?

Added a Pallet config item for the whitelisted policy. 

## Testing?

Added `user_cannot_dispense_with_wrong_policy` and updated the rest of the tests.

## Screenshots (optional)

## Anything Else?
