### PR TITLE
🐛 Start failed evaluation settlement

### DIFF
--- a/pallets/funding/src/benchmarking.rs
+++ b/pallets/funding/src/benchmarking.rs
@@ -1867,7 +1867,10 @@ mod benchmarks {
 	}
 
 	#[benchmark]
-	fn end_evaluation_failure() {
+	fn end_evaluation_failure(
+		// Insertion attempts in add_to_update_store. Total amount of storage items iterated through in `ProjectsToUpdate`. Leave one free to make the fn succeed
+		x: Linear<1, { <T as Config>::MaxProjectsToUpdateInsertionAttempts::get() - 1 }>,
+	) {
 		// * setup *
 		let mut inst = BenchInstantiator::<T>::new(None);
 		<T as Config>::SetPrices::set_prices();
@@ -1910,6 +1913,8 @@ mod benchmarks {
 			inst.get_project_details(project_id).phase_transition_points.evaluation.end().unwrap();
 		// move block manually without calling any hooks, to avoid triggering the transition outside the benchmarking context
 		frame_system::Pallet::<T>::set_block_number(evaluation_end_block + One::one());
+
+		fill_projects_to_update::<T>(x, evaluation_end_block + 2u32.into());
 
 		// Instead of advancing in time for the automatic `do_evaluation_end` call in on_initialize, we call it directly to benchmark it
 		#[block]

--- a/pallets/funding/src/lib.rs
+++ b/pallets/funding/src/lib.rs
@@ -810,6 +810,10 @@ pub mod pallet {
 		WrongParaId,
 		/// Migration channel is not ready for migrations.
 		ChannelNotReady,
+		/// Settlement for this project has not yet started.
+		SettlementNotStarted,
+		/// Wanted to settle as successful when it failed, or vice versa.
+		WrongSettlementOutcome,
 		/// User still has participations that need to be settled before migration.
 		ParticipationsNotSettled,
 	}

--- a/pallets/funding/src/tests/3_auction.rs
+++ b/pallets/funding/src/tests/3_auction.rs
@@ -1259,6 +1259,9 @@ mod bid_extrinsic {
 			assert_eq!(bid_held_balance, frozen_amount);
 			assert_eq!(frozen_balance, frozen_amount);
 
+			let settlement_block = inst.get_update_block(project_id, &UpdateType::StartSettlement).unwrap();
+			inst.jump_to_block(settlement_block);
+
 			inst.execute(|| {
 				PolimecFunding::settle_failed_bid(RuntimeOrigin::signed(BIDDER_4), project_id, BIDDER_4, 0).unwrap();
 			});

--- a/pallets/funding/src/tests/4_community.rs
+++ b/pallets/funding/src/tests/4_community.rs
@@ -909,6 +909,9 @@ mod community_contribute_extrinsic {
 			assert_eq!(bid_held_balance, frozen_amount);
 			assert_eq!(frozen_balance, frozen_amount);
 
+			let settlement_block = inst.get_update_block(project_id, &UpdateType::StartSettlement).unwrap();
+			inst.jump_to_block(settlement_block);
+
 			inst.execute(|| {
 				PolimecFunding::settle_failed_contribution(RuntimeOrigin::signed(BUYER_4), project_id, BUYER_4, 0)
 					.unwrap();

--- a/pallets/funding/src/tests/5_remainder.rs
+++ b/pallets/funding/src/tests/5_remainder.rs
@@ -995,6 +995,9 @@ mod remaining_contribute_extrinsic {
 			};
 			assert_eq!(account_data, expected_account_data);
 
+			let settlement_block = inst.get_update_block(project_id, &UpdateType::StartSettlement).unwrap();
+			inst.jump_to_block(settlement_block);
+
 			inst.execute(|| {
 				PolimecFunding::settle_failed_contribution(RuntimeOrigin::signed(BUYER_4), project_id, BUYER_4, 0)
 					.unwrap();

--- a/pallets/funding/src/tests/6_funding_end.rs
+++ b/pallets/funding/src/tests/6_funding_end.rs
@@ -8,7 +8,7 @@ mod round_flow {
 
 		#[test]
 		fn evaluator_slash_is_decided() {
-			let (mut inst, project_id) = create_project_with_funding_percentage(20, None);
+			let (mut inst, project_id) = create_project_with_funding_percentage(20, None, true);
 			assert_eq!(inst.get_project_details(project_id).status, ProjectStatus::FundingFailed);
 			assert_eq!(
 				inst.get_project_details(project_id).evaluation_round_info.evaluators_outcome,
@@ -19,7 +19,7 @@ mod round_flow {
 		#[test]
 		fn evaluator_unchanged_is_decided() {
 			let (mut inst, project_id) =
-				create_project_with_funding_percentage(80, Some(FundingOutcomeDecision::AcceptFunding));
+				create_project_with_funding_percentage(80, Some(FundingOutcomeDecision::AcceptFunding), true);
 			assert_eq!(inst.get_project_details(project_id).status, ProjectStatus::FundingSuccessful);
 			assert_eq!(
 				inst.get_project_details(project_id).evaluation_round_info.evaluators_outcome,
@@ -29,7 +29,7 @@ mod round_flow {
 
 		#[test]
 		fn evaluator_reward_is_decided() {
-			let (mut inst, project_id) = create_project_with_funding_percentage(95, None);
+			let (mut inst, project_id) = create_project_with_funding_percentage(95, None, true);
 			let project_details = inst.get_project_details(project_id);
 			let project_metadata = inst.get_project_metadata(project_id);
 			assert_eq!(project_details.status, ProjectStatus::FundingSuccessful);
@@ -85,6 +85,7 @@ mod decide_project_outcome {
 				let _ = create_project_with_funding_percentage(
 					funding_percent,
 					Some(FundingOutcomeDecision::AcceptFunding),
+					true,
 				);
 			}
 		}
@@ -95,6 +96,7 @@ mod decide_project_outcome {
 				let _ = create_project_with_funding_percentage(
 					funding_percent,
 					Some(FundingOutcomeDecision::RejectFunding),
+					true,
 				);
 			}
 		}
@@ -102,7 +104,7 @@ mod decide_project_outcome {
 		#[test]
 		fn automatic_fail_less_eq_33_percent() {
 			for funding_percent in (1..=33).step_by(5) {
-				let _ = create_project_with_funding_percentage(funding_percent, None);
+				let _ = create_project_with_funding_percentage(funding_percent, None, true);
 			}
 		}
 
@@ -144,7 +146,7 @@ mod decide_project_outcome {
 		#[test]
 		fn automatic_success_bigger_eq_90_percent() {
 			for funding_percent in (90..=100).step_by(2) {
-				let _ = create_project_with_funding_percentage(funding_percent, None);
+				let _ = create_project_with_funding_percentage(funding_percent, None, true);
 			}
 		}
 	}

--- a/pallets/funding/src/weights.rs
+++ b/pallets/funding/src/weights.rs
@@ -70,7 +70,7 @@ pub trait WeightInfo {
 	fn settle_successful_contribution() -> Weight;
 	fn settle_failed_contribution() -> Weight;
 	fn end_evaluation_success(x: u32, ) -> Weight;
-	fn end_evaluation_failure() -> Weight;
+	fn end_evaluation_failure(x: u32, ) -> Weight;
 	fn start_auction_closing_phase(x: u32, ) -> Weight;
 	fn end_auction_closing(x: u32, y: u32, z: u32, ) -> Weight;
 	fn start_community_funding(x: u32, y: u32, z: u32, ) -> Weight;
@@ -531,7 +531,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `Funding::ProjectsDetails` (`max_values`: None, `max_size`: Some(380), added: 2855, mode: `MaxEncodedLen`)
 	/// Storage: `Funding::DidWithActiveProjects` (r:0 w:1)
 	/// Proof: `Funding::DidWithActiveProjects` (`max_values`: None, `max_size`: Some(78), added: 2553, mode: `MaxEncodedLen`)
-	fn end_evaluation_failure() -> Weight {
+	fn end_evaluation_failure(_x: u32, ) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `533`
 		//  Estimated: `3845`
@@ -1260,7 +1260,7 @@ impl WeightInfo for () {
 	/// Proof: `Funding::ProjectsDetails` (`max_values`: None, `max_size`: Some(380), added: 2855, mode: `MaxEncodedLen`)
 	/// Storage: `Funding::DidWithActiveProjects` (r:0 w:1)
 	/// Proof: `Funding::DidWithActiveProjects` (`max_values`: None, `max_size`: Some(78), added: 2553, mode: `MaxEncodedLen`)
-	fn end_evaluation_failure() -> Weight {
+	fn end_evaluation_failure(_x: u32) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `533`
 		//  Estimated: `3845`

--- a/runtimes/polimec/src/weights/pallet_funding.rs
+++ b/runtimes/polimec/src/weights/pallet_funding.rs
@@ -491,7 +491,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `Funding::ProjectsDetails` (`max_values`: None, `max_size`: Some(397), added: 2872, mode: `MaxEncodedLen`)
 	/// Storage: `Funding::DidWithActiveProjects` (r:0 w:1)
 	/// Proof: `Funding::DidWithActiveProjects` (`max_values`: None, `max_size`: Some(78), added: 2553, mode: `MaxEncodedLen`)
-	fn end_evaluation_failure() -> Weight {
+	fn end_evaluation_failure(_x: u32) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `534`
 		//  Estimated: `3862`


### PR DESCRIPTION
## What?
- Schedule the start of settlement for a failed evaluation round
- Settlement functions now check that the settlement was started, and the round is correct (with new more descriptive errors)

## Why?
- We forgor 💀

## Testing?
Refactored some tests to adapt to the new logic

## Anything Else?
We need to re-benchmark end_evaluation_failure since it has a new parameter. For now the parameter is added but not used