### PR TITLE
👨🏻‍💻 Allow polimec receiver pallet to have any index

### DIFF
--- a/integration-tests/penpal/src/lib.rs
+++ b/integration-tests/penpal/src/lib.rs
@@ -672,8 +672,8 @@ construct_runtime!(
 
 		// The main stage.
 		Assets: pallet_assets::{Pallet, Call, Storage, Event<T>} = 50,
-		PolimecReceiver: polimec_receiver = 51,
-		Vesting: pallet_vesting = 52,
+		Vesting: pallet_vesting = 51,
+		PolimecReceiver: polimec_receiver = 69,
 
 		Sudo: pallet_sudo::{Pallet, Call, Storage, Event<T>, Config<T>} = 255,
 	}

--- a/pallets/funding/src/functions/misc.rs
+++ b/pallets/funding/src/functions/misc.rs
@@ -573,15 +573,17 @@ impl<T: Config> Pallet<T> {
 	pub fn construct_migration_xcm_message(
 		migrations: BoundedVec<Migration, MaxParticipationsPerUser<T>>,
 		query_id: QueryId,
+		pallet_index: PalletIndex,
 	) -> Xcm<()> {
 		// TODO: adjust this as benchmarks for polimec-receiver are written
 		const MAX_WEIGHT: Weight = Weight::from_parts(10_000, 0);
 		const MAX_RESPONSE_WEIGHT: Weight = Weight::from_parts(700_000_000, 10_000);
 		// const MAX_WEIGHT: Weight = Weight::from_parts(100_003_000_000_000, 10_000_196_608);
-		let _polimec_receiver_info = T::PolimecReceiverInfo::get();
 		let migrations_item = Migrations::from(migrations.into());
 
-		let mut encoded_call = vec![51u8, 0];
+		// First byte is the pallet index, second byte is the call index
+		let mut encoded_call = vec![pallet_index, 0];
+
 		// migrations_item can contain a Maximum of MaxParticipationsPerUser migrations which
 		// is 48. So we know that there is an upper limit to this encoded call, namely 48 *
 		// Migration encode size.

--- a/pallets/funding/src/lib.rs
+++ b/pallets/funding/src/lib.rs
@@ -360,10 +360,6 @@ pub mod pallet {
 		#[pallet::constant]
 		type PalletId: Get<PalletId>;
 
-		/// Pallet info of the polimec receiver pallet. Used for CT migrations
-		#[pallet::constant]
-		type PolimecReceiverInfo: Get<PalletInfo>;
-
 		/// The maximum size of a preimage allowed, expressed in bytes.
 		#[pallet::constant]
 		type PreImageLimit: Get<u32>;

--- a/pallets/funding/src/mock.rs
+++ b/pallets/funding/src/mock.rs
@@ -424,7 +424,6 @@ impl Config for TestRuntime {
 	type Multiplier = Multiplier;
 	type NativeCurrency = Balances;
 	type PalletId = FundingPalletId;
-	type PolimecReceiverInfo = PolimecReceiverInfo;
 	type PreImageLimit = ConstU32<1024>;
 	type Price = FixedU128;
 	type PriceProvider = ConstPriceProvider;

--- a/pallets/funding/src/tests/misc.rs
+++ b/pallets/funding/src/tests/misc.rs
@@ -310,6 +310,7 @@ mod helper_functions {
 // logic of small functions that extrinsics use to process data or interact with storage
 mod inner_functions {
 	use super::*;
+	use parity_scale_codec::Encode;
 
 	#[test]
 	fn calculate_vesting_duration() {

--- a/pallets/funding/src/types.rs
+++ b/pallets/funding/src/types.rs
@@ -833,14 +833,16 @@ pub mod inner_types {
 
 	impl MigrationReadinessCheck {
 		pub fn is_ready(&self) -> bool {
-			self.holding_check.1 == CheckOutcome::Passed && self.pallet_check.1 == CheckOutcome::Passed
+			self.holding_check.1 == CheckOutcome::Passed(None) &&
+				matches!(self.pallet_check.1, CheckOutcome::Passed(Some(_)))
 		}
 	}
 
+	pub type PalletIndex = u8;
 	#[derive(Clone, Copy, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 	pub enum CheckOutcome {
 		AwaitingResponse,
-		Passed,
+		Passed(Option<PalletIndex>),
 		Failed,
 	}
 

--- a/runtimes/polimec/src/lib.rs
+++ b/runtimes/polimec/src/lib.rs
@@ -1045,7 +1045,6 @@ impl pallet_funding::Config for Runtime {
 	type Multiplier = pallet_funding::types::Multiplier;
 	type NativeCurrency = Balances;
 	type PalletId = FundingPalletId;
-	type PolimecReceiverInfo = PolimecReceiverInfo;
 	type PreImageLimit = ConstU32<1024>;
 	type Price = Price;
 	type PriceProvider = OraclePriceProvider<AssetId, Price, Oracle>;

--- a/runtimes/politest/src/lib.rs
+++ b/runtimes/politest/src/lib.rs
@@ -1047,7 +1047,6 @@ impl pallet_funding::Config for Runtime {
 	type Multiplier = pallet_funding::types::Multiplier;
 	type NativeCurrency = Balances;
 	type PalletId = FundingPalletId;
-	type PolimecReceiverInfo = PolimecReceiverInfo;
 	type PreImageLimit = ConstU32<1024>;
 	type Price = Price;
 	type PriceProvider = OraclePriceProvider<AssetId, FixedU128, Oracle>;


### PR DESCRIPTION
## What?
- Allow parachains to have their polimec receiver pallet assigned to any pallet index

## Why?
- We should not opinionate that

## How?
- We no longer have the config item `PolimecReceiverInfo`. 
- We previously needed it because the `PalletInfo` items returned on the pallet query were set to private. Now we can just check the pallet name and save the index for later

## Testing?
- Modify penpal so the receiver has a different index and run the integration ct_migration tests

