### PR TITLE
⬆️ Update penpal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2352,20 +2352,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cumulus-primitives-timestamp"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d1d900bd9e76607a4a0734cbb2b004d86177d2d6938b5d25eb812c6c1b7500"
-dependencies = [
- "cumulus-primitives-core",
- "futures",
- "parity-scale-codec",
- "sp-inherents",
- "sp-std",
- "sp-timestamp",
-]
-
-[[package]]
 name = "cumulus-primitives-utility"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8165,8 +8151,9 @@ dependencies = [
 
 [[package]]
 name = "penpal-runtime"
-version = "0.9.27"
+version = "0.14.3"
 dependencies = [
+ "assets-common",
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
  "cumulus-pallet-parachain-system",
@@ -8174,7 +8161,6 @@ dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
  "cumulus-primitives-core",
- "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",
  "frame-benchmarking",
  "frame-executive",
@@ -8183,7 +8169,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
- "hex-literal 0.3.4",
+ "hex-literal 0.4.1",
  "log",
  "pallet-asset-tx-payment",
  "pallet-assets",
@@ -8209,15 +8195,18 @@ dependencies = [
  "polkadot-runtime-parachains",
  "scale-info",
  "smallvec",
+ "snowbridge-rococo-common",
  "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-core",
+ "sp-genesis-builder",
  "sp-inherents",
  "sp-offchain",
  "sp-runtime",
  "sp-session",
  "sp-std",
+ "sp-storage",
  "sp-transaction-pool",
  "sp-version",
  "staging-parachain-info",
@@ -8456,6 +8445,7 @@ dependencies = [
 name = "polimec-receiver"
 version = "0.1.0"
 dependencies = [
+ "cumulus-pallet-xcm",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -8463,7 +8453,6 @@ dependencies = [
  "parity-scale-codec",
  "polimec-common",
  "polkadot-parachain-primitives",
- "polkadot-runtime-parachains",
  "scale-info",
  "serde",
  "sp-core",
@@ -12786,6 +12775,17 @@ dependencies = [
  "rustc_version 0.4.0",
  "sha2 0.10.8",
  "subtle 2.5.0",
+]
+
+[[package]]
+name = "snowbridge-rococo-common"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc8ddfb7bec2140079a788c312010f793d75fde1f996128517b0c14270296a4"
+dependencies = [
+ "frame-support",
+ "log",
+ "staging-xcm",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,7 @@ pallet-preimage = { version = "28.0.0", default-features = false }
 pallet-grandpa = { version = "28.0.0", default-features = false }
 pallet-transaction-payment-rpc = { version = "30.0.0" }
 pallet-vesting = { version = "28.0.0", default-features = false }
-pallet-staking = { version = "28.0.0", default-features = false }
+pallet-staking = { version = "28.0.1", default-features = false }
 pallet-proxy = { version = "28.0.0", default-features = false }
 pallet-identity = { version = "28.0.0", default-features = false }
 
@@ -182,10 +182,10 @@ cumulus-pallet-xcmp-queue = { version = "0.7.0", default-features = false }
 cumulus-primitives-core = { version = "0.7.0", default-features = false }
 cumulus-primitives-timestamp = { version = "0.7.0", default-features = false }
 cumulus-primitives-utility = { version = "0.7.3", default-features = false }
-pallet-collator-selection = { version = "9.0.0", default-features = false }
 parachain-info = { version = "0.7.0", package = 'staging-parachain-info', default-features = false }
 parachains-common = { version = "7.0.0", default-features = false }
 cumulus-primitives-aura = { version = "0.7.0", default-features = false }
+
 
 # Client-only (with default enabled)
 cumulus-client-cli = { version = "0.7.0" }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -76,7 +76,7 @@ pallet-treasury.workspace = true
 polkadot-runtime.workspace = true
 asset-hub-polkadot-runtime.workspace = true
 polimec-runtime.workspace = true
-penpal-runtime = { path = "./penpal", default-features = false }
+penpal-runtime = { path = "penpal", default-features = false }
 
 [features]
 default = [ "instant-mode", "std", "development-settings"]

--- a/integration-tests/penpal/Cargo.toml
+++ b/integration-tests/penpal/Cargo.toml
@@ -1,90 +1,96 @@
 [package]
 name = "penpal-runtime"
-version = "0.9.27"
+version = "0.14.3"
 authors = ["Anonymous"]
 description = "A parachain for communication back and forth with XCM of assets and uniques."
 license = "Unlicense"
 homepage = "https://substrate.io"
-repository = "https://github.com/paritytech/polkadot-sdk"
-edition = "2021"
+repository.workspace = true
+edition.workspace = true
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
-substrate-wasm-builder = { optional = true , workspace = true}
+substrate-wasm-builder = { workspace = true, optional = true }
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-hex-literal.workspace = true
-log.workspace = true
-scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
-smallvec = "1.10.0"
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
+hex-literal = { version = "0.4.1", optional = true }
+log = { version = "0.4.20", default-features = false }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+smallvec = "1.11.0"
 
 # Local
 polimec-receiver.workspace = true
 polimec-common.workspace = true
 
 # Substrate
-frame-benchmarking = { workspace = true, optional = true }
-frame-executive.workspace = true
-frame-support.workspace = true
-frame-system.workspace = true
-frame-system-benchmarking = { workspace = true, optional = true }
-frame-system-rpc-runtime-api.workspace = true
-frame-try-runtime = { workspace = true, optional = true }
-pallet-aura.workspace = true
-pallet-authorship.workspace = true
-pallet-balances.workspace = true
-pallet-message-queue.workspace = true
-pallet-session.workspace = true
-pallet-sudo.workspace = true
-pallet-timestamp.workspace = true
-pallet-transaction-payment.workspace = true
-pallet-transaction-payment-rpc-runtime-api.workspace = true
-pallet-asset-tx-payment.workspace = true
-pallet-assets.workspace = true
-sp-api.workspace = true
-sp-block-builder.workspace = true
-sp-consensus-aura.workspace = true
-sp-core.workspace = true
-sp-inherents.workspace = true
-sp-offchain.workspace = true
-sp-runtime.workspace = true
-sp-session.workspace = true
-sp-std.workspace = true
-sp-transaction-pool.workspace = true
-sp-version.workspace = true
+frame-benchmarking = { workspace = true, default-features = false, optional = true }
+frame-executive = { workspace = true, default-features = false }
+frame-support = { workspace = true, default-features = false }
+frame-system = { workspace = true, default-features = false }
+frame-system-benchmarking = { workspace = true, default-features = false, optional = true }
+frame-system-rpc-runtime-api = { workspace = true, default-features = false }
+frame-try-runtime = { workspace = true, default-features = false, optional = true }
+pallet-aura = { workspace = true, default-features = false }
+pallet-authorship = { workspace = true, default-features = false }
+pallet-balances = { workspace = true, default-features = false }
+pallet-session = { workspace = true, default-features = false }
+pallet-sudo = { workspace = true, default-features = false }
+pallet-timestamp = { workspace = true, default-features = false }
+pallet-transaction-payment = { workspace = true, default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { workspace = true, default-features = false }
+pallet-asset-tx-payment = { workspace = true, default-features = false }
+pallet-assets = { workspace = true, default-features = false }
+sp-api = { workspace = true, default-features = false }
+sp-block-builder = { workspace = true, default-features = false }
+sp-consensus-aura = { workspace = true, default-features = false }
+sp-core = { workspace = true, default-features = false }
+sp-genesis-builder = { workspace = true, default-features = false }
+sp-inherents = { workspace = true, default-features = false }
+sp-offchain = { workspace = true, default-features = false }
+sp-runtime = { workspace = true, default-features = false }
+sp-session = { workspace = true, default-features = false }
+sp-std = { workspace = true, default-features = false }
+sp-storage = { version = "19.0.0", default-features = false }
+sp-transaction-pool = { workspace = true, default-features = false }
+sp-version = { workspace = true, default-features = false }
 polkadot-runtime-parachains.workspace = true
+pallet-collator-selection = { version = "9.0.2", default-features = false }
+
+
 
 # Polkadot
-polkadot-primitives.workspace = true
-pallet-xcm.workspace = true
-polkadot-parachain-primitives.workspace = true
-polkadot-runtime-common.workspace = true
-xcm.workspace = true
-xcm-builder.workspace = true
-xcm-executor.workspace = true
+polkadot-primitives = { workspace = true, default-features = false }
+pallet-xcm = { workspace = true, default-features = false }
+polkadot-parachain-primitives = { workspace = true, default-features = false }
+polkadot-runtime-common = { workspace = true, default-features = false }
+xcm = { workspace = true, default-features = false }
+xcm-builder = { workspace = true, default-features = false }
+xcm-executor = { workspace = true, default-features = false }
 
 # Cumulus
-cumulus-pallet-aura-ext.workspace = true
-cumulus-pallet-dmp-queue.workspace = true
-cumulus-pallet-parachain-system.workspace = true
-cumulus-pallet-session-benchmarking.workspace = true
-cumulus-pallet-xcm.workspace = true
-cumulus-pallet-xcmp-queue.workspace = true
-cumulus-primitives-core.workspace = true
-cumulus-primitives-timestamp.workspace = true
-cumulus-primitives-utility.workspace = true
-pallet-collator-selection.workspace = true
-parachain-info.workspace = true
-parachains-common.workspace = true
+cumulus-pallet-aura-ext = { workspace = true, default-features = false }
+pallet-message-queue = { workspace = true, default-features = false }
+cumulus-pallet-dmp-queue = { workspace = true, default-features = false }
+cumulus-pallet-parachain-system = { workspace = true, default-features = false, features = ["parameterized-consensus-hook"] }
+cumulus-pallet-session-benchmarking = { workspace = true, default-features = false }
+cumulus-pallet-xcm = { workspace = true, default-features = false }
+cumulus-pallet-xcmp-queue = { workspace = true, default-features = false }
+cumulus-primitives-core = { workspace = true, default-features = false }
+cumulus-primitives-utility = { workspace = true, default-features = false }
+parachain-info = {  workspace = true, default-features = false }
+parachains-common = { workspace = true, default-features = false }
 pallet-vesting.workspace = true
+assets-common = { version = "0.7.0", default-features = false }
+snowbridge-rococo-common = { version = "0.1.0", default-features = false }
 
 [features]
-default = [ "std" ]
+default = ["std"]
 std = [
-	"codec/std",
+	"assets-common/std",
+	"parity-scale-codec/std",
 	"cumulus-pallet-aura-ext/std",
 	"cumulus-pallet-dmp-queue/std",
 	"cumulus-pallet-parachain-system/std",
@@ -92,15 +98,14 @@ std = [
 	"cumulus-pallet-xcm/std",
 	"cumulus-pallet-xcmp-queue/std",
 	"cumulus-primitives-core/std",
-	"cumulus-primitives-timestamp/std",
 	"cumulus-primitives-utility/std",
-	"frame-benchmarking/std",
+	"frame-benchmarking?/std",
 	"frame-executive/std",
 	"frame-support/std",
 	"frame-system-benchmarking?/std",
 	"frame-system-rpc-runtime-api/std",
 	"frame-system/std",
-	"frame-try-runtime/std",
+	"frame-try-runtime?/std",
 	"log/std",
 	"pallet-asset-tx-payment/std",
 	"pallet-assets/std",
@@ -114,26 +119,25 @@ std = [
 	"pallet-timestamp/std",
 	"pallet-transaction-payment-rpc-runtime-api/std",
 	"pallet-transaction-payment/std",
-	"pallet-vesting/std",
 	"pallet-xcm/std",
 	"parachain-info/std",
 	"parachains-common/std",
-	"polimec-common/std",
-	"polimec-receiver/std",
 	"polkadot-parachain-primitives/std",
 	"polkadot-primitives/std",
 	"polkadot-runtime-common/std",
-	"polkadot-runtime-parachains/std",
 	"scale-info/std",
+	"snowbridge-rococo-common/std",
 	"sp-api/std",
 	"sp-block-builder/std",
 	"sp-consensus-aura/std",
 	"sp-core/std",
+	"sp-genesis-builder/std",
 	"sp-inherents/std",
 	"sp-offchain/std",
 	"sp-runtime/std",
 	"sp-session/std",
 	"sp-std/std",
+	"sp-storage/std",
 	"sp-transaction-pool/std",
 	"sp-version/std",
 	"substrate-wasm-builder",
@@ -143,6 +147,7 @@ std = [
 ]
 
 runtime-benchmarks = [
+	"assets-common/runtime-benchmarks",
 	"cumulus-pallet-dmp-queue/runtime-benchmarks",
 	"cumulus-pallet-parachain-system/runtime-benchmarks",
 	"cumulus-pallet-session-benchmarking/runtime-benchmarks",
@@ -153,6 +158,7 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system-benchmarking/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
+	"hex-literal",
 	"pallet-asset-tx-payment/runtime-benchmarks",
 	"pallet-assets/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks",
@@ -160,15 +166,12 @@ runtime-benchmarks = [
 	"pallet-message-queue/runtime-benchmarks",
 	"pallet-sudo/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
-	"pallet-vesting/runtime-benchmarks",
 	"pallet-xcm/runtime-benchmarks",
 	"parachains-common/runtime-benchmarks",
-	"polimec-common/runtime-benchmarks",
-	"polimec-receiver/runtime-benchmarks",
 	"polkadot-parachain-primitives/runtime-benchmarks",
 	"polkadot-primitives/runtime-benchmarks",
 	"polkadot-runtime-common/runtime-benchmarks",
-	"polkadot-runtime-parachains/runtime-benchmarks",
+	"snowbridge-rococo-common/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
@@ -195,12 +198,10 @@ try-runtime = [
 	"pallet-sudo/try-runtime",
 	"pallet-timestamp/try-runtime",
 	"pallet-transaction-payment/try-runtime",
-	"pallet-vesting/try-runtime",
 	"pallet-xcm/try-runtime",
 	"parachain-info/try-runtime",
-	"polimec-common/try-runtime",
-	"polimec-receiver/try-runtime",
 	"polkadot-runtime-common/try-runtime",
-	"polkadot-runtime-parachains/try-runtime",
 	"sp-runtime/try-runtime",
 ]
+
+experimental = ["pallet-aura/experimental"]

--- a/integration-tests/penpal/build.rs
+++ b/integration-tests/penpal/build.rs
@@ -1,7 +1,4 @@
-// Polimec Blockchain – https://www.polimec.org/
-// Copyright (C) Polimec 2022. All rights reserved.
-
-// Copyright 2019-2021 Parity Technologies (UK) Ltd.
+// Copyright (C) Parity Technologies (UK) Ltd.
 // This file is part of Cumulus.
 
 // Substrate is free software: you can redistribute it and/or modify

--- a/integration-tests/penpal/src/weights/block_weights.rs
+++ b/integration-tests/penpal/src/weights/block_weights.rs
@@ -1,6 +1,6 @@
 // This file is part of Substrate.
 
-// Copyright (C) 2022 Parity Technologies (UK) Ltd.
+// Copyright (C) Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration-tests/penpal/src/weights/extrinsic_weights.rs
+++ b/integration-tests/penpal/src/weights/extrinsic_weights.rs
@@ -1,6 +1,6 @@
 // This file is part of Substrate.
 
-// Copyright (C) 2022 Parity Technologies (UK) Ltd.
+// Copyright (C) Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration-tests/penpal/src/weights/mod.rs
+++ b/integration-tests/penpal/src/weights/mod.rs
@@ -1,6 +1,6 @@
 // This file is part of Substrate.
 
-// Copyright (C) 2022 Parity Technologies (UK) Ltd.
+// Copyright (C) Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration-tests/penpal/src/weights/paritydb_weights.rs
+++ b/integration-tests/penpal/src/weights/paritydb_weights.rs
@@ -1,6 +1,6 @@
 // This file is part of Substrate.
 
-// Copyright (C) 2022 Parity Technologies (UK) Ltd.
+// Copyright (C) Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration-tests/penpal/src/weights/rocksdb_weights.rs
+++ b/integration-tests/penpal/src/weights/rocksdb_weights.rs
@@ -1,6 +1,6 @@
 // This file is part of Substrate.
 
-// Copyright (C) 2022 Parity Technologies (UK) Ltd.
+// Copyright (C) Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pallets/polimec-receiver/Cargo.toml
+++ b/pallets/polimec-receiver/Cargo.toml
@@ -21,7 +21,7 @@ frame-benchmarking = { workspace = true, optional = true}
 frame-support.workspace = true
 frame-system.workspace = true
 sp-std.workspace = true
-polkadot-runtime-parachains.workspace = true
+cumulus-pallet-xcm.workspace = true
 polkadot-parachain-primitives.workspace = true
 polimec-common.workspace = true
 sp-runtime.workspace = true
@@ -42,7 +42,6 @@ runtime-benchmarks = [
 	"frame-system/runtime-benchmarks",
 	"polimec-common/runtime-benchmarks",
 	"polkadot-parachain-primitives/runtime-benchmarks",
-	"polkadot-runtime-parachains/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 ]
 std = [
@@ -53,7 +52,6 @@ std = [
 	"log/std",
 	"polimec-common/std",
 	"polkadot-parachain-primitives/std",
-	"polkadot-runtime-parachains/std",
 	"scale-info/std",
 	"serde/std",
 	"sp-core/std",
@@ -65,6 +63,5 @@ try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"polimec-common/try-runtime",
-	"polkadot-runtime-parachains/try-runtime",
 	"sp-runtime/try-runtime",
 ]

--- a/pallets/polimec-receiver/src/lib.rs
+++ b/pallets/polimec-receiver/src/lib.rs
@@ -21,6 +21,7 @@
 pub use pallet::*;
 #[frame_support::pallet]
 pub mod pallet {
+	use cumulus_pallet_xcm::{ensure_sibling_para, Origin as ParachainOrigin};
 	use frame_support::{
 		pallet_prelude::*,
 		traits::{tokens::Balance, Currency, ExistenceRequirement::KeepAlive, VestingSchedule},
@@ -28,7 +29,6 @@ pub mod pallet {
 	use frame_system::pallet_prelude::*;
 	use polimec_common::migration_types::{Migration, MigrationInfo, MigrationOrigin, Migrations, ParticipationType};
 	use polkadot_parachain_primitives::primitives::{Id as ParaId, Sibling};
-	use polkadot_runtime_parachains::origin::{ensure_parachain, Origin as ParachainOrigin};
 	use sp_runtime::traits::{AccountIdConversion, Convert};
 	use sp_std::prelude::*;
 
@@ -98,7 +98,7 @@ pub mod pallet {
 		#[pallet::call_index(0)]
 		#[pallet::weight(Weight::from_parts(10_000, 0))]
 		pub fn execute_migrations(origin: OriginFor<T>, migrations: Migrations) -> DispatchResult {
-			let para_id: ParaId = ensure_parachain(<T as Config>::RuntimeOrigin::from(origin))?;
+			let para_id: ParaId = ensure_sibling_para(<T as Config>::RuntimeOrigin::from(origin))?;
 			let polimec_id = T::PolimecParaId::get();
 			let polimec_soverign_account = Sibling(polimec_id).into_account_truncating();
 


### PR DESCRIPTION
## What?
- Update penpal runtime

## Why?
- To make sure our CT migration works with the latest xcm conventions

## How?
- Replace the old xcm with the new xcm from sdk 1.6.
- Add the polimec receiver and vesting pallets
- Modify the xcm config

## Testing?
`cargo test -p integration-tests`
