### PR TITLE
🔧 Fix storage migration

### DIFF
--- a/pallets/funding/src/storage_migrations.rs
+++ b/pallets/funding/src/storage_migrations.rs
@@ -170,6 +170,23 @@ pub mod v3 {
 	use sp_core::{Decode, Encode, MaxEncodedLen, RuntimeDebug};
 	use sp_std::marker::PhantomData;
 
+	#[derive(Default, Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	pub enum OldProjectStatus {
+		#[default]
+		Application,
+		EvaluationRound,
+		AuctionInitializePeriod,
+		AuctionOpening,
+		AuctionClosing,
+		CommunityRound,
+		RemainderRound,
+		FundingFailed,
+		AwaitingProjectDecision,
+		FundingSuccessful,
+		ReadyToStartMigration,
+		MigrationCompleted,
+	}
 	#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
 	pub struct OldProjectDetails<
 		AccountId,
@@ -186,7 +203,7 @@ pub mod v3 {
 		/// The price in USD per token decided after the Auction Round
 		pub weighted_average_price: Option<Price>,
 		/// The current status of the project
-		pub status: ProjectStatus,
+		pub status: OldProjectStatus,
 		/// When the different project phases start and end
 		pub phase_transition_points: PhaseTransitionPoints<BlockNumber>,
 		/// Fundraising target amount in USD (6 decimals)
@@ -215,12 +232,26 @@ pub mod v3 {
 			let mut items = 0;
 			let mut translate = |_key, item: OldProjectDetailsOf<T>| -> Option<ProjectDetailsOf<T>> {
 				items += 1;
+				let new_status = match item.status {
+					OldProjectStatus::Application => ProjectStatus::Application,
+					OldProjectStatus::EvaluationRound => ProjectStatus::EvaluationRound,
+					OldProjectStatus::AuctionInitializePeriod => ProjectStatus::AuctionInitializePeriod,
+					OldProjectStatus::AuctionOpening => ProjectStatus::AuctionOpening,
+					OldProjectStatus::AuctionClosing => ProjectStatus::AuctionClosing,
+					OldProjectStatus::CommunityRound => ProjectStatus::CommunityRound,
+					OldProjectStatus::RemainderRound => ProjectStatus::RemainderRound,
+					OldProjectStatus::FundingFailed => ProjectStatus::FundingFailed,
+					OldProjectStatus::AwaitingProjectDecision => ProjectStatus::AwaitingProjectDecision,
+					OldProjectStatus::FundingSuccessful => ProjectStatus::FundingSuccessful,
+					OldProjectStatus::ReadyToStartMigration => ProjectStatus::ReadyToStartMigration,
+					OldProjectStatus::MigrationCompleted => ProjectStatus::MigrationCompleted,
+				};
 				Some(ProjectDetailsOf::<T> {
 					issuer_account: item.issuer_account,
 					issuer_did: item.issuer_did,
 					is_frozen: item.is_frozen,
 					weighted_average_price: item.weighted_average_price,
-					status: item.status,
+					status: new_status,
 					phase_transition_points: item.phase_transition_points,
 					fundraising_target_usd: item.fundraising_target_usd,
 					remaining_contribution_tokens: item.remaining_contribution_tokens,

--- a/scripts/chopsticks/polimec-testing/polkadot-polimec.yml
+++ b/scripts/chopsticks/polimec-testing/polkadot-polimec.yml
@@ -1,0 +1,96 @@
+db: ./db.sqlite
+mock-signature-host: true
+endpoint: wss://rpc.polimec.org
+import-storage:
+  System:
+    Account:
+      # account0 - 50k PLMC
+      - - - "5Ca5mpGKqE8BTo7ZvF6S4aN7j2DoWPgp5L6p3q9hm25fsy1z"
+        - providers: 1
+          data:
+            free: "500000000000000"
+
+      # account1 - 50k PLMC
+      - - - "5EoHniZVuKRKNXNtVZzw8Jbc8Qtgy8GN5QKDKSA78HEok7YW"
+        - providers: 1
+          data:
+            free: "500000000000000"
+
+      # account2 - 50k PLMC
+      - - - "5GeXY2mKL4ADz7mDtsuHvNrRky48NqdWb4u8c5Sg9N8s3T1y"
+        - providers: 1
+          data:
+            free: "500000000000000"
+
+      # account3 - 50k PLMC
+      - - - "5EfE8r9uWWMazvyh8tkcuuKSy6PbAZQSqq42CXYwGdvwjpb8"
+        - providers: 1
+          data:
+            free: "500000000000000"
+
+      # account4 - 50k PLMC
+      - - - "5C8ULBGhfaP2nmDcuFbiShQ1hMwWsB7ghbChDKAwdszSWnA5"
+        - providers: 1
+          data:
+            free: "500000000000000"
+
+      # account5 - 50k PLMC
+      - - - "5HGqvcE29nHekDEYND3ZZtobbP4UeCcALFgwEm5YUvroZJr6"
+        - providers: 1
+          data:
+            free: "500000000000000"
+
+      # account6 - 50k PLMC
+      - - - "5CGEmsGTJcYSBCdXvsjDUBxW2dtvte5M8By95gwMwToih37s"
+        - providers: 1
+          data:
+            free: "500000000000000"
+
+      # account7 - 50k PLMC
+      - - - "5GsWm46kXRF7p6ifSQjrdc8HgPbzY4uWgJdQSUcGGDczkDGa"
+        - providers: 1
+          data:
+            free: "500000000000000"
+
+      # account8 - 50k PLMC
+      - - - "5H4AWTrkHN6aaQCv2jn48HVZjGhiCqswt6sPBksFPrrf2FPY"
+        - providers: 1
+          data:
+            free: "500000000000000"
+
+      # account9 - 50k PLMC
+      - - - "5CabLepLT8e6NvJCtzrEZLEBRd1FxKXU72F2NvbYTVf3bNej"
+        - providers: 1
+          data:
+            free: "500000000000000"
+
+
+  ForeignAssets:
+    Account:
+      # account0 - 50k DOT, 50k USDT, 50k USDC
+      [
+        [
+          [1984, 5Ca5mpGKqE8BTo7ZvF6S4aN7j2DoWPgp5L6p3q9hm25fsy1z],
+          { balance: 50000000 },
+        ],
+        [
+          [1337, 5Ca5mpGKqE8BTo7ZvF6S4aN7j2DoWPgp5L6p3q9hm25fsy1z],
+          { balance: 50000000 },
+        ],
+        [
+          [ 10, 5Ca5mpGKqE8BTo7ZvF6S4aN7j2DoWPgp5L6p3q9hm25fsy1z ],
+          { balance: 500000000000 },
+        ],
+      ]
+
+  Council:
+    Members:
+      [
+          "5Ca5mpGKqE8BTo7ZvF6S4aN7j2DoWPgp5L6p3q9hm25fsy1z",
+      ]
+
+  TechnicalCommittee:
+    Members:
+      [
+        "5Ca5mpGKqE8BTo7ZvF6S4aN7j2DoWPgp5L6p3q9hm25fsy1z",
+      ]

--- a/scripts/zombienet/native/polkadot-polimec.toml
+++ b/scripts/zombienet/native/polkadot-polimec.toml
@@ -1,0 +1,25 @@
+[settings]
+timeout = 1000
+provider = "native"
+
+[relaychain]
+default_command = "polkadot"
+chain_spec_path = "/usr/local/paseo-local.plain.json"
+
+	[[relaychain.nodes]]
+	name = "alice"
+
+	[[relaychain.nodes]]
+	name = "bob"
+
+[[parachains]]
+id = 3344
+chain_spec_path = "chain-specs/paseo/temp.json"
+
+[[parachains.collators]]
+name = "polimec-collator"
+ws_port = 8888
+command = "./target/release/polimec-node"
+args = ["--offchain-worker when-authority --log ocw=trace"]
+# ss58 key: 5Do5UoayFvDrHroGS1YMqxTVUysSkrhNwVMzmj1foVb3vzzb
+keystore_key_types = ["aura", "plmc_sr"]


### PR DESCRIPTION
## What?
- Fix a bug in the storage migration of pallet funding from 2->3

## Why?
- ProjectStatus was wrongly migrated inside ProjectDetails

## How?
- We added a new status `CalculatingWap` which changed the indices of all enums when encoded, which we forgot to account for

## Testing?
Tested by forking Polkadot and Polimec with chopsticks using `npx @acala-network/chopsticks@latest xcm -r polkadot -p scripts/chopsticks/polimec-testing/polkadot-polimec.yml
`

## Anything Else?
The new chopsticks script replaces the Council and TC with test accounts, which means we can quickly do sudo operations
