### PR TITLE
🔖 Whitelist pallet_funding sudo and root calls. New Polimec Release

### DIFF
--- a/integration-tests/src/constants.rs
+++ b/integration-tests/src/constants.rs
@@ -548,7 +548,7 @@ pub mod polimec {
 	use super::*;
 	use crate::{PolimecNet, PolimecOrigin, PolimecRuntime};
 	use pallet_funding::AcceptedFundingAsset;
-	use polimec_runtime::PayMaster;
+	use polimec_runtime::{PayMaster, TreasuryAccount};
 	use xcm::v3::Parent;
 	use xcm_emulator::TestExt;
 
@@ -622,7 +622,7 @@ pub mod polimec {
 
 		funded_accounts.extend(accounts::init_balances().iter().cloned().map(|k| (k, INITIAL_DEPOSIT)));
 		funded_accounts.extend(collators::initial_authorities().iter().cloned().map(|(acc, _)| (acc, 20_005 * PLMC)));
-		funded_accounts.push((get_account_id_from_seed::<sr25519::Public>("TREASURY_STASH"), 20_005 * PLMC));
+		funded_accounts.push((TreasuryAccount::get(), 20_005 * PLMC));
 		funded_accounts.push((PayMaster::get(), 20_005 * PLMC));
 
 		let genesis_config = polimec_runtime::RuntimeGenesisConfig {
@@ -640,7 +640,11 @@ pub mod polimec {
 					(usdt_asset_id, "Local USDT".as_bytes().to_vec(), "USDT".as_bytes().to_vec(), 6),
 					(usdc_asset_id, "Local USDC".as_bytes().to_vec(), "USDC".as_bytes().to_vec(), 6),
 				],
-				accounts: vec![],
+				accounts: vec![
+					(dot_asset_id, TreasuryAccount::get(), 0_0_010_000_000u128),
+					(usdt_asset_id, TreasuryAccount::get(), 0_0_010_000_000u128),
+					(usdc_asset_id, TreasuryAccount::get(), 0_0_010_000_000u128),
+				],
 			},
 			parachain_info: polimec_runtime::ParachainInfoConfig { parachain_id: PARA_ID.into(), ..Default::default() },
 			session: polimec_runtime::SessionConfig {

--- a/integration-tests/src/tests/credentials.rs
+++ b/integration-tests/src/tests/credentials.rs
@@ -21,11 +21,10 @@ use polimec_common::credentials::{Did, InvestorType};
 use polimec_common_test_utils::{get_fake_jwt, get_mock_jwt_with_cid, get_test_jwt};
 use polimec_runtime::PLMC;
 use sp_runtime::{
-	bounded_vec,
 	generic::Era,
 	traits::SignedExtension,
 	transaction_validity::{InvalidTransaction::Payment, TransactionValidityError},
-	AccountId32, BoundedVec, DispatchError,
+	AccountId32, DispatchError,
 };
 use tests::defaults::*;
 

--- a/integration-tests/src/tests/governance.rs
+++ b/integration-tests/src/tests/governance.rs
@@ -386,6 +386,8 @@ fn election_phragmen_works() {
 			<PolimecRuntime as pallet_elections_phragmen::Config>::MaxCandidates::get() as usize
 		);
 
+		let prev_treasury_balance = Balances::balance(&Treasury::account_id());
+
 		for (i, voter) in vec![ALICE, BOB, CHARLIE, DAVE, EVE, FERDIE, ALICE_STASH, BOB_STASH].into_iter().enumerate() {
 			let voter = PolimecNet::account_id_of(voter);
 			assert_ok!(Elections::vote(
@@ -411,10 +413,11 @@ fn election_phragmen_works() {
 		{
 			assert_eq!(Balances::total_balance(candidate), ED);
 		}
+		let post_treasury_balance = Balances::balance(&Treasury::account_id());
+		let net_treasury_balance = post_treasury_balance - prev_treasury_balance;
 		assert_eq!(
-			Balances::balance(&Treasury::account_id()),
-			(<PolimecRuntime as pallet_elections_phragmen::Config>::MaxCandidates::get() as u128 - 15) * 1000 * PLMC +
-				ED
+			net_treasury_balance,
+			(<PolimecRuntime as pallet_elections_phragmen::Config>::MaxCandidates::get() as u128 - 15) * 1000 * PLMC
 		)
 	});
 }

--- a/integration-tests/src/tests/mod.rs
+++ b/integration-tests/src/tests/mod.rs
@@ -22,3 +22,4 @@ mod governance;
 mod oracle;
 mod reserve_backed_transfers;
 mod vest;
+mod xcm_config;

--- a/integration-tests/src/tests/xcm_config.rs
+++ b/integration-tests/src/tests/xcm_config.rs
@@ -1,0 +1,113 @@
+use crate::{PolimecAccountId, PolimecBalances, PolimecCall, PolimecForeignAssets, PolimecNet, PolimecRuntime, ALICE};
+use parity_scale_codec::Encode;
+use polimec_runtime::{xcm_config::SupportedAssets, TreasuryAccount};
+use sp_runtime::traits::MaybeEquivalence;
+use xcm::prelude::*;
+use xcm_emulator::{Chain, TestExt};
+pub fn fake_message_hash<T>(message: &Xcm<T>) -> XcmHash {
+	message.using_encoded(sp_io::hashing::blake2_256)
+}
+#[test]
+fn execution_fees_go_to_treasury() {
+	let dot_amount = MultiAsset { id: Concrete(MultiLocation::parent()), fun: Fungible(100_0_000_000_000) };
+	let usdt_amount = MultiAsset {
+		id: Concrete(MultiLocation {
+			parents: 1,
+			interior: X3(Parachain(1000), PalletInstance(50), GeneralIndex(1984)),
+		}),
+		fun: Fungible(100_000_000),
+	};
+	let usdc_amount = MultiAsset {
+		id: Concrete(MultiLocation {
+			parents: 1,
+			interior: X3(Parachain(1000), PalletInstance(50), GeneralIndex(1337)),
+		}),
+		fun: Fungible(100_000_000),
+	};
+
+	let beneficiary: PolimecAccountId = [0u8; 32].into();
+
+	let assert_reserve_asset_fee_goes_to_treasury = |multi_asset: MultiAsset| {
+		let asset_multilocation =
+			if let Concrete(asset_multilocation) = multi_asset.id { asset_multilocation } else { unreachable!() };
+		let asset_id = SupportedAssets::convert(&asset_multilocation).unwrap();
+		let asset_amount = if let Fungible(amount) = multi_asset.fun { amount } else { unreachable!() };
+
+		let xcm = Xcm::<PolimecCall>(vec![
+			ReserveAssetDeposited(vec![multi_asset.clone()].into()),
+			ClearOrigin,
+			BuyExecution { fees: multi_asset, weight_limit: Unlimited },
+			DepositAsset {
+				assets: WildMultiAsset::All.into(),
+				beneficiary: MultiLocation::new(0, X1(AccountId32 { network: None, id: beneficiary.clone().into() })),
+			},
+		])
+		.into();
+		PolimecNet::execute_with(|| {
+			let prev_treasury_balance = PolimecForeignAssets::balance(asset_id, TreasuryAccount::get());
+			let prev_beneficiary_balance = PolimecForeignAssets::balance(asset_id, beneficiary.clone());
+
+			let outcome = <PolimecRuntime as pallet_xcm::Config>::XcmExecutor::execute_xcm(
+				MultiLocation::new(1, X1(Parachain(1000))),
+				xcm.clone(),
+				fake_message_hash(&xcm),
+				Weight::MAX,
+			);
+			assert!(outcome.ensure_complete().is_ok());
+
+			let post_treasury_balance = PolimecForeignAssets::balance(asset_id, TreasuryAccount::get());
+			let post_beneficiary_balance = PolimecForeignAssets::balance(asset_id, beneficiary.clone());
+
+			let net_treasury_balance = post_treasury_balance - prev_treasury_balance;
+			let net_beneficiary_balance = post_beneficiary_balance - prev_beneficiary_balance;
+
+			let net_total = net_treasury_balance + net_beneficiary_balance;
+
+			assert_eq!(net_total, asset_amount);
+			assert!(net_treasury_balance > 0);
+		});
+	};
+
+	let assert_plmc_fee_goes_to_treasury = || {
+		let asset_amount = 100_0_000_000_000;
+		let multi_asset = MultiAsset { id: Concrete(MultiLocation::here()), fun: Fungible(asset_amount) };
+
+		let xcm = Xcm::<PolimecCall>(vec![
+			WithdrawAsset(vec![multi_asset.clone()].into()),
+			BuyExecution { fees: multi_asset, weight_limit: Unlimited },
+			DepositAsset {
+				assets: WildMultiAsset::All.into(),
+				beneficiary: MultiLocation::new(0, X1(AccountId32 { network: None, id: beneficiary.clone().into() })),
+			},
+		])
+		.into();
+		PolimecNet::execute_with(|| {
+			let prev_treasury_balance = PolimecBalances::free_balance(TreasuryAccount::get());
+			let prev_beneficiary_balance = PolimecBalances::free_balance(beneficiary.clone());
+
+			let outcome = <PolimecRuntime as pallet_xcm::Config>::XcmExecutor::execute_xcm(
+				MultiLocation::new(0, X1(AccountId32 { network: None, id: PolimecNet::account_id_of(ALICE).into() })),
+				xcm.clone(),
+				fake_message_hash(&xcm),
+				Weight::MAX,
+			);
+			assert!(outcome.ensure_complete().is_ok());
+
+			let post_treasury_balance = PolimecBalances::free_balance(TreasuryAccount::get());
+			let post_beneficiary_balance = PolimecBalances::free_balance(beneficiary.clone());
+
+			let net_treasury_balance = post_treasury_balance - prev_treasury_balance;
+			let net_beneficiary_balance = post_beneficiary_balance - prev_beneficiary_balance;
+
+			let net_total = net_treasury_balance + net_beneficiary_balance;
+
+			assert_eq!(net_total, asset_amount);
+			assert!(net_treasury_balance > 0);
+		});
+	};
+
+	assert_reserve_asset_fee_goes_to_treasury(dot_amount);
+	assert_reserve_asset_fee_goes_to_treasury(usdt_amount);
+	assert_reserve_asset_fee_goes_to_treasury(usdc_amount);
+	assert_plmc_fee_goes_to_treasury();
+}

--- a/runtimes/polimec/src/lib.rs
+++ b/runtimes/polimec/src/lib.rs
@@ -157,11 +157,9 @@ pub type Migrations = migrations::Unreleased;
 /// The runtime migrations per release.
 #[allow(missing_docs)]
 pub mod migrations {
-	use crate::Runtime;
-
 	/// Unreleased migrations. Add new ones here:
 	#[allow(unused_parens)]
-	pub type Unreleased = (pallet_funding::storage_migrations::v3::MigrationToV3<Runtime>);
+	pub type Unreleased = ();
 }
 
 /// Executive: handles dispatch to the various modules.
@@ -207,7 +205,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("polimec-mainnet"),
 	impl_name: create_runtime_str!("polimec-mainnet"),
 	authoring_version: 1,
-	spec_version: 0_007_002,
+	spec_version: 0_007_003,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
@@ -233,10 +231,15 @@ impl Contains<RuntimeCall> for BaseCallFilter {
 				matches!(
 					call,
 					pallet_funding::Call::create_project { .. } |
-						pallet_funding::Call::edit_project { .. } |
 						pallet_funding::Call::remove_project { .. } |
+						pallet_funding::Call::edit_project { .. } |
 						pallet_funding::Call::start_evaluation { .. } |
-						pallet_funding::Call::evaluate { .. }
+						pallet_funding::Call::root_do_evaluation_end { .. } |
+						pallet_funding::Call::evaluate { .. } |
+						pallet_funding::Call::start_auction { .. } |
+						pallet_funding::Call::root_do_auction_opening { .. } |
+						pallet_funding::Call::root_do_start_auction_closing { .. } |
+						pallet_funding::Call::bid { .. }
 				)
 			},
 			_ => true,

--- a/runtimes/polimec/src/xcm_config.rs
+++ b/runtimes/polimec/src/xcm_config.rs
@@ -16,8 +16,8 @@
 
 use super::{
 	AccountId, AllPalletsWithSystem, AssetId as AssetIdPalletAssets, Balance, Balances, EnsureRoot, ForeignAssets,
-	ParachainInfo, ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, Vec, WeightToFee,
-	XcmpQueue,
+	ParachainInfo, ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, Treasury,
+	TreasuryAccount, Vec, WeightToFee, XcmpQueue,
 };
 use core::marker::PhantomData;
 use frame_support::{
@@ -31,7 +31,6 @@ use polimec_xcm_executor::{
 	XcmExecutor,
 };
 use polkadot_parachain_primitives::primitives::Sibling;
-use polkadot_runtime_common::impls::ToAuthor;
 use sp_runtime::traits::MaybeEquivalence;
 use xcm::latest::prelude::*;
 use xcm_builder::{
@@ -261,7 +260,8 @@ pub type Reserves = AssetHubAssetsAsReserve;
 /// ForeignAssetsAdapter is a FungiblesAdapter that allows for transacting foreign assets.
 /// Currently we only support DOT, USDT and USDC.
 pub type AssetTransactors = (FungibleTransactor, ForeignAssetsAdapter);
-
+pub type TakeRevenueToTreasury =
+	cumulus_primitives_utility::XcmFeesTo32ByteAccount<AssetTransactors, AccountId, TreasuryAccount>;
 pub struct XcmConfig;
 impl polimec_xcm_executor::Config for XcmConfig {
 	type Aliasers = ();
@@ -290,10 +290,10 @@ impl polimec_xcm_executor::Config for XcmConfig {
 	type SubscriptionService = PolkadotXcm;
 	type Trader = (
 		// TODO: weight to fee has to be carefully considered. For now use default
-		UsingComponents<WeightToFee, HereLocation, AccountId, Balances, ToAuthor<Runtime>>,
-		FixedRateOfFungible<UsdtTraderParams, ()>,
-		FixedRateOfFungible<DotTraderParams, ()>,
-		FixedRateOfFungible<UsdcTraderParams, ()>,
+		UsingComponents<WeightToFee, HereLocation, AccountId, Balances, Treasury>,
+		FixedRateOfFungible<UsdtTraderParams, TakeRevenueToTreasury>,
+		FixedRateOfFungible<DotTraderParams, TakeRevenueToTreasury>,
+		FixedRateOfFungible<UsdcTraderParams, TakeRevenueToTreasury>,
 	);
 	type UniversalAliases = Nothing;
 	type UniversalLocation = UniversalLocation;


### PR DESCRIPTION
## What?
Upgrade Polimec

## Why?
Whitelist the auction and root calls

## How?
Add them to the `Basecall` filter

## Testing?
try-runtime output:
```
❯ try-runtime --runtime ./target/release/wbuild/polimec-runtime/polimec_runtime.compact.compressed.wasm on-runtime-upgrade live --uri wss://rpc.polimec.org:443
[2024-06-14T13:30:20Z INFO  remote-ext] replacing wss:// in uri with https://: "https://rpc.polimec.org:443" (ws is currently unstable for fetching remote storage, for more see https://github.com/paritytech/jsonrpsee/issues/1086)
[2024-06-14T13:30:20Z INFO  remote-ext] since no at is provided, setting it to latest finalized head, 0xdd9f49b5e3403d646002a5329323dbb0e69ff3e29068277338bcc4322d016eca
[2024-06-14T13:30:20Z INFO  remote-ext] since no prefix is filtered, the data for all pallets will be downloaded
[2024-06-14T13:30:20Z INFO  remote-ext] scraping key-pairs from remote at block height 0xdd9f49b5e3403d646002a5329323dbb0e69ff3e29068277338bcc4322d016eca
✅ Found 9362 keys (0.39s)
[00:00:01] ✅ Downloaded key values 5,586.4844/s [===================================================================================================] 9362/9362 (0s)
✅ Inserted keys into DB (0.02s)
[2024-06-14T13:30:22Z INFO  remote-ext] adding data for hashed prefix: , took 2.19s
[2024-06-14T13:30:22Z INFO  remote-ext] adding data for hashed key: 3a636f6465
[2024-06-14T13:30:22Z INFO  remote-ext] adding data for hashed key: 26aa394eea5630e07c48ae0c9558cef7f9cce9c888469bb1a0dceaa129672ef8
[2024-06-14T13:30:22Z INFO  remote-ext] adding data for hashed key: 26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac
[2024-06-14T13:30:22Z INFO  remote-ext] 👩‍👦 no child roots found to scrape
[2024-06-14T13:30:22Z INFO  remote-ext] initialized state externalities with storage root 0x5bd4097792b70d2f8044967ff8a7cee2061de95f180124fcf6c665419efc6a17 and state_version V1
[2024-06-14T13:30:22Z INFO  try-runtime::cli] Original runtime [Name: RuntimeString::Owned("polimec-mainnet")] [Version: 7002] [Code hash: 0x4398...b5e4]
[2024-06-14T13:30:22Z INFO  try-runtime::cli] New runtime      [Name: RuntimeString::Owned("polimec-mainnet")] [Version: 7003] [Code hash: 0xf246...8455]
[2024-06-14T13:30:23Z INFO  try-runtime::cli] 🚀 Speed up your workflow by using snapshots instead of live state. See `try-runtime create-snapshot --help`.
[2024-06-14T13:30:23Z INFO  try_runtime_core::misc] ------------------------------------------------------------------
    
    
[2024-06-14T13:30:23Z INFO  try_runtime_core::misc] 🔬 Running TryRuntime_on_runtime_upgrade with checks: PreAndPost
    
    
[2024-06-14T13:30:23Z INFO  try_runtime_core::misc] ------------------------------------------------------------------
    
    
[2024-06-14T13:30:23Z INFO  runtime::executive] ✅ Entire runtime state decodes without error. 547614 bytes total.
[2024-06-14T13:30:23Z INFO  try_runtime_core::misc] ------------------------------------------------------------------------------------------------------
    
    
[2024-06-14T13:30:23Z INFO  try_runtime_core::misc] 🔬 TryRuntime_on_runtime_upgrade succeeded! Running it again without checks for weight measurements.
    
    
[2024-06-14T13:30:23Z INFO  try_runtime_core::misc] ------------------------------------------------------------------------------------------------------
    
    
[2024-06-14T13:30:23Z INFO  try_runtime_core::misc] ---------------------------------------------------------------------------------
    
    
[2024-06-14T13:30:23Z INFO  try_runtime_core::misc] 🔬 Running TryRuntime_on_runtime_upgrade again to check idempotency: PreAndPost
    
    
[2024-06-14T13:30:23Z INFO  try_runtime_core::misc] ---------------------------------------------------------------------------------
    
    
[2024-06-14T13:30:23Z INFO  runtime::executive] ✅ Entire runtime state decodes without error. 547614 bytes total.
[2024-06-14T13:30:23Z INFO  try-runtime::cli] PoV size (zstd-compressed compact proof): 7.8 KB. For parachains, it's your responsibility to verify that a PoV of this size fits within any relaychain constraints.
[2024-06-14T13:30:23Z INFO  try-runtime::cli] Consumed ref_time: 0.000925s (0.19% of max 0.5s)
[2024-06-14T13:30:23Z INFO  try-runtime::cli] ✅ No weight safety issues detected. Please note this does not guarantee a successful runtime upgrade. Always test your runtime upgrade with recent state, and ensure that the weight usage of your migrations will not drastically differ between testing and actual on-chain execution.

polimec-node on  06-14-whitelist_pallet_funding_sudo_and_root_calls [!] via 🦀 v1.76.0-nightly took 3s 

```
srtool output:
```
✨ Your Substrate WASM Runtime is ready! ✨
✨ WASM  : runtimes/polimec/target/srtool/production/wbuild/polimec-runtime/polimec_runtime.compact.wasm
✨ Z_WASM: runtimes/polimec/target/srtool/production/wbuild/polimec-runtime/polimec_runtime.compact.compressed.wasm
Summary generated with srtool v0.15.0 using the docker image paritytech/srtool:1.77.0:
 Package     : polimec-runtime v0.7.0
 GIT commit  : 5385a0f9f7dc451d4b513f0be5bd6ca22501032a
 GIT tag     : v0.7.2
 GIT branch  : 06-14-whitelist_pallet_funding_sudo_and_root_calls
 Rustc       : rustc 1.77.0 (aedd173a2 2024-03-17)
 Time        : 2024-06-14T13:39:54Z

== Compact
 Version          : polimec-mainnet-7003 (polimec-mainnet-0.tx2.au1)
 Metadata         : V14
 Size             : 5.05 MB (5300323 bytes)
 setCode          : 0x9ef21882fcd88f36b505c254fc62d197aa0c08350ac0b8afbb9b67674c8376fb
 authorizeUpgrade : 0x086b1ef3054d630c355d5ac167895ea87322ac3cfe69bd694d30027aa26a4651
 IPFS             : Qmc4u4zXWfyP5oN75pcRo39BbmJBkEoUSwDbK7BocnkBWC
 BLAKE2_256       : 0x9b3fd1108446b57fc13918246078fc12273a83a8838653885c6c65754ef39e67
 Wasm             : runtimes/polimec/target/srtool/production/wbuild/polimec-runtime/polimec_runtime.compact.wasm

== Compressed
 Version          : polimec-mainnet-7003 (polimec-mainnet-0.tx2.au1)
 Metadata         : V14
 Size             : 1.26 MB (1317183 bytes)
 Compression      : 75.15%
 setCode          : 0xa30e79d56610ab3da235849de5c0045905ea91490832c763cd832a240f278037
 authorizeUpgrade : 0xe8d25332054a46040087608f1ff553ef1f5f03c6edbc20b3ba585d2b30a3280c
 IPFS             : QmP7f6jbrHXnroEvxyDuYoSKb7htr28teDkoKmiNok9jL6
 BLAKE2_256       : 0xbcc6fc9d1ff6d9c662d7ee392132838313315e8904c0f5bdeb55935a2e261875
 Wasm             : runtimes/polimec/target/srtool/production/wbuild/polimec-runtime/polimec_runtime.compact.compressed.wasm


```