### PR TITLE
Remove politest from integration-tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4557,7 +4557,6 @@ dependencies = [
  "polimec-common-test-utils",
  "polimec-receiver",
  "polimec-runtime",
- "politest-runtime",
  "polkadot-core-primitives",
  "polkadot-parachain-primitives",
  "polkadot-primitives",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -76,14 +76,12 @@ pallet-treasury.workspace = true
 polkadot-runtime.workspace = true
 asset-hub-polkadot-runtime.workspace = true
 polimec-runtime.workspace = true
-politest-runtime.workspace = true
 penpal-runtime = { path = "./penpal", default-features = false }
 
 [features]
-default = [ "instant-mode", "std" ]
+default = [ "instant-mode", "std", "development-settings"]
 instant-mode = [
 	"polimec-runtime/instant-mode",
-	"politest-runtime/instant-mode",
 ]
 std = [
 	"asset-hub-polkadot-runtime/std",
@@ -118,7 +116,7 @@ std = [
 	"polimec-common-test-utils/std",
 	"polimec-common/std",
 	"polimec-receiver/std",
-	"politest-runtime/std",
+	"polimec-runtime/std",
 	"polkadot-core-primitives/std",
 	"polkadot-parachain-primitives/std",
 	"polkadot-primitives/std",
@@ -139,5 +137,8 @@ std = [
 	"xcm-builder/std",
 	"xcm-executor/std",
 	"xcm/std",
+]
+development-settings = [
+	"polimec-runtime/development-settings",
 ]
 

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -19,7 +19,7 @@ pub mod constants;
 #[cfg(test)]
 mod tests;
 
-pub use constants::{accounts::*, asset_hub, penpal, polimec, politest, polkadot};
+pub use constants::{accounts::*, asset_hub, penpal, polimec, polkadot};
 pub use frame_support::{assert_noop, assert_ok, pallet_prelude::Weight, parameter_types, traits::Hooks};
 pub use parachains_common::{AccountId, AssetHubPolkadotAuraId, AuraId, Balance, BlockNumber};
 pub use sp_core::{sr25519, storage::Storage, Encode, Get};
@@ -66,27 +66,6 @@ decl_test_parachains! {
 			ParachainInfo: penpal_runtime::ParachainInfo,
 		}
 	},
-	pub struct Politest {
-		genesis = politest::genesis(),
-		on_init = politest_runtime::AuraExt::on_initialize(1),
-		runtime = politest_runtime,
-		core = {
-			XcmpMessageHandler: politest_runtime::XcmpQueue,
-			LocationToAccountId: politest_runtime::xcm_config::LocationToAccountId,
-			ParachainInfo: politest_runtime::ParachainInfo,
-			MessageOrigin: cumulus_primitives_core::AggregateMessageOrigin,
-		},
-		pallets = {
-			Balances: politest_runtime::Balances,
-			ParachainSystem: politest_runtime::ParachainSystem,
-			PolkadotXcm: politest_runtime::PolkadotXcm,
-			LocalAssets: politest_runtime::ContributionTokensInstance,
-			ForeignAssets: politest_runtime::ForeignAssets,
-			FundingPallet: politest_runtime::Funding,
-			Dispenser: politest_runtime::Dispenser,
-			Vesting: politest_runtime::Vesting,
-		}
-	},
 	pub struct AssetHub {
 		genesis = asset_hub::genesis(),
 		on_init = asset_hub_polkadot_runtime::AuraExt::on_initialize(1),
@@ -120,6 +99,9 @@ decl_test_parachains! {
 			ParachainSystem: polimec_runtime::ParachainSystem,
 			PolkadotXcm: polimec_runtime::PolkadotXcm,
 			ForeignAssets: polimec_runtime::ForeignAssets,
+			Funding: polimec_runtime::Funding,
+			Dispenser: polimec_runtime::Dispenser,
+			Vesting: polimec_runtime::Vesting,
 		}
 	}
 }
@@ -128,7 +110,6 @@ decl_test_networks! {
 	pub struct PolkadotNet {
 		relay_chain = PolkadotRelay,
 		parachains = vec![
-			Politest,
 			Penpal,
 			AssetHub,
 			Polimec,
@@ -140,74 +121,61 @@ decl_test_networks! {
 /// Shortcuts to reduce boilerplate on runtime types
 pub mod shortcuts {
 	use super::{
-		AssetHub, AssetHubParaPallet, Chain, Penpal, PenpalParaPallet, Polimec, PolimecParaPallet, Politest,
-		PolitestParaPallet, PolkadotNet, PolkadotRelay as Polkadot, PolkadotRelayRelayPallet,
+		AssetHub, AssetHubParaPallet, Chain, Penpal, PenpalParaPallet, Polimec, PolimecParaPallet, PolkadotNet,
+		PolkadotRelay as Polkadot, PolkadotRelayRelayPallet,
 	};
 
 	pub type PolkaNet = Polkadot<PolkadotNet>;
 	pub type PolimecNet = Polimec<PolkadotNet>;
 	pub type PenNet = Penpal<PolkadotNet>;
 	pub type AssetNet = AssetHub<PolkadotNet>;
-	pub type PolitestNet = Politest<PolkadotNet>;
-
-	pub type PolitestFundingPallet = <Politest<PolkadotNet> as PolitestParaPallet>::FundingPallet;
 
 	pub type PolkadotRuntime = <PolkaNet as Chain>::Runtime;
-	pub type PolitestRuntime = <PolitestNet as Chain>::Runtime;
 	pub type PenpalRuntime = <PenNet as Chain>::Runtime;
 	pub type AssetHubRuntime = <AssetNet as Chain>::Runtime;
 	pub type PolimecRuntime = <PolimecNet as Chain>::Runtime;
 
+	pub type PolimecFunding = <PolimecNet as PolimecParaPallet>::Funding;
+	pub type PolimecDispenser = <PolimecNet as PolimecParaPallet>::Dispenser;
+	pub type PolimecVesting = <PolimecNet as PolimecParaPallet>::Vesting;
+
 	pub type PolkadotXcmPallet = <PolkaNet as PolkadotRelayRelayPallet>::XcmPallet;
-	pub type PolitestXcmPallet = <PolitestNet as PolitestParaPallet>::PolkadotXcm;
 	pub type PenpalXcmPallet = <PenNet as PenpalParaPallet>::PolkadotXcm;
 	pub type AssetHubXcmPallet = <AssetNet as AssetHubParaPallet>::PolkadotXcm;
 	pub type PolimecXcmPallet = <PolimecNet as PolimecParaPallet>::PolkadotXcm;
 
 	pub type PolkadotBalances = <PolkaNet as PolkadotRelayRelayPallet>::Balances;
-	pub type PolitestBalances = <PolitestNet as PolitestParaPallet>::Balances;
 	pub type PenpalBalances = <PenNet as PenpalParaPallet>::Balances;
 	pub type AssetHubBalances = <AssetNet as AssetHubParaPallet>::Balances;
 	pub type PolimecBalances = <PolimecNet as PolimecParaPallet>::Balances;
 
-	pub type PolitestLocalAssets = <PolitestNet as PolitestParaPallet>::LocalAssets;
-	pub type PolitestForeignAssets = <PolitestNet as PolitestParaPallet>::ForeignAssets;
 	pub type PenpalAssets = <PenNet as PenpalParaPallet>::Assets;
 	pub type AssetHubAssets = <AssetNet as AssetHubParaPallet>::LocalAssets;
 	pub type PolimecForeignAssets = <PolimecNet as PolimecParaPallet>::ForeignAssets;
 
 	pub type PolkadotOrigin = <PolkaNet as Chain>::RuntimeOrigin;
-	pub type PolitestOrigin = <PolitestNet as Chain>::RuntimeOrigin;
 	pub type PenpalOrigin = <PenNet as Chain>::RuntimeOrigin;
 	pub type AssetHubOrigin = <AssetNet as Chain>::RuntimeOrigin;
 	pub type PolimecOrigin = <PolimecNet as Chain>::RuntimeOrigin;
 
 	pub type PolkadotCall = <PolkaNet as Chain>::RuntimeCall;
-	pub type PolitestCall = <PolitestNet as Chain>::RuntimeCall;
 	pub type PenpalCall = <PenNet as Chain>::RuntimeCall;
 	pub type AssetHubCall = <AssetNet as Chain>::RuntimeCall;
 	pub type PolimecCall = <PolimecNet as Chain>::RuntimeCall;
 
 	pub type PolkadotAccountId = <PolkadotRuntime as frame_system::Config>::AccountId;
-	pub type PolitestAccountId = <PolitestRuntime as frame_system::Config>::AccountId;
 	pub type PenpalAccountId = <PenpalRuntime as frame_system::Config>::AccountId;
 	pub type AssetHubAccountId = <AssetHubRuntime as frame_system::Config>::AccountId;
 	pub type PolimecAccountId = <PolimecRuntime as frame_system::Config>::AccountId;
 
 	pub type PolkadotEvent = <PolkaNet as Chain>::RuntimeEvent;
-	pub type PolitestEvent = <PolitestNet as Chain>::RuntimeEvent;
 	pub type PenpalEvent = <PenNet as Chain>::RuntimeEvent;
 	pub type AssetHubEvent = <AssetNet as Chain>::RuntimeEvent;
 	pub type PolimecEvent = <PolimecNet as Chain>::RuntimeEvent;
 
 	pub type PolkadotSystem = <PolkaNet as Chain>::System;
-	pub type PolitestSystem = <PolitestNet as Chain>::System;
 	pub type PenpalSystem = <PenNet as Chain>::System;
 	pub type AssetHubSystem = <AssetNet as Chain>::System;
 	pub type PolimecSystem = <PolimecNet as Chain>::System;
-
-	// Politest specific pallets
-	pub type PolitestDispenser = <PolitestNet as PolitestParaPallet>::Dispenser;
-	pub type PolitestVesting = <PolitestNet as PolitestParaPallet>::Vesting;
 }
 pub use shortcuts::*;

--- a/integration-tests/src/tests/credentials.rs
+++ b/integration-tests/src/tests/credentials.rs
@@ -31,33 +31,29 @@ use tests::defaults::*;
 #[test]
 fn test_jwt_for_create() {
 	let project = default_project_metadata(ISSUER.into());
-	PolitestNet::execute_with(|| {
+	PolimecNet::execute_with(|| {
 		let issuer = AccountId32::from(ISSUER);
-		assert_ok!(PolitestBalances::force_set_balance(PolitestOrigin::root(), issuer.into(), 10_000 * PLMC));
-		let retail_jwt = get_test_jwt(PolitestAccountId::from(ISSUER), InvestorType::Retail);
+		assert_ok!(PolimecBalances::force_set_balance(PolimecOrigin::root(), issuer.into(), 10_000 * PLMC));
+		let retail_jwt = get_test_jwt(PolimecAccountId::from(ISSUER), InvestorType::Retail);
 		assert_noop!(
-			PolitestFundingPallet::create_project(PolitestOrigin::signed(ISSUER.into()), retail_jwt, project.clone()),
-			pallet_funding::Error::<PolitestRuntime>::WrongInvestorType
+			PolimecFunding::create_project(PolimecOrigin::signed(ISSUER.into()), retail_jwt, project.clone()),
+			pallet_funding::Error::<PolimecRuntime>::WrongInvestorType
 		);
-		let inst_jwt = get_test_jwt(PolitestAccountId::from(ISSUER), InvestorType::Institutional);
-		assert_ok!(PolitestFundingPallet::create_project(
-			PolitestOrigin::signed(ISSUER.into()),
-			inst_jwt,
-			project.clone()
-		));
+		let inst_jwt = get_test_jwt(PolimecAccountId::from(ISSUER), InvestorType::Institutional);
+		assert_ok!(PolimecFunding::create_project(PolimecOrigin::signed(ISSUER.into()), inst_jwt, project.clone()));
 	});
 }
 
 #[test]
 fn test_jwt_verification() {
 	let project = default_project_metadata(ISSUER.into());
-	PolitestNet::execute_with(|| {
+	PolimecNet::execute_with(|| {
 		let issuer = AccountId32::from(ISSUER);
-		assert_ok!(PolitestBalances::force_set_balance(PolitestOrigin::root(), issuer.into(), 1000 * PLMC));
+		assert_ok!(PolimecBalances::force_set_balance(PolimecOrigin::root(), issuer.into(), 1000 * PLMC));
 		// This JWT tokens is signed with a private key that is not the one set in the Pallet Funding configuration in the real runtime.
-		let inst_jwt = get_fake_jwt(PolitestAccountId::from(ISSUER), InvestorType::Institutional);
+		let inst_jwt = get_fake_jwt(PolimecAccountId::from(ISSUER), InvestorType::Institutional);
 		assert_noop!(
-			PolitestFundingPallet::create_project(PolitestOrigin::signed(ISSUER.into()), inst_jwt, project.clone()),
+			PolimecFunding::create_project(PolimecOrigin::signed(ISSUER.into()), inst_jwt, project.clone()),
 			DispatchError::BadOrigin
 		);
 	});
@@ -67,22 +63,22 @@ generate_accounts!(EMPTY_ACCOUNT);
 
 #[test]
 fn dispenser_signed_extensions_pass_for_new_account() {
-	PolitestNet::execute_with(|| {
-		let who = PolitestAccountId::from(EMPTY_ACCOUNT);
+	PolimecNet::execute_with(|| {
+		let who = PolimecAccountId::from(EMPTY_ACCOUNT);
 		assert_eq!(PolimecBalances::free_balance(who.clone()), 0);
 
 		let jwt = get_test_jwt(who.clone(), InvestorType::Retail);
-		let free_call = PolitestCall::Dispenser(pallet_dispenser::Call::dispense { jwt: jwt.clone() });
-		let paid_call = PolitestCall::System(frame_system::Call::remark { remark: vec![69, 69] });
-		let extra: politest_runtime::SignedExtra = (
-			frame_system::CheckNonZeroSender::<PolitestRuntime>::new(),
-			frame_system::CheckSpecVersion::<PolitestRuntime>::new(),
-			frame_system::CheckTxVersion::<PolitestRuntime>::new(),
-			frame_system::CheckGenesis::<PolitestRuntime>::new(),
-			frame_system::CheckEra::<PolitestRuntime>::from(Era::mortal(0u64, 0u64)),
-			pallet_dispenser::extensions::CheckNonce::<PolitestRuntime>::from(0u32),
-			frame_system::CheckWeight::<PolitestRuntime>::new(),
-			pallet_transaction_payment::ChargeTransactionPayment::<PolitestRuntime>::from(0u64.into()).into(),
+		let free_call = PolimecCall::Dispenser(pallet_dispenser::Call::dispense { jwt: jwt.clone() });
+		let paid_call = PolimecCall::System(frame_system::Call::remark { remark: vec![69, 69] });
+		let extra: polimec_runtime::SignedExtra = (
+			frame_system::CheckNonZeroSender::<PolimecRuntime>::new(),
+			frame_system::CheckSpecVersion::<PolimecRuntime>::new(),
+			frame_system::CheckTxVersion::<PolimecRuntime>::new(),
+			frame_system::CheckGenesis::<PolimecRuntime>::new(),
+			frame_system::CheckEra::<PolimecRuntime>::from(Era::mortal(0u64, 0u64)),
+			pallet_dispenser::extensions::CheckNonce::<PolimecRuntime>::from(0u32),
+			frame_system::CheckWeight::<PolimecRuntime>::new(),
+			pallet_transaction_payment::ChargeTransactionPayment::<PolimecRuntime>::from(0u64.into()).into(),
 		);
 		assert_err!(
 			extra.validate(&who, &paid_call, &paid_call.get_dispatch_info(), 0),
@@ -100,8 +96,8 @@ fn dispenser_signed_extensions_pass_for_new_account() {
 
 #[test]
 fn dispenser_works_with_runtime_values() {
-	PolitestNet::execute_with(|| {
-		let who = PolitestAccountId::from(EMPTY_ACCOUNT);
+	PolimecNet::execute_with(|| {
+		let who = PolimecAccountId::from(EMPTY_ACCOUNT);
 		let did = "kilt:did:tz:tz1K7fCz9QJtXv3J8Ud3Zvz7eQ6";
 		let bytes_did = did.as_bytes().to_vec();
 		let bounded_did: Did = bytes_did.try_into().unwrap();
@@ -109,25 +105,25 @@ fn dispenser_works_with_runtime_values() {
 			who.clone(),
 			InvestorType::Retail,
 			bounded_did,
-			politest_runtime::DispenserWhitelistedPolicy::get(),
+			polimec_runtime::DispenserWhitelistedPolicy::get(),
 		);
-		PolitestBalances::force_set_balance(
-			PolitestOrigin::root(),
-			PolitestDispenser::dispense_account().into(),
+		PolimecBalances::force_set_balance(
+			PolimecOrigin::root(),
+			PolimecDispenser::dispense_account().into(),
 			1000 * PLMC,
 		)
 		.unwrap();
-		assert_ok!(PolitestDispenser::dispense(PolitestOrigin::signed(who.clone()), jwt));
-		assert_eq!(PolitestBalances::free_balance(&who), 700 * PLMC);
+		assert_ok!(PolimecDispenser::dispense(PolimecOrigin::signed(who.clone()), jwt));
+		assert_eq!(PolimecBalances::free_balance(&who), 700 * PLMC);
 		assert_eq!(
-			PolitestBalances::usable_balance(who.clone()),
-			<PolitestRuntime as pallet_dispenser::Config>::FreeDispenseAmount::get()
+			PolimecBalances::usable_balance(who.clone()),
+			<PolimecRuntime as pallet_dispenser::Config>::FreeDispenseAmount::get()
 		);
 		assert_eq!(
-			PolitestVesting::vesting_balance(&who),
+			PolimecVesting::vesting_balance(&who),
 			Some(
-				<PolitestRuntime as pallet_dispenser::Config>::InitialDispenseAmount::get() -
-					<PolitestRuntime as pallet_dispenser::Config>::FreeDispenseAmount::get()
+				<PolimecRuntime as pallet_dispenser::Config>::InitialDispenseAmount::get() -
+					<PolimecRuntime as pallet_dispenser::Config>::FreeDispenseAmount::get()
 			)
 		);
 	})

--- a/integration-tests/src/tests/defaults.rs
+++ b/integration-tests/src/tests/defaults.rs
@@ -13,7 +13,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-use crate::PolitestRuntime;
+use crate::PolimecRuntime;
 use frame_support::BoundedVec;
 pub use pallet_funding::instantiator::{BidParams, ContributionParams, UserToUSDBalance};
 use pallet_funding::{
@@ -25,8 +25,7 @@ use sp_arithmetic::{FixedPointNumber, Percent};
 use macros::generate_accounts;
 use pallet_funding::traits::ProvideAssetPrice;
 use polimec_common::{USD_DECIMALS, USD_UNIT};
-use polimec_runtime::PLMC;
-use politest_runtime::AccountId;
+use polimec_runtime::{AccountId, PLMC};
 use sp_runtime::{traits::ConstU32, Perquintill};
 
 pub const IPFS_CID: &str = "QmeuJ24ffwLAZppQcgcggJs3n689bewednYkuc8Bx5Gngz";
@@ -34,9 +33,9 @@ pub const CT_DECIMALS: u8 = 18;
 pub const CT_UNIT: u128 = 10_u128.pow(CT_DECIMALS as u32);
 
 pub type IntegrationInstantiator = pallet_funding::instantiator::Instantiator<
-	PolitestRuntime,
-	<PolitestRuntime as pallet_funding::Config>::AllPalletsWithoutSystem,
-	<PolitestRuntime as pallet_funding::Config>::RuntimeEvent,
+	PolimecRuntime,
+	<PolimecRuntime as pallet_funding::Config>::AllPalletsWithoutSystem,
+	<PolimecRuntime as pallet_funding::Config>::RuntimeEvent,
 >;
 
 generate_accounts!(
@@ -63,13 +62,13 @@ pub fn default_contributor_multipliers() -> Vec<u8> {
 	vec![1u8, 1u8, 1u8, 1u8, 1u8]
 }
 
-pub fn default_project_metadata(issuer: AccountId) -> ProjectMetadataOf<politest_runtime::Runtime> {
+pub fn default_project_metadata(issuer: AccountId) -> ProjectMetadataOf<polimec_runtime::Runtime> {
 	ProjectMetadata {
 		token_information: CurrencyMetadata { name: bounded_name(), symbol: bounded_symbol(), decimals: CT_DECIMALS },
 		mainnet_token_max_supply: 8_000_000 * CT_UNIT,
 		total_allocation_size: 1_000_000 * CT_UNIT,
 		auction_round_allocation_percentage: Percent::from_percent(50u8),
-		minimum_price: PriceProviderOf::<PolitestRuntime>::calculate_decimals_aware_price(
+		minimum_price: PriceProviderOf::<PolimecRuntime>::calculate_decimals_aware_price(
 			sp_runtime::FixedU128::from_float(10.0),
 			USD_DECIMALS,
 			CT_DECIMALS,
@@ -91,7 +90,7 @@ pub fn default_project_metadata(issuer: AccountId) -> ProjectMetadataOf<politest
 		policy_ipfs_cid: Some(ipfs_hash()),
 	}
 }
-pub fn default_evaluations() -> Vec<UserToUSDBalance<PolitestRuntime>> {
+pub fn default_evaluations() -> Vec<UserToUSDBalance<PolimecRuntime>> {
 	vec![
 		UserToUSDBalance::new(EVAL_1.into(), 500_000 * PLMC),
 		UserToUSDBalance::new(EVAL_2.into(), 250_000 * PLMC),
@@ -102,7 +101,7 @@ pub fn default_bidders() -> Vec<AccountId> {
 	vec![BIDDER_1.into(), BIDDER_2.into(), BIDDER_3.into(), BIDDER_4.into(), BIDDER_5.into()]
 }
 
-pub fn default_bids() -> Vec<BidParams<PolitestRuntime>> {
+pub fn default_bids() -> Vec<BidParams<PolimecRuntime>> {
 	let inst = IntegrationInstantiator::new(None);
 	let default_metadata = default_project_metadata(ISSUER.into());
 	let auction_allocation =
@@ -119,7 +118,7 @@ pub fn default_bids() -> Vec<BidParams<PolitestRuntime>> {
 	)
 }
 
-pub fn default_community_contributions() -> Vec<ContributionParams<PolitestRuntime>> {
+pub fn default_community_contributions() -> Vec<ContributionParams<PolimecRuntime>> {
 	let inst = IntegrationInstantiator::new(None);
 
 	let default_metadata = default_project_metadata(ISSUER.into());
@@ -140,7 +139,7 @@ pub fn default_community_contributions() -> Vec<ContributionParams<PolitestRunti
 	)
 }
 
-pub fn default_remainder_contributions() -> Vec<ContributionParams<PolitestRuntime>> {
+pub fn default_remainder_contributions() -> Vec<ContributionParams<PolimecRuntime>> {
 	let inst = IntegrationInstantiator::new(None);
 
 	let default_metadata = default_project_metadata(ISSUER.into());

--- a/integration-tests/src/tests/e2e.rs
+++ b/integration-tests/src/tests/e2e.rs
@@ -42,7 +42,7 @@ generate_accounts!(
 	JOEL, POLKA, MALIK, ALEXANDER, SOLOMUN, JOHNNY, GRINGO, JONAS, BUNDI, FELIX,
 );
 
-pub fn excel_project() -> ProjectMetadataOf<PolitestRuntime> {
+pub fn excel_project() -> ProjectMetadataOf<PolimecRuntime> {
 	let bounded_name = BoundedVec::try_from("Polimec".as_bytes().to_vec()).unwrap();
 	let bounded_symbol = BoundedVec::try_from("PLMC".as_bytes().to_vec()).unwrap();
 	let metadata_hash = ipfs_hash();
@@ -54,8 +54,8 @@ pub fn excel_project() -> ProjectMetadataOf<PolitestRuntime> {
 		auction_round_allocation_percentage: Percent::from_percent(50u8),
 
 		// Minimum Price per Contribution Token (in USDT)
-		minimum_price: PriceProviderOf::<PolitestRuntime>::calculate_decimals_aware_price(
-			PriceOf::<PolitestRuntime>::from_float(10.0f64),
+		minimum_price: PriceProviderOf::<PolimecRuntime>::calculate_decimals_aware_price(
+			PriceOf::<PolimecRuntime>::from_float(10.0f64),
 			USD_DECIMALS,
 			CT_DECIMALS,
 		)
@@ -77,7 +77,7 @@ pub fn excel_project() -> ProjectMetadataOf<PolitestRuntime> {
 	}
 }
 
-fn excel_evaluators() -> Vec<UserToUSDBalance<PolitestRuntime>> {
+fn excel_evaluators() -> Vec<UserToUSDBalance<PolimecRuntime>> {
 	vec![
 		(LINA.into(), 93754 * USD_UNIT).into(),
 		(MIA.into(), 162 * USD_UNIT).into(),
@@ -98,7 +98,7 @@ fn excel_evaluators() -> Vec<UserToUSDBalance<PolitestRuntime>> {
 	]
 }
 
-fn excel_bidders() -> Vec<BidParams<PolitestRuntime>> {
+fn excel_bidders() -> Vec<BidParams<PolimecRuntime>> {
 	vec![
 		(ADAMS.into(), 700 * CT_UNIT).into(),
 		(POLK.into(), 4000 * CT_UNIT).into(),
@@ -125,7 +125,7 @@ fn excel_bidders() -> Vec<BidParams<PolitestRuntime>> {
 	]
 }
 
-fn excel_contributions() -> Vec<ContributionParams<PolitestRuntime>> {
+fn excel_contributions() -> Vec<ContributionParams<PolimecRuntime>> {
 	vec![
 		(XI.into(), 692 * CT_UNIT).into(),
 		(PARI.into(), 236 * CT_UNIT).into(),
@@ -172,7 +172,7 @@ fn excel_contributions() -> Vec<ContributionParams<PolitestRuntime>> {
 		(LUIS.into(), 422 * CT_UNIT).into(),
 	]
 }
-fn excel_remainders() -> Vec<ContributionParams<PolitestRuntime>> {
+fn excel_remainders() -> Vec<ContributionParams<PolimecRuntime>> {
 	vec![
 		(JOEL.into(), 692 * CT_UNIT).into(),
 		(POLK.into(), 236 * CT_UNIT).into(),
@@ -271,7 +271,7 @@ fn excel_ct_amounts() -> UserToCTBalance {
 
 #[test]
 fn evaluation_round_completed() {
-	politest::set_prices();
+	polimec::set_prices();
 
 	let mut inst = IntegrationInstantiator::new(None);
 
@@ -279,14 +279,14 @@ fn evaluation_round_completed() {
 	let project = excel_project();
 	let evaluations = excel_evaluators();
 
-	PolitestNet::execute_with(|| {
+	PolimecNet::execute_with(|| {
 		inst.create_auctioning_project(project, issuer, evaluations);
 	});
 }
 
 #[test]
 fn auction_round_completed() {
-	politest::set_prices();
+	polimec::set_prices();
 
 	let mut inst = IntegrationInstantiator::new(None);
 
@@ -295,13 +295,13 @@ fn auction_round_completed() {
 	let evaluations = excel_evaluators();
 	let bids = excel_bidders();
 
-	PolitestNet::execute_with(|| {
+	PolimecNet::execute_with(|| {
 		let project_id = inst.create_community_contributing_project(project, issuer, evaluations, bids);
 		let excel_wap_fixed = FixedU128::from_float(10.202357561f64);
 		let excel_wap_usd = excel_wap_fixed.saturating_mul_int(USD_UNIT);
 
 		let stored_wap_fixed = inst.get_project_details(project_id).weighted_average_price.unwrap();
-		let stored_wap_fixed_decimal_unaware = PriceProviderOf::<PolitestRuntime>::convert_back_to_normal_price(
+		let stored_wap_fixed_decimal_unaware = PriceProviderOf::<PolimecRuntime>::convert_back_to_normal_price(
 			stored_wap_fixed,
 			USD_DECIMALS,
 			CT_DECIMALS,
@@ -314,7 +314,7 @@ fn auction_round_completed() {
 		let names = names();
 		inst.execute(|| {
 			let bids =
-				Bids::<PolitestRuntime>::iter_prefix_values((0,)).sorted_by_key(|bid| bid.bidder.clone()).collect_vec();
+				Bids::<PolimecRuntime>::iter_prefix_values((0,)).sorted_by_key(|bid| bid.bidder.clone()).collect_vec();
 
 			for bid in bids.clone() {
 				let key: [u8; 32] = bid.bidder.clone().into();
@@ -326,11 +326,11 @@ fn auction_round_completed() {
 
 #[test]
 fn community_round_completed() {
-	politest::set_prices();
+	polimec::set_prices();
 
 	let mut inst = IntegrationInstantiator::new(None);
 
-	PolitestNet::execute_with(|| {
+	PolimecNet::execute_with(|| {
 		let _ = inst.create_remainder_contributing_project(
 			excel_project(),
 			ISSUER.into(),
@@ -340,7 +340,7 @@ fn community_round_completed() {
 		);
 
 		inst.execute(|| {
-			let contributions = Contributions::<PolitestRuntime>::iter_prefix_values((0,))
+			let contributions = Contributions::<PolimecRuntime>::iter_prefix_values((0,))
 				.sorted_by_key(|bid| bid.contributor.clone())
 				.collect_vec();
 			let _total_contribution =
@@ -352,11 +352,11 @@ fn community_round_completed() {
 
 #[test]
 fn remainder_round_completed() {
-	politest::set_prices();
+	polimec::set_prices();
 
 	let mut inst = IntegrationInstantiator::new(None);
 
-	PolitestNet::execute_with(|| {
+	PolimecNet::execute_with(|| {
 		inst.create_finished_project(
 			excel_project(),
 			ISSUER.into(),
@@ -366,13 +366,13 @@ fn remainder_round_completed() {
 			excel_remainders(),
 		);
 
-		let contributions = Contributions::<PolitestRuntime>::iter_prefix_values((0,))
+		let contributions = Contributions::<PolimecRuntime>::iter_prefix_values((0,))
 			.sorted_by_key(|contribution| contribution.contributor.clone())
 			.collect_vec();
 		let total_stored =
 			contributions.into_iter().fold(0, |acc, contribution| acc + contribution.funding_asset_amount);
 
-		let usdt_decimals = <PolitestRuntime as pallet_funding::Config>::FundingCurrency::decimals(
+		let usdt_decimals = <PolimecRuntime as pallet_funding::Config>::FundingCurrency::decimals(
 			AcceptedFundingAsset::USDT.to_assethub_id(),
 		);
 		let usdt_total_from_excel_f64 = 503_945.4_517_000_000f64;
@@ -385,11 +385,11 @@ fn remainder_round_completed() {
 
 #[test]
 fn funds_raised() {
-	politest::set_prices();
+	polimec::set_prices();
 
 	let mut inst = IntegrationInstantiator::new(None);
 
-	PolitestNet::execute_with(|| {
+	PolimecNet::execute_with(|| {
 		let project_id = inst.create_finished_project(
 			excel_project(),
 			ISSUER.into(),
@@ -400,12 +400,12 @@ fn funds_raised() {
 		);
 
 		inst.execute(|| {
-			let project_specific_account: AccountId = PolitestFundingPallet::fund_account_id(project_id);
+			let project_specific_account: AccountId = PolimecFunding::fund_account_id(project_id);
 			let stored_usdt_funded =
-				PolitestForeignAssets::balance(AcceptedFundingAsset::USDT.to_assethub_id(), project_specific_account);
+				PolimecForeignAssets::balance(AcceptedFundingAsset::USDT.to_assethub_id(), project_specific_account);
 			let excel_usdt_funded_f64 = 1_004_256.0_140_000_000f64;
 			let excet_usdt_funding_fixed = FixedU128::from_float(excel_usdt_funded_f64);
-			let usdt_decimals = <PolitestRuntime as pallet_funding::Config>::FundingCurrency::decimals(
+			let usdt_decimals = <PolimecRuntime as pallet_funding::Config>::FundingCurrency::decimals(
 				AcceptedFundingAsset::USDT.to_assethub_id(),
 			);
 			let excel_usdt_funded = excet_usdt_funding_fixed.saturating_mul_int(10u128.pow(usdt_decimals as u32));
@@ -416,11 +416,11 @@ fn funds_raised() {
 
 #[test]
 fn ct_minted() {
-	politest::set_prices();
+	polimec::set_prices();
 
 	let mut inst = IntegrationInstantiator::new(None);
 
-	PolitestNet::execute_with(|| {
+	PolimecNet::execute_with(|| {
 		let project_id = inst.create_finished_project(
 			excel_project(),
 			ISSUER.into(),
@@ -429,13 +429,13 @@ fn ct_minted() {
 			excel_contributions(),
 			excel_remainders(),
 		);
-		inst.advance_time(<PolitestRuntime as Config>::SuccessToSettlementTime::get()).unwrap();
+		inst.advance_time(<PolimecRuntime as Config>::SuccessToSettlementTime::get()).unwrap();
 
 		inst.settle_project(project_id).unwrap();
 
 		for (contributor, expected_amount_fixed, project_id) in excel_ct_amounts() {
 			let minted = inst
-				.execute(|| <PolitestRuntime as Config>::ContributionTokenCurrency::balance(project_id, &contributor));
+				.execute(|| <PolimecRuntime as Config>::ContributionTokenCurrency::balance(project_id, &contributor));
 			let expected_amount = expected_amount_fixed.saturating_mul_int(CT_UNIT);
 			assert_close_enough!(minted, expected_amount, Perquintill::from_float(0.99));
 		}
@@ -444,11 +444,11 @@ fn ct_minted() {
 
 #[test]
 fn ct_migrated() {
-	politest::set_prices();
+	polimec::set_prices();
 
 	let mut inst = IntegrationInstantiator::new(None);
 
-	let project_id = PolitestNet::execute_with(|| {
+	let project_id = PolimecNet::execute_with(|| {
 		let project_id = inst.create_finished_project(
 			excel_project(),
 			ISSUER.into(),
@@ -457,13 +457,13 @@ fn ct_migrated() {
 			excel_contributions(),
 			excel_remainders(),
 		);
-		inst.advance_time(<PolitestRuntime as Config>::SuccessToSettlementTime::get()).unwrap();
+		inst.advance_time(<PolimecRuntime as Config>::SuccessToSettlementTime::get()).unwrap();
 
 		inst.settle_project(project_id).unwrap();
 
 		for (contributor, expected_amount_fixed, project_id) in excel_ct_amounts() {
 			let minted = inst
-				.execute(|| <PolitestRuntime as Config>::ContributionTokenCurrency::balance(project_id, &contributor));
+				.execute(|| <PolimecRuntime as Config>::ContributionTokenCurrency::balance(project_id, &contributor));
 			let expected_amount = expected_amount_fixed.saturating_mul_int(CT_UNIT);
 			assert_close_enough!(minted, expected_amount, Perquintill::from_float(0.99));
 		}
@@ -471,11 +471,10 @@ fn ct_migrated() {
 		project_id
 	});
 
-	let project_details = PolitestNet::execute_with(|| inst.get_project_details(project_id));
+	let project_details = PolimecNet::execute_with(|| inst.get_project_details(project_id));
 	assert!(matches!(project_details.evaluation_round_info.evaluators_outcome, EvaluatorsOutcome::Rewarded(_)));
-	let ct_issued = PolitestNet::execute_with(|| {
-		<PolitestRuntime as Config>::ContributionTokenCurrency::total_issuance(project_id)
-	});
+	let ct_issued =
+		PolimecNet::execute_with(|| <PolimecRuntime as Config>::ContributionTokenCurrency::total_issuance(project_id));
 
 	PenNet::execute_with(|| {
 		let polimec_sovereign_account =
@@ -484,22 +483,18 @@ fn ct_migrated() {
 	});
 
 	// Mock HRMP establishment
-	PolitestNet::execute_with(|| {
-		let _account_id: PolitestAccountId = ISSUER.into();
-		assert_ok!(PolitestFundingPallet::do_set_para_id_for_project(
-			&ISSUER.into(),
-			project_id,
-			ParaId::from(6969u32),
-		));
+	PolimecNet::execute_with(|| {
+		let _account_id: PolimecAccountId = ISSUER.into();
+		assert_ok!(PolimecFunding::do_set_para_id_for_project(&ISSUER.into(), project_id, ParaId::from(6969u32),));
 		let open_channel_message = xcm::v3::opaque::Instruction::HrmpNewChannelOpenRequest {
 			sender: 6969,
 			max_message_size: 102_300,
 			max_capacity: 1000,
 		};
-		assert_ok!(PolitestFundingPallet::do_handle_channel_open_request(open_channel_message));
+		assert_ok!(PolimecFunding::do_handle_channel_open_request(open_channel_message));
 
 		let channel_accepted_message = xcm::v3::opaque::Instruction::HrmpChannelAccepted { recipient: 6969u32 };
-		assert_ok!(PolitestFundingPallet::do_handle_channel_accepted(channel_accepted_message));
+		assert_ok!(PolimecFunding::do_handle_channel_accepted(channel_accepted_message));
 	});
 
 	PenNet::execute_with(|| {
@@ -508,8 +503,8 @@ fn ct_migrated() {
 	});
 
 	// Migration is ready
-	PolitestNet::execute_with(|| {
-		let project_details = pallet_funding::ProjectsDetails::<PolitestRuntime>::get(project_id).unwrap();
+	PolimecNet::execute_with(|| {
+		let project_details = pallet_funding::ProjectsDetails::<PolimecRuntime>::get(project_id).unwrap();
 		assert!(project_details.migration_readiness_check.unwrap().is_ready())
 	});
 
@@ -529,9 +524,9 @@ fn ct_migrated() {
 	let names = names();
 
 	for account in accounts {
-		PolitestNet::execute_with(|| {
-			assert_ok!(PolitestFundingPallet::migrate_one_participant(
-				PolitestOrigin::signed(account.clone()),
+		PolimecNet::execute_with(|| {
+			assert_ok!(PolimecFunding::migrate_one_participant(
+				PolimecOrigin::signed(account.clone()),
 				project_id,
 				account.clone()
 			));

--- a/integration-tests/src/tests/governance.rs
+++ b/integration-tests/src/tests/governance.rs
@@ -116,7 +116,7 @@ fn council_and_technical_committee_members_set_correctly() {
 	let dave = PolimecNet::account_id_of(DAVE);
 	let eve = PolimecNet::account_id_of(EVE);
 	let accounts = vec![alice, bob, charlie, dave, eve];
-	PolitestNet::execute_with(|| {
+	PolimecNet::execute_with(|| {
 		assert_same_members(Council::members(), &accounts);
 		assert_same_members(TechnicalCommittee::members(), &accounts);
 	});

--- a/integration-tests/src/tests/oracle.rs
+++ b/integration-tests/src/tests/oracle.rs
@@ -19,13 +19,13 @@ use crate::*;
 /// Alice, Bob, Charlie are members of the OracleProvidersMembers.
 /// Only members should be able to feed data into the oracle.
 use parity_scale_codec::alloc::collections::HashMap;
-use politest_runtime::{Oracle, RuntimeOrigin};
+use polimec_runtime::{Oracle, RuntimeOrigin};
 use sp_runtime::{bounded_vec, BoundedVec, FixedU128};
 use tests::defaults::*;
 
 fn values(
 	values: [f64; 4],
-) -> BoundedVec<(u32, FixedU128), <politest_runtime::Runtime as orml_oracle::Config<()>>::MaxFeedValues> {
+) -> BoundedVec<(u32, FixedU128), <polimec_runtime::Runtime as orml_oracle::Config<()>>::MaxFeedValues> {
 	let [dot, usdc, usdt, plmc] = values;
 	bounded_vec![
 		(10u32, FixedU128::from_float(dot)),
@@ -39,16 +39,16 @@ fn values(
 fn members_can_feed_data() {
 	let mut inst = IntegrationInstantiator::new(None);
 
-	PolitestNet::execute_with(|| {
+	PolimecNet::execute_with(|| {
 		// pallet_funding genesis builder already inputs prices, so we need to advance one block to feed new values.
 		inst.advance_time(1u32).unwrap();
-		let alice = PolitestNet::account_id_of(ALICE);
+		let alice = PolimecNet::account_id_of(ALICE);
 		assert_ok!(Oracle::feed_values(RuntimeOrigin::signed(alice.clone()), values([4.84, 1.0, 1.0, 0.4])));
 
-		let bob = PolitestNet::account_id_of(BOB);
+		let bob = PolimecNet::account_id_of(BOB);
 		assert_ok!(Oracle::feed_values(RuntimeOrigin::signed(bob.clone()), values([4.84, 1.0, 1.0, 0.4])));
 
-		let charlie = PolitestNet::account_id_of(CHARLIE);
+		let charlie = PolimecNet::account_id_of(CHARLIE);
 		assert_ok!(Oracle::feed_values(RuntimeOrigin::signed(charlie.clone()), values([4.84, 1.0, 1.0, 0.4])));
 
 		let expected_values = HashMap::from([
@@ -67,11 +67,11 @@ fn members_can_feed_data() {
 
 #[test]
 fn non_members_cannot_feed_data() {
-	PolitestNet::execute_with(|| {
-		let dave = PolitestNet::account_id_of(DAVE);
+	PolimecNet::execute_with(|| {
+		let dave = PolimecNet::account_id_of(DAVE);
 		assert_noop!(
 			Oracle::feed_values(RuntimeOrigin::signed(dave.clone()), values([4.84, 1.0, 1.0, 0.4])),
-			orml_oracle::Error::<politest_runtime::Runtime, ()>::NoPermission
+			orml_oracle::Error::<polimec_runtime::Runtime, ()>::NoPermission
 		);
 	});
 }
@@ -79,17 +79,17 @@ fn non_members_cannot_feed_data() {
 #[test]
 fn data_is_correctly_combined() {
 	let mut inst = IntegrationInstantiator::new(None);
-	PolitestNet::execute_with(|| {
+	PolimecNet::execute_with(|| {
 		// pallet_funding genesis builder already inputs prices, so we need to advance one block to feed new values.
 		inst.advance_time(1u32).unwrap();
 
-		let alice = PolitestNet::account_id_of(ALICE);
+		let alice = PolimecNet::account_id_of(ALICE);
 		assert_ok!(Oracle::feed_values(RuntimeOrigin::signed(alice.clone()), values([1.0, 1.5, 1.1, 0.11111])));
 
-		let bob = PolitestNet::account_id_of(BOB);
+		let bob = PolimecNet::account_id_of(BOB);
 		assert_ok!(Oracle::feed_values(RuntimeOrigin::signed(bob.clone()), values([2.0, 1.0, 1.2, 0.22222])));
 
-		let charlie = PolitestNet::account_id_of(CHARLIE);
+		let charlie = PolimecNet::account_id_of(CHARLIE);
 		assert_ok!(Oracle::feed_values(RuntimeOrigin::signed(charlie.clone()), values([3.0, 0.8, 1.1, 0.33333])));
 
 		// Default CombineData implementation is the median value
@@ -111,17 +111,17 @@ fn data_is_correctly_combined() {
 fn pallet_funding_works() {
 	let mut inst = IntegrationInstantiator::new(None);
 
-	PolitestNet::execute_with(|| {
+	PolimecNet::execute_with(|| {
 		// pallet_funding genesis builder already inputs prices, so we need to advance one block to feed new values.
 		inst.advance_time(1u32).unwrap();
 
-		let alice = PolitestNet::account_id_of(ALICE);
+		let alice = PolimecNet::account_id_of(ALICE);
 		assert_ok!(Oracle::feed_values(RuntimeOrigin::signed(alice.clone()), values([4.84, 1.0, 1.0, 0.4])));
 
-		let bob = PolitestNet::account_id_of(BOB);
+		let bob = PolimecNet::account_id_of(BOB);
 		assert_ok!(Oracle::feed_values(RuntimeOrigin::signed(bob.clone()), values([4.84, 1.0, 1.0, 0.4])));
 
-		let charlie = PolitestNet::account_id_of(CHARLIE);
+		let charlie = PolimecNet::account_id_of(CHARLIE);
 		assert_ok!(Oracle::feed_values(RuntimeOrigin::signed(charlie.clone()), values([4.84, 1.0, 1.0, 0.4])));
 
 		let _project_id = inst.create_finished_project(

--- a/integration-tests/src/tests/reserve_backed_transfers.rs
+++ b/integration-tests/src/tests/reserve_backed_transfers.rs
@@ -63,9 +63,9 @@ fn mint_asset_on_asset_hub_to(asset_id: u32, recipient: &AssetHubAccountId, amou
 fn get_polimec_balances(asset_id: u32, user_account: AccountId) -> (u128, u128, u128, u128) {
 	PolimecNet::execute_with(|| {
 		(
-			PolitestForeignAssets::balance(asset_id, user_account.clone()),
+			PolimecForeignAssets::balance(asset_id, user_account.clone()),
 			PolimecBalances::balance(&user_account.clone()),
-			PolitestForeignAssets::total_issuance(asset_id),
+			PolimecForeignAssets::total_issuance(asset_id),
 			PolimecBalances::total_issuance(),
 		)
 	})
@@ -169,14 +169,14 @@ fn test_reserve_to_polimec(asset_id: u32) {
 	let asset_hub_delta_asset_issuance = asset_hub_post_asset_issuance.abs_diff(asset_hub_prev_asset_issuance);
 
 	assert!(
-	    polimec_delta_alice_asset_balance >= RESERVE_TRANSFER_AMOUNT - politest_runtime::WeightToFee::weight_to_fee(&max_weight) &&
+	    polimec_delta_alice_asset_balance >= RESERVE_TRANSFER_AMOUNT - polimec_runtime::WeightToFee::weight_to_fee(&max_weight) &&
 	    polimec_delta_alice_asset_balance <= RESERVE_TRANSFER_AMOUNT,
 	    "Polimec alice_account.clone() Asset balance should have increased by at least the transfer amount minus the XCM execution fee"
 	);
 
 	assert!(
 		polimec_delta_asset_issuance >=
-			RESERVE_TRANSFER_AMOUNT - politest_runtime::WeightToFee::weight_to_fee(&max_weight) &&
+			RESERVE_TRANSFER_AMOUNT - polimec_runtime::WeightToFee::weight_to_fee(&max_weight) &&
 			polimec_delta_asset_issuance <= RESERVE_TRANSFER_AMOUNT,
 		"Polimec Asset issuance should have increased by at least the transfer amount minus the XCM execution fee"
 	);

--- a/integration-tests/src/tests/vest.rs
+++ b/integration-tests/src/tests/vest.rs
@@ -42,7 +42,7 @@ fn base_vested_can_stake() {
 		// Stake 60 PLMC from "new_account" to "COLL_1", it should fail since the account has no PLMC
 		assert_noop!(
 			ParachainStaking::delegate(RuntimeOrigin::signed(new_account.clone()), coll_1.clone(), 60 * PLMC, 0, 0),
-			pallet_parachain_staking::Error::<politest_runtime::Runtime>::InsufficientBalance
+			pallet_parachain_staking::Error::<polimec_runtime::Runtime>::InsufficientBalance
 		);
 
 		// Create a vesting schedule for 60 PLMC + ED over 60 blocks (~1 PLMC per block) to NEW_ACCOUNT

--- a/runtimes/polimec/Cargo.toml
+++ b/runtimes/polimec/Cargo.toml
@@ -278,4 +278,6 @@ try-runtime = [
 # to make it smaller, like logging for example.
 on-chain-release-build = [ "sp-api/disable-logging" ]
 
-development-settings = []
+development-settings = [
+	"shared-configuration/development-settings"
+]

--- a/runtimes/polimec/src/lib.rs
+++ b/runtimes/polimec/src/lib.rs
@@ -227,21 +227,24 @@ pub struct BaseCallFilter;
 impl Contains<RuntimeCall> for BaseCallFilter {
 	fn contains(c: &RuntimeCall) -> bool {
 		match c {
-			RuntimeCall::Funding(call) => {
-				matches!(
-					call,
-					pallet_funding::Call::create_project { .. } |
-						pallet_funding::Call::remove_project { .. } |
-						pallet_funding::Call::edit_project { .. } |
-						pallet_funding::Call::start_evaluation { .. } |
-						pallet_funding::Call::root_do_evaluation_end { .. } |
-						pallet_funding::Call::evaluate { .. } |
-						pallet_funding::Call::start_auction { .. } |
-						pallet_funding::Call::root_do_auction_opening { .. } |
-						pallet_funding::Call::root_do_start_auction_closing { .. } |
-						pallet_funding::Call::bid { .. }
-				)
-			},
+			RuntimeCall::Funding(call) =>
+				if cfg!(feature = "development-settings") {
+					true
+				} else {
+					matches!(
+						call,
+						pallet_funding::Call::create_project { .. } |
+							pallet_funding::Call::remove_project { .. } |
+							pallet_funding::Call::edit_project { .. } |
+							pallet_funding::Call::start_evaluation { .. } |
+							pallet_funding::Call::root_do_evaluation_end { .. } |
+							pallet_funding::Call::evaluate { .. } |
+							pallet_funding::Call::start_auction { .. } |
+							pallet_funding::Call::root_do_auction_opening { .. } |
+							pallet_funding::Call::root_do_start_auction_closing { .. } |
+							pallet_funding::Call::bid { .. }
+					)
+				},
 			_ => true,
 		}
 	}
@@ -993,24 +996,6 @@ parameter_types! {
 	pub RequiredMaxMessageSize: u32 = 102_400;
 	pub MinUsdPerEvaluation: Balance = 100 * USD_UNIT;
 
-}
-
-// Development public key
-#[cfg(any(feature = "development-settings", test))]
-parameter_types! {
-	pub VerifierPublicKey: [u8; 32] = [
-		32, 118, 30, 171, 58, 212, 197, 27, 146, 122, 255, 243, 34, 245, 90, 244, 221, 37, 253,
-		195, 18, 202, 111, 55, 39, 48, 123, 17, 101, 78, 215, 94,
-	];
-}
-
-// Production public key
-#[cfg(not(any(feature = "development-settings", test)))]
-parameter_types! {
-	pub VerifierPublicKey: [u8; 32] = [
-		83,  49,  95, 191,  98, 138,  14,  43, 234, 192, 105, 248,  11,  96, 127, 234, 192,  62,  80,
-		35, 204,   0,  38, 210, 177,  72, 167, 116, 133, 127, 140, 249
-	 ];
 }
 
 pub struct ConvertSelf;

--- a/runtimes/politest/src/lib.rs
+++ b/runtimes/politest/src/lib.rs
@@ -997,10 +997,6 @@ parameter_types! {
 	pub MaxCapacityThresholds: (u32, u32) = (8, 1000);
 	pub RequiredMaxCapacity: u32 = 1000;
 	pub RequiredMaxMessageSize: u32 = 102_400;
-	pub VerifierPublicKey: [u8; 32] = [
-		32, 118, 30, 171, 58, 212, 197, 27, 146, 122, 255, 243, 34, 245, 90, 244, 221, 37, 253,
-		195, 18, 202, 111, 55, 39, 48, 123, 17, 101, 78, 215, 94,
-	];
 	pub MinUsdPerEvaluation: Balance = 100 * USD_UNIT;
 
 }

--- a/runtimes/shared-configuration/Cargo.toml
+++ b/runtimes/shared-configuration/Cargo.toml
@@ -86,3 +86,4 @@ try-runtime = [
 	"polimec-common/try-runtime",
 	"sp-runtime/try-runtime",
 ]
+development-settings = []

--- a/runtimes/shared-configuration/src/identity.rs
+++ b/runtimes/shared-configuration/src/identity.rs
@@ -58,3 +58,19 @@ pub type UsernameAuthorityOrigin = frame_system::EnsureNever<AccountId>;
 
 #[cfg(feature = "runtime-benchmarks")]
 pub type UsernameAuthorityOrigin = frame_system::EnsureRoot<AccountId>;
+
+parameter_types! {
+	pub TestingVerifierPublicKey: [u8; 32] = [
+		32, 118, 30, 171, 58, 212, 197, 27, 146, 122, 255, 243, 34, 245, 90, 244, 221, 37, 253,
+		195, 18, 202, 111, 55, 39, 48, 123, 17, 101, 78, 215, 94,
+	];
+	pub ProductionVerifierPublicKey: [u8; 32] = [
+		83,  49,  95, 191,  98, 138,  14,  43, 234, 192, 105, 248,  11,  96, 127, 234, 192,  62,  80,
+		35, 204,   0,  38, 210, 177,  72, 167, 116, 133, 127, 140, 249
+	 ];
+}
+
+#[cfg(any(feature = "runtime-benchmarks", test, feature = "development-settings"))]
+pub type VerifierPublicKey = TestingVerifierPublicKey;
+#[cfg(not(any(feature = "runtime-benchmarks", test, feature = "development-settings")))]
+pub type VerifierPublicKey = ProductionVerifierPublicKey;


### PR DESCRIPTION
## What?
- Remove politest from integration tests, and replace all references with polimec

## Why?
- First step in deleting politest

## Testing?
`cargo test --package integration-tests`