### PR TITLE
⬆️ 0.7.5 Release Polimec/Politest

### DIFF
--- a/runtimes/polimec/src/lib.rs
+++ b/runtimes/polimec/src/lib.rs
@@ -157,10 +157,11 @@ pub type Migrations = migrations::Unreleased;
 /// The runtime migrations per release.
 #[allow(missing_docs)]
 pub mod migrations {
-	use crate::{custom_migrations::init_pallet::InitializePallet, DmpQueue};
+	use crate::Runtime;
+
 	/// Unreleased migrations. Add new ones here:
 	#[allow(unused_parens)]
-	pub type Unreleased = (InitializePallet<DmpQueue>);
+	pub type Unreleased = (pallet_funding::storage_migrations::v3::MigrationToV3<Runtime>);
 }
 
 /// Executive: handles dispatch to the various modules.
@@ -206,7 +207,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("polimec-mainnet"),
 	impl_name: create_runtime_str!("polimec-mainnet"),
 	authoring_version: 1,
-	spec_version: 0_007_001,
+	spec_version: 0_007_002,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtimes/politest/src/lib.rs
+++ b/runtimes/politest/src/lib.rs
@@ -166,8 +166,10 @@ pub type Migrations = migrations::Unreleased;
 /// The runtime migrations per release.
 #[allow(missing_docs)]
 pub mod migrations {
+	use crate::Runtime;
+
 	/// Unreleased migrations. Add new ones here:
-	pub type Unreleased = ();
+	pub type Unreleased = (pallet_funding::storage_migrations::v3::MigrationToV3<Runtime>);
 }
 
 /// Executive: handles dispatch to the various modules.
@@ -213,7 +215,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("politest"),
 	impl_name: create_runtime_str!("politest"),
 	authoring_version: 1,
-	spec_version: 0_007_004,
+	spec_version: 0_007_005,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
## What?
- New runtime for Politest and Polimec

## Why?
- WAP calculation changed
- Evaluator rewards fixed

## How?
- Bump version and write migration for ProjectDetails

## Testing?
Try-runtime output for polimec:
```sh
polimec-node on  06-03-new-release [!] via 🦀 v1.76.0-nightly 
❯ try-runtime --runtime ./target/release/wbuild/polimec-runtime/polimec_runtime.compact.compressed.wasm on-runtime-upgrade live --uri wss://rpc.polimec.org:443
[2024-06-03T15:07:18Z INFO  remote-ext] replacing wss:// in uri with https://: "https://rpc.polimec.org:443" (ws is currently unstable for fetching remote storage, for more see https://github.com/paritytech/jsonrpsee/issues/1086)
[2024-06-03T15:07:18Z INFO  remote-ext] since no at is provided, setting it to latest finalized head, 0xd014d5b26ca93fab61eb751f501e7c3dd8261294312177d192863dbe09b457a6
[2024-06-03T15:07:18Z INFO  remote-ext] since no prefix is filtered, the data for all pallets will be downloaded
[2024-06-03T15:07:18Z INFO  remote-ext] scraping key-pairs from remote at block height 0xd014d5b26ca93fab61eb751f501e7c3dd8261294312177d192863dbe09b457a6
✅ Found 7323 keys (0.40s)
[00:00:01] ✅ Downloaded key values 5,262.6345/s [=======================================================================================================] 7323/7323 (0s)
✅ Inserted keys into DB (0.03s)
[2024-06-03T15:07:20Z INFO  remote-ext] adding data for hashed prefix: , took 1.90s
[2024-06-03T15:07:20Z INFO  remote-ext] adding data for hashed key: 3a636f6465
[2024-06-03T15:07:20Z INFO  remote-ext] adding data for hashed key: 26aa394eea5630e07c48ae0c9558cef7f9cce9c888469bb1a0dceaa129672ef8
[2024-06-03T15:07:20Z INFO  remote-ext] adding data for hashed key: 26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac
[2024-06-03T15:07:20Z INFO  remote-ext] 👩‍👦 no child roots found to scrape
[2024-06-03T15:07:20Z INFO  remote-ext] initialized state externalities with storage root 0xef346e03d62a4c25945962c2172acdd1cb25ddf239c984e5a9144f5ae057b13b and state_version V1
[2024-06-03T15:07:20Z INFO  try-runtime::cli] Original runtime [Name: RuntimeString::Owned("polimec-mainnet")] [Version: 7001] [Code hash: 0xb7f5...fa01]
[2024-06-03T15:07:20Z INFO  try-runtime::cli] New runtime      [Name: RuntimeString::Owned("polimec-mainnet")] [Version: 8000] [Code hash: 0x9b0e...e800]
[2024-06-03T15:07:20Z INFO  try-runtime::cli] 🚀 Speed up your workflow by using snapshots instead of live state. See `try-runtime create-snapshot --help`.
[2024-06-03T15:07:20Z INFO  try_runtime_core::misc] ------------------------------------------------------------------
    
    
[2024-06-03T15:07:20Z INFO  try_runtime_core::misc] 🔬 Running TryRuntime_on_runtime_upgrade with checks: PreAndPost
    
    
[2024-06-03T15:07:20Z INFO  try_runtime_core::misc] ------------------------------------------------------------------
    
    
[2024-06-03T15:07:21Z INFO  frame_support::migrations] 🚚 Pallet "Funding" VersionedMigration migrating storage version from 2 to 3.
[2024-06-03T15:07:21Z INFO  runtime::executive] ✅ Entire runtime state decodes without error. 430868 bytes total.
[2024-06-03T15:07:21Z INFO  try_runtime_core::misc] ------------------------------------------------------------------------------------------------------
    
    
[2024-06-03T15:07:21Z INFO  try_runtime_core::misc] 🔬 TryRuntime_on_runtime_upgrade succeeded! Running it again without checks for weight measurements.
    
    
[2024-06-03T15:07:21Z INFO  try_runtime_core::misc] ------------------------------------------------------------------------------------------------------
    
    
[2024-06-03T15:07:21Z INFO  frame_support::migrations] 🚚 Pallet "Funding" VersionedMigration migrating storage version from 2 to 3.
[2024-06-03T15:07:21Z INFO  try_runtime_core::misc] ---------------------------------------------------------------------------------
    
    
[2024-06-03T15:07:21Z INFO  try_runtime_core::misc] 🔬 Running TryRuntime_on_runtime_upgrade again to check idempotency: PreAndPost
    
    
[2024-06-03T15:07:21Z INFO  try_runtime_core::misc] ---------------------------------------------------------------------------------
    
    
[2024-06-03T15:07:21Z WARN  frame_support::migrations] 🚚 Pallet "Funding" VersionedMigration migration 2->3 can be removed; on-chain is already at StorageVersion(3).
[2024-06-03T15:07:21Z INFO  runtime::executive] ✅ Entire runtime state decodes without error. 430868 bytes total.
[2024-06-03T15:07:21Z INFO  try-runtime::cli] PoV size (zstd-compressed compact proof): 7.1 KB. For parachains, it's your responsibility to verify that a PoV of this size fits within any relaychain constraints.
[2024-06-03T15:07:21Z INFO  try-runtime::cli] Consumed ref_time: 0.001175s (0.23% of max 0.5s)
[2024-06-03T15:07:21Z INFO  try-runtime::cli] ✅ No weight safety issues detected. Please note this does not guarantee a successful runtime upgrade. Always test your runtime upgrade with recent state, and ensure that the weight usage of your migrations will not drastically differ between testing and actual on-chain execution.
```

Politest output:
```sh
polimec-node on  06-03-new-release [!] via 🦀 v1.76.0-nightly 
❯ try-runtime --runtime ./target/release/wbuild/politest-runtime/politest_runtime.compact.compressed.wasm on-runtime-upgrade live --uri wss://beta.rolimec.org:443
[2024-06-03T15:08:58Z INFO  remote-ext] replacing wss:// in uri with https://: "https://beta.rolimec.org:443" (ws is currently unstable for fetching remote storage, for more see https://github.com/paritytech/jsonrpsee/issues/1086)
[2024-06-03T15:08:58Z INFO  remote-ext] since no at is provided, setting it to latest finalized head, 0x8bcc13d328c028a0a6c5d40b07b27c14b13fc64c8325397ad0b20e49594c2f23
[2024-06-03T15:08:58Z INFO  remote-ext] since no prefix is filtered, the data for all pallets will be downloaded
[2024-06-03T15:08:58Z INFO  remote-ext] scraping key-pairs from remote at block height 0x8bcc13d328c028a0a6c5d40b07b27c14b13fc64c8325397ad0b20e49594c2f23
✅ Found 4901 keys (0.24s)
[00:00:01] ✅ Downloaded key values 4,507.4666/s [=======================================================================================================] 4901/4901 (0s)
✅ Inserted keys into DB (0.02s)
[2024-06-03T15:08:59Z INFO  remote-ext] adding data for hashed prefix: , took 1.43s
[2024-06-03T15:08:59Z INFO  remote-ext] adding data for hashed key: 3a636f6465
[2024-06-03T15:08:59Z INFO  remote-ext] adding data for hashed key: 26aa394eea5630e07c48ae0c9558cef7f9cce9c888469bb1a0dceaa129672ef8
[2024-06-03T15:08:59Z INFO  remote-ext] adding data for hashed key: 26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac
[2024-06-03T15:09:00Z INFO  remote-ext] 👩‍👦 no child roots found to scrape
[2024-06-03T15:09:00Z INFO  remote-ext] initialized state externalities with storage root 0x72b4d17b9898800f58b7e65186a4d3a04517f8a86554fdc9cf097e5d8090b935 and state_version V1
[2024-06-03T15:09:00Z INFO  try-runtime::cli] Original runtime [Name: RuntimeString::Owned("politest")] [Version: 7005] [Code hash: 0xd45f...b7e5]
[2024-06-03T15:09:00Z INFO  try-runtime::cli] New runtime      [Name: RuntimeString::Owned("politest")] [Version: 8000] [Code hash: 0x9897...cbae]
[2024-06-03T15:09:00Z INFO  try-runtime::cli] 🚀 Speed up your workflow by using snapshots instead of live state. See `try-runtime create-snapshot --help`.
[2024-06-03T15:09:00Z INFO  try_runtime_core::misc] ------------------------------------------------------------------
    
    
[2024-06-03T15:09:00Z INFO  try_runtime_core::misc] 🔬 Running TryRuntime_on_runtime_upgrade with checks: PreAndPost
    
    
[2024-06-03T15:09:00Z INFO  try_runtime_core::misc] ------------------------------------------------------------------
    
    
[2024-06-03T15:09:00Z INFO  frame_support::migrations] 🚚 Pallet "Funding" VersionedMigration migrating storage version from 2 to 3.
[2024-06-03T15:09:00Z INFO  runtime::executive] ✅ Entire runtime state decodes without error. 212814 bytes total.
[2024-06-03T15:09:00Z INFO  try_runtime_core::misc] ------------------------------------------------------------------------------------------------------
    
    
[2024-06-03T15:09:00Z INFO  try_runtime_core::misc] 🔬 TryRuntime_on_runtime_upgrade succeeded! Running it again without checks for weight measurements.
    
    
[2024-06-03T15:09:00Z INFO  try_runtime_core::misc] ------------------------------------------------------------------------------------------------------
    
    
[2024-06-03T15:09:00Z INFO  frame_support::migrations] 🚚 Pallet "Funding" VersionedMigration migrating storage version from 2 to 3.
[2024-06-03T15:09:00Z INFO  try_runtime_core::misc] ---------------------------------------------------------------------------------
    
    
[2024-06-03T15:09:00Z INFO  try_runtime_core::misc] 🔬 Running TryRuntime_on_runtime_upgrade again to check idempotency: PreAndPost
    
    
[2024-06-03T15:09:00Z INFO  try_runtime_core::misc] ---------------------------------------------------------------------------------
    
    
[2024-06-03T15:09:00Z WARN  frame_support::migrations] 🚚 Pallet "Funding" VersionedMigration migration 2->3 can be removed; on-chain is already at StorageVersion(3).
[2024-06-03T15:09:00Z INFO  runtime::executive] ✅ Entire runtime state decodes without error. 212814 bytes total.
[2024-06-03T15:09:00Z INFO  try-runtime::cli] PoV size (zstd-compressed compact proof): 9.6 KB. For parachains, it's your responsibility to verify that a PoV of this size fits within any relaychain constraints.
[2024-06-03T15:09:00Z INFO  try-runtime::cli] Consumed ref_time: 0.007325s (1.47% of max 0.5s)
[2024-06-03T15:09:00Z INFO  try-runtime::cli] ✅ No weight safety issues detected. Please note this does not guarantee a successful runtime upgrade. Always test your runtime upgrade with recent state, and ensure that the weight usage of your migrations will not drastically differ between testing and actual on-chain execution.
```

## Anything else?
Srtool output:
```sh
✨ Your Substrate WASM Runtime is ready! ✨
✨ WASM  : runtimes/polimec/target/srtool/production/wbuild/polimec-runtime/polimec_runtime.compact.wasm
✨ Z_WASM: runtimes/polimec/target/srtool/production/wbuild/polimec-runtime/polimec_runtime.compact.compressed.wasm
Summary generated with srtool v0.15.0 using the docker image paritytech/srtool:1.77.0:
 Package     : polimec-runtime v0.7.0
 GIT commit  : 70a2e8272bdbf5841f413761035d177c1d4fd242
 GIT tag     : v0.7.1
 GIT branch  : 06-03-new-release
 Rustc       : rustc 1.77.0 (aedd173a2 2024-03-17)
 Time        : 2024-06-03T16:00:02Z

== Compact
 Version          : polimec-mainnet-8000 (polimec-mainnet-0.tx2.au1)
 Metadata         : V14
 Size             : 5.06 MB (5310465 bytes)
 setCode          : 0x06af567b18b0cf38fe65ab3d343a7d273ae62c845ee92f07d59507563e193642
 authorizeUpgrade : 0xc0e16c491677d5288a41fdc23899b9d31d1baf6ba6a10776270d1aff36361a3a
 IPFS             : QmQaspjJBhC3NXZcqUwivwbdnnV1vuafbK216uat6vcBme
 BLAKE2_256       : 0x4ce5d816233409c0b4fa87ac0a52a2e4dea8159d09f757b2e1cfc1e01defaba5
 Wasm             : runtimes/polimec/target/srtool/production/wbuild/polimec-runtime/polimec_runtime.compact.wasm

== Compressed
 Version          : polimec-mainnet-8000 (polimec-mainnet-0.tx2.au1)
 Metadata         : V14
 Size             : 1.26 MB (1320120 bytes)
 Compression      : 75.15%
 setCode          : 0x9ddad8e071d1f5fdbb422e2519c2748b3ab71b6c700a79f04d53ed5543488e33
 authorizeUpgrade : 0xf50fa40ec27e04f9059669d1e48b057e43474ddcede4e289aba63529cbb519f4
 IPFS             : QmQ8GTsFbstKtaPnoHntvmEk2o5Lg6tV4vVbsNDS6dCw2m
 BLAKE2_256       : 0x6014bb2c081c70360f5d3ef5c18f6930a6ec1ed0670f8f761fc17551194b9bb4
 Wasm             : runtimes/polimec/target/srtool/production/wbuild/polimec-runtime/polimec_runtime.compact.compressed.wasm

``