### PR TITLE
Fix transaction version v0.7.4

### DIFF
--- a/runtimes/polimec/src/lib.rs
+++ b/runtimes/polimec/src/lib.rs
@@ -208,7 +208,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 0_007_004,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 2,
+	transaction_version: 3,
 	state_version: 1,
 };
 


### PR DESCRIPTION
Try-runtime output:
```
❯ try-runtime --runtime ./target/release/wbuild/polimec-runtime/polimec_runtime.compact.compressed.wasm on-runtime-upgrade live --uri wss://rpc.polimec.org:443
[2024-06-24T15:12:08Z INFO  remote-ext] replacing wss:// in uri with https://: "https://rpc.polimec.org:443" (ws is currently unstable for fetching remote storage, for more see https://github.com/paritytech/jsonrpsee/issues/1086)
[2024-06-24T15:12:09Z INFO  remote-ext] since no at is provided, setting it to latest finalized head, 0x3030b10ffda583e4429d864d6f05e000bb58bbb5959c8c828eeb98056377d1fb
[2024-06-24T15:12:09Z INFO  remote-ext] since no prefix is filtered, the data for all pallets will be downloaded
[2024-06-24T15:12:09Z INFO  remote-ext] scraping key-pairs from remote at block height 0x3030b10ffda583e4429d864d6f05e000bb58bbb5959c8c828eeb98056377d1fb
✅ Found 11310 keys (0.47s)
[00:00:01] ✅ Downloaded key values 6,115.5298/s [============================================================================================================================================] 11310/11310 (0s)
✅ Inserted keys into DB (0.04s)
[2024-06-24T15:12:11Z INFO  remote-ext] adding data for hashed prefix: , took 2.44s
[2024-06-24T15:12:11Z INFO  remote-ext] adding data for hashed key: 3a636f6465
[2024-06-24T15:12:11Z INFO  remote-ext] adding data for hashed key: 26aa394eea5630e07c48ae0c9558cef7f9cce9c888469bb1a0dceaa129672ef8
[2024-06-24T15:12:11Z INFO  remote-ext] adding data for hashed key: 26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac
[2024-06-24T15:12:12Z INFO  remote-ext] 👩‍👦 no child roots found to scrape
[2024-06-24T15:12:12Z INFO  remote-ext] initialized state externalities with storage root 0xbc2bbdc53a9b1fa7ae764f52518771c634215864c89d53f53aaca6b922a76114 and state_version V1
[2024-06-24T15:12:12Z INFO  try-runtime::cli] Original runtime [Name: RuntimeString::Owned("polimec-mainnet")] [Version: 7003] [Code hash: 0xb87c...963a]
[2024-06-24T15:12:12Z INFO  try-runtime::cli] New runtime      [Name: RuntimeString::Owned("polimec-mainnet")] [Version: 7004] [Code hash: 0xfa59...1fae]
[2024-06-24T15:12:12Z INFO  try-runtime::cli] 🚀 Speed up your workflow by using snapshots instead of live state. See `try-runtime create-snapshot --help`.
[2024-06-24T15:12:12Z INFO  try_runtime_core::misc] ------------------------------------------------------------------
    
    
[2024-06-24T15:12:12Z INFO  try_runtime_core::misc] 🔬 Running TryRuntime_on_runtime_upgrade with checks: PreAndPost
    
    
[2024-06-24T15:12:12Z INFO  try_runtime_core::misc] ------------------------------------------------------------------
    
    
[2024-06-24T15:12:12Z INFO  runtime::executive] ✅ Entire runtime state decodes without error. 664495 bytes total.
[2024-06-24T15:12:12Z INFO  try_runtime_core::misc] ------------------------------------------------------------------------------------------------------
    
    
[2024-06-24T15:12:12Z INFO  try_runtime_core::misc] 🔬 TryRuntime_on_runtime_upgrade succeeded! Running it again without checks for weight measurements.
    
    
[2024-06-24T15:12:12Z INFO  try_runtime_core::misc] ------------------------------------------------------------------------------------------------------
    
    
[2024-06-24T15:12:12Z INFO  try_runtime_core::misc] ---------------------------------------------------------------------------------
    
    
[2024-06-24T15:12:12Z INFO  try_runtime_core::misc] 🔬 Running TryRuntime_on_runtime_upgrade again to check idempotency: PreAndPost
    
    
[2024-06-24T15:12:12Z INFO  try_runtime_core::misc] ---------------------------------------------------------------------------------
    
    
[2024-06-24T15:12:12Z INFO  runtime::executive] ✅ Entire runtime state decodes without error. 664495 bytes total.
[2024-06-24T15:12:12Z INFO  try-runtime::cli] PoV size (zstd-compressed compact proof): 7.9 KB. For parachains, it's your responsibility to verify that a PoV of this size fits within any relaychain constraints.
[2024-06-24T15:12:12Z INFO  try-runtime::cli] Consumed ref_time: 0.000925s (0.19% of max 0.5s)
[2024-06-24T15:12:12Z INFO  try-runtime::cli] ✅ No weight safety issues detected. Please note this does not guarantee a successful runtime upgrade. Always test your runtime upgrade with recent state, and ensure that the weight usage of your migrations will not drastically differ between testing and actual on-chain execution.
```

Srtool output:
```
✨ Your Substrate WASM Runtime is ready! ✨
✨ WASM  : runtimes/polimec/target/srtool/production/wbuild/polimec-runtime/polimec_runtime.compact.wasm
✨ Z_WASM: runtimes/polimec/target/srtool/production/wbuild/polimec-runtime/polimec_runtime.compact.compressed.wasm
Summary generated with srtool v0.15.0 using the docker image paritytech/srtool:1.77.0:
 Package     : polimec-runtime v0.7.0
 GIT commit  : 037393c92b3df8fd1eff2f91e21065ce68f5bc03
 GIT tag     : v0.7.3
 GIT branch  : 06-24-fix_transaction_version_v0.7.4
 Rustc       : rustc 1.77.0 (aedd173a2 2024-03-17)
 Time        : 2024-06-24T15:18:33Z

== Compact
 Version          : polimec-mainnet-7004 (polimec-mainnet-0.tx3.au1)
 Metadata         : V14
 Size             : 5.06 MB (5303976 bytes)
 setCode          : 0x83a0a1d6ab1708b6e53ea69ed725a2d4a75160eecd6329e0395cf613b9559e65
 authorizeUpgrade : 0x36de90c974f4b157d9f934d8ec4da5c70521e290aac01dc5342e217a55d359eb
 IPFS             : QmbfNVT5RgCu67HDoddMXHWbUxFwfH5a9FUxuCWfiJhZCR
 BLAKE2_256       : 0x77ba88c4e6e26dd730798ba4b51ee9a42fbf4e31bbfd6164dbe441d32e29275f
 Wasm             : runtimes/polimec/target/srtool/production/wbuild/polimec-runtime/polimec_runtime.compact.wasm

== Compressed
 Version          : polimec-mainnet-7004 (polimec-mainnet-0.tx3.au1)
 Metadata         : V14
 Size             : 1.26 MB (1318332 bytes)
 Compression      : 75.15%
 setCode          : 0x1422ac7bc4bdd7fbae7087696934258fe5dce036015d0d9efd022ea4af2884f5
 authorizeUpgrade : 0x1782f2f1fdf4d4cea50e24b70706c0fcfe3752f0771139d33ed99f303d7ba0b0
 IPFS             : Qmezsvoz5tH1CxxKp7wQmSVGMcbvvaEZLf89TmGnpKtBtp
 BLAKE2_256       : 0xb792eb0d57026b8ae9170a7ef474c92efd30aafc9a443b37a79a85b340d782cb
 Wasm             : runtimes/polimec/target/srtool/production/wbuild/polimec-runtime/polimec_runtime.compact.compressed.wasm
```
Subwasm output:
```
[≠] pallet 0: System -> 1 change(s)
  - constants changes:
    [≠] Version: [ 60, 112, 111, 108, 105, 109, 101, 99, 45, 109, 97, 105, 110, 110, 101, 116, 60, 112, 111, 108, 105, 109, 101, 99, 45, 109, 97, 105, 110, 110, 101, 116, ... ]
        [Value([Changed(36, U8Change(91, 92)), Changed(201, U8Change(2, 3))])]

[≠] pallet 80: Funding -> 13 change(s)
  - calls changes:
    [≠] 29: root_do_start_auction_closing ( project_id: ProjectId, )  )
        [Name(StringChange("root_do_start_auction_closing", "root_do_auction_opening"))]
    [≠] 30: root_do_community_funding ( project_id: ProjectId, )  )
        [Name(StringChange("root_do_community_funding", "root_do_start_auction_closing"))]
    [≠] 31: root_do_remainder_funding ( project_id: ProjectId, )  )
        [Name(StringChange("root_do_remainder_funding", "root_do_end_auction_closing"))]
    [≠] 32: root_do_end_funding ( project_id: ProjectId, )  )
        [Name(StringChange("root_do_end_funding", "root_do_community_funding"))]
    [≠] 33: root_do_project_decision ( project_id: ProjectId, decision: FundingOutcomeDecision, )  )
        [Name(StringChange("root_do_project_decision", "root_do_remainder_funding")), Signature(SignatureChange { args: [Removed(1, ArgDesc { name: "decision", ty: "FundingOutcomeDecision" })] })]
    [≠] 34: root_do_start_settlement ( project_id: ProjectId, )  )
        [Name(StringChange("root_do_start_settlement", "root_do_end_funding"))]
    [+] CallDesc { index: 36, name: "root_do_project_decision", signature: SignatureDesc { args: [ArgDesc { name: "project_id", ty: "ProjectId" }, ArgDesc { name: "decision", ty: "FundingOutcomeDecision" }] } }
    [+] CallDesc { index: 37, name: "root_do_start_settlement", signature: SignatureDesc { args: [ArgDesc { name: "project_id", ty: "ProjectId" }] } }
    [-] "root_do_auction_opening"

  - errors changes:
    [≠] 47: ParticipationsNotSettled
        [Name(StringChange("ParticipationsNotSettled", "SettlementNotStarted"))]
    [+] ErrorDesc { index: 48, name: "WrongSettlementOutcome" }
    [+] ErrorDesc { index: 49, name: "ParticipationsNotSettled" }

  - constants changes:
    [-] "PolimecReceiverInfo"

SUMMARY:
- Compatible.......................: false
- Require transaction_version bump.: true
```
