### PR TITLE
🔖 Polimec release v0.7.4

### DIFF
--- a/runtimes/polimec/src/lib.rs
+++ b/runtimes/polimec/src/lib.rs
@@ -205,7 +205,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("polimec-mainnet"),
 	impl_name: create_runtime_str!("polimec-mainnet"),
 	authoring_version: 1,
-	spec_version: 0_007_003,
+	spec_version: 0_007_004,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
*Srtool Output:*
```sh
✨ Your Substrate WASM Runtime is ready! ✨
✨ WASM  : runtimes/polimec/target/srtool/production/wbuild/polimec-runtime/polimec_runtime.compact.wasm
✨ Z_WASM: runtimes/polimec/target/srtool/production/wbuild/polimec-runtime/polimec_runtime.compact.compressed.wasm
Summary generated with srtool v0.15.0 using the docker image paritytech/srtool:1.77.0:
 Package     : polimec-runtime v0.7.0
 GIT commit  : 6ccd7ce1aaf1bd3a0c5d36e19a5d28a4e92b209a
 GIT tag     : v0.7.3
 GIT branch  : 06-24-new_polimec_release
 Rustc       : rustc 1.77.0 (aedd173a2 2024-03-17)
 Time        : 2024-06-24T14:49:01Z

== Compact
 Version          : polimec-mainnet-7004 (polimec-mainnet-0.tx2.au1)
 Metadata         : V14
 Size             : 5.06 MB (5303976 bytes)
 setCode          : 0xb8799668c05fb996c552dc9f33df3abbb50fded218760541f559b226a5906054
 authorizeUpgrade : 0x4a4b97b6dde9a7aee15a3796d4dfa6f0696fc3effc3b6cacf6a7c4d7fcc010e1
 IPFS             : QmX2sD9VqW1g4UgJWv7dkhPcZpfKCyGfRkgdRhdBSwkqBj
 BLAKE2_256       : 0x791c073fb18b0c2acdc22c3a673f18dcc46223d66f721463534ec97f844f8968
 Wasm             : runtimes/polimec/target/srtool/production/wbuild/polimec-runtime/polimec_runtime.compact.wasm

== Compressed
 Version          : polimec-mainnet-7004 (polimec-mainnet-0.tx2.au1)
 Metadata         : V14
 Size             : 1.26 MB (1318336 bytes)
 Compression      : 75.15%
 setCode          : 0x16ee654dd1791c9c6945d5477c5d751f06bb653ef279da63fd8ab9aea0c74258
 authorizeUpgrade : 0x4a14e1ac4e12cc93c023f498d14a621516638dd7ac186185798e28c18c03bdf8
 IPFS             : QmcZp35aEzygbpzkyKPHmiYmMCtEYopHNKzk9McfZ3bPpc
 BLAKE2_256       : 0x5a885342c0e1c23948d290dd300afb9acf2c70bb953f94f556a3aedb7e8be3fd
 Wasm             : runtimes/polimec/target/srtool/production/wbuild/polimec-runtime/polimec_runtime.compact.compressed.wasm


```
## Testing?
```sh
❯ try-runtime --runtime ./target/release/wbuild/polimec-runtime/polimec_runtime.compact.compressed.wasm on-runtime-upgrade live --uri wss://rpc.polimec.org:443
[2024-06-24T14:41:30Z INFO  remote-ext] replacing wss:// in uri with https://: "https://rpc.polimec.org:443" (ws is currently unstable for fetching remote storage, for more see https://github.com/paritytech/jsonrpsee/issues/1086)
[2024-06-24T14:41:30Z INFO  remote-ext] since no at is provided, setting it to latest finalized head, 0xbdf8b3f66806fca24f5460078e38403a092aca3e551b90a0c4376a814c659942
[2024-06-24T14:41:30Z INFO  remote-ext] since no prefix is filtered, the data for all pallets will be downloaded
[2024-06-24T14:41:30Z INFO  remote-ext] scraping key-pairs from remote at block height 0xbdf8b3f66806fca24f5460078e38403a092aca3e551b90a0c4376a814c659942
✅ Found 11310 keys (0.51s)
[00:00:01] ✅ Downloaded key values 7,069.1592/s [============================================================================================================================================] 11310/11310 (0s)
✅ Inserted keys into DB (0.02s)
[2024-06-24T14:41:33Z INFO  remote-ext] adding data for hashed prefix: , took 2.28s
[2024-06-24T14:41:33Z INFO  remote-ext] adding data for hashed key: 3a636f6465
[2024-06-24T14:41:33Z INFO  remote-ext] adding data for hashed key: 26aa394eea5630e07c48ae0c9558cef7f9cce9c888469bb1a0dceaa129672ef8
[2024-06-24T14:41:33Z INFO  remote-ext] adding data for hashed key: 26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac
[2024-06-24T14:41:33Z INFO  remote-ext] 👩‍👦 no child roots found to scrape
[2024-06-24T14:41:33Z INFO  remote-ext] initialized state externalities with storage root 0x5fa768937bf364ea2e8d4b968c8dece73fce69e2f552b4b2b52df8d4a79e11f3 and state_version V1
[2024-06-24T14:41:33Z INFO  try-runtime::cli] Original runtime [Name: RuntimeString::Owned("polimec-mainnet")] [Version: 7003] [Code hash: 0xb87c...963a]
[2024-06-24T14:41:33Z INFO  try-runtime::cli] New runtime      [Name: RuntimeString::Owned("polimec-mainnet")] [Version: 7004] [Code hash: 0x3032...c209]
[2024-06-24T14:41:33Z INFO  try-runtime::cli] 🚀 Speed up your workflow by using snapshots instead of live state. See `try-runtime create-snapshot --help`.
[2024-06-24T14:41:33Z INFO  try_runtime_core::misc] ------------------------------------------------------------------
    
    
[2024-06-24T14:41:33Z INFO  try_runtime_core::misc] 🔬 Running TryRuntime_on_runtime_upgrade with checks: PreAndPost
    
    
[2024-06-24T14:41:33Z INFO  try_runtime_core::misc] ------------------------------------------------------------------
    
    
[2024-06-24T14:41:34Z INFO  runtime::executive] ✅ Entire runtime state decodes without error. 664495 bytes total.
[2024-06-24T14:41:34Z INFO  try_runtime_core::misc] ------------------------------------------------------------------------------------------------------
    
    
[2024-06-24T14:41:34Z INFO  try_runtime_core::misc] 🔬 TryRuntime_on_runtime_upgrade succeeded! Running it again without checks for weight measurements.
    
    
[2024-06-24T14:41:34Z INFO  try_runtime_core::misc] ------------------------------------------------------------------------------------------------------
    
    
[2024-06-24T14:41:34Z INFO  try_runtime_core::misc] ---------------------------------------------------------------------------------
    
    
[2024-06-24T14:41:34Z INFO  try_runtime_core::misc] 🔬 Running TryRuntime_on_runtime_upgrade again to check idempotency: PreAndPost
    
    
[2024-06-24T14:41:34Z INFO  try_runtime_core::misc] ---------------------------------------------------------------------------------
    
    
[2024-06-24T14:41:34Z INFO  runtime::executive] ✅ Entire runtime state decodes without error. 664495 bytes total.
[2024-06-24T14:41:34Z INFO  try-runtime::cli] PoV size (zstd-compressed compact proof): 7.9 KB. For parachains, it's your responsibility to verify that a PoV of this size fits within any relaychain constraints.
[2024-06-24T14:41:34Z INFO  try-runtime::cli] Consumed ref_time: 0.000925s (0.19% of max 0.5s)
[2024-06-24T14:41:34Z INFO  try-runtime::cli] ✅ No weight safety issues detected. Please note this does not guarantee a successful runtime upgrade. Always test your runtime upgrade with recent state, and ensure that the weight usage of your migrations will not drastically differ between testing and actual on-chain execution.

polimec-node on  06-24-new_polimec_release via 🦀 v1.76.0-nightly took 4s 
```
