### PR TITLE
Make issuer decide migration type

### DIFF
--- a/pallets/funding/src/functions/1_application.rs
+++ b/pallets/funding/src/functions/1_application.rs
@@ -46,12 +46,7 @@ impl<T: Config> Pallet<T> {
 			},
 			usd_bid_on_oversubscription: None,
 			funding_end_block: None,
-			parachain_id: None,
-			migration_readiness_check: None,
-			hrmp_channel_status: HRMPChannelStatus {
-				project_to_polimec: ChannelStatus::Closed,
-				polimec_to_project: ChannelStatus::Closed,
-			},
+			migration_type: MigrationType::Offchain,
 		};
 
 		let bucket: BucketOf<T> = Self::create_bucket_from_metadata(&project_metadata)?;

--- a/pallets/funding/src/functions/7_ct_migration.rs
+++ b/pallets/funding/src/functions/7_ct_migration.rs
@@ -3,7 +3,7 @@ use xcm::v3::MaxPalletNameLen;
 
 impl<T: Config> Pallet<T> {
 	#[transactional]
-	pub fn do_set_para_id_for_project(
+	pub fn do_configure_receiver_pallet_migration(
 		caller: &AccountIdOf<T>,
 		project_id: ProjectId,
 		para_id: ParaId,
@@ -13,9 +13,18 @@ impl<T: Config> Pallet<T> {
 
 		// * Validity checks *
 		ensure!(&(project_details.issuer_account) == caller, Error::<T>::NotIssuer);
+		ensure!(project_details.status == ProjectStatus::FundingSuccessful, Error::<T>::IncorrectRound);
 
 		// * Update storage *
-		project_details.parachain_id = Some(para_id);
+		let parachain_receiver_pallet_info = ParachainReceiverPalletInfo {
+			parachain_id: para_id,
+			hrmp_channel_status: HRMPChannelStatus {
+				project_to_polimec: ChannelStatus::Closed,
+				polimec_to_project: ChannelStatus::Closed,
+			},
+			migration_readiness_check: None,
+		};
+		project_details.migration_type = MigrationType::ParachainReceiverPallet(parachain_receiver_pallet_info);
 		ProjectsDetails::<T>::insert(project_id, project_details);
 
 		// * Emit events *
@@ -51,7 +60,10 @@ impl<T: Config> Pallet<T> {
 
 				let (project_id, mut project_details) = ProjectsDetails::<T>::iter()
 					.find(|(_id, details)| {
-						details.parachain_id == Some(ParaId::from(sender)) && details.status == FundingSuccessful
+						matches!(
+							&details.migration_type,
+							MigrationType::ParachainReceiverPallet(info) if
+								info.parachain_id == ParaId::from(sender) && details.status == FundingSuccessful)
 					})
 					.ok_or(XcmError::BadOrigin)?;
 
@@ -95,8 +107,14 @@ impl<T: Config> Pallet<T> {
 				match T::XcmRouter::deliver(ticket) {
 					Ok(_) => {
 						log::trace!(target: "pallet_funding::hrmp", "HrmpNewChannelOpenRequest: acceptance successfully sent");
-						project_details.hrmp_channel_status.project_to_polimec = ChannelStatus::Open;
-						project_details.hrmp_channel_status.polimec_to_project = ChannelStatus::AwaitingAcceptance;
+						match project_details.migration_type {
+							MigrationType::ParachainReceiverPallet(ref mut info) => {
+								info.hrmp_channel_status.project_to_polimec = ChannelStatus::Open;
+								info.hrmp_channel_status.polimec_to_project = ChannelStatus::AwaitingAcceptance;
+							},
+							_ => return Err(XcmError::NoDeal),
+						}
+
 						ProjectsDetails::<T>::insert(project_id, project_details);
 
 						Pallet::<T>::deposit_event(Event::<T>::HrmpChannelAccepted {
@@ -126,11 +144,20 @@ impl<T: Config> Pallet<T> {
 				log::trace!(target: "pallet_funding::hrmp", "HrmpChannelAccepted received: {:?}", message);
 				let (project_id, mut project_details) = ProjectsDetails::<T>::iter()
 					.find(|(_id, details)| {
-						details.parachain_id == Some(ParaId::from(recipient)) && details.status == FundingSuccessful
+						matches!(
+							&details.migration_type,
+							MigrationType::ParachainReceiverPallet(info) if
+								info.parachain_id == ParaId::from(recipient) && details.status == FundingSuccessful)
 					})
 					.ok_or(XcmError::BadOrigin)?;
 
-				project_details.hrmp_channel_status.polimec_to_project = ChannelStatus::Open;
+				match project_details.migration_type {
+					MigrationType::ParachainReceiverPallet(ref mut info) => {
+						info.hrmp_channel_status.polimec_to_project = ChannelStatus::Open;
+					},
+					_ => return Err(XcmError::NoDeal),
+				}
+
 				ProjectsDetails::<T>::insert(project_id, project_details);
 				Pallet::<T>::deposit_event(Event::<T>::HrmpChannelEstablished {
 					project_id,
@@ -157,7 +184,10 @@ impl<T: Config> Pallet<T> {
 	pub fn do_start_migration_readiness_check(caller: &AccountIdOf<T>, project_id: ProjectId) -> DispatchResult {
 		// * Get variables *
 		let mut project_details = ProjectsDetails::<T>::get(project_id).ok_or(Error::<T>::ProjectDetailsNotFound)?;
-		let parachain_id: u32 = project_details.parachain_id.ok_or(Error::<T>::ImpossibleState)?.into();
+		let MigrationType::ParachainReceiverPallet(ref mut migration_info) = project_details.migration_type else {
+			return Err(Error::<T>::NotAllowed.into())
+		};
+		let parachain_id: u32 = migration_info.parachain_id.into();
 		let project_multilocation = ParentThen(X1(Parachain(parachain_id)));
 		let now = <frame_system::Pallet<T>>::block_number();
 
@@ -167,17 +197,17 @@ impl<T: Config> Pallet<T> {
 		// * Validity checks *
 		ensure!(project_details.status == ProjectStatus::FundingSuccessful, Error::<T>::IncorrectRound);
 		ensure!(
-			project_details.hrmp_channel_status ==
+			migration_info.hrmp_channel_status ==
 				HRMPChannelStatus {
 					project_to_polimec: ChannelStatus::Open,
 					polimec_to_project: ChannelStatus::Open
 				},
 			Error::<T>::ChannelNotOpen
 		);
-		if project_details.migration_readiness_check.is_none() {
+		if migration_info.migration_readiness_check.is_none() {
 			ensure!(caller.clone() == T::PalletId::get().into_account_truncating(), Error::<T>::NotAllowed);
 		} else if matches!(
-			project_details.migration_readiness_check,
+			migration_info.migration_readiness_check,
 			Some(MigrationReadinessCheck {
 				holding_check: (_, CheckOutcome::Failed),
 				pallet_check: (_, CheckOutcome::Failed),
@@ -203,7 +233,7 @@ impl<T: Config> Pallet<T> {
 			Here,
 		);
 
-		project_details.migration_readiness_check = Some(MigrationReadinessCheck {
+		migration_info.migration_readiness_check = Some(MigrationReadinessCheck {
 			holding_check: (query_id_holdings, CheckOutcome::AwaitingResponse),
 			pallet_check: (query_id_pallet, CheckOutcome::AwaitingResponse),
 		});
@@ -253,13 +283,13 @@ impl<T: Config> Pallet<T> {
 	) -> DispatchResult {
 		use xcm::v3::prelude::*;
 		// TODO: check if this is too low performance. Maybe we want a new map of query_id -> project_id
-		let (project_id, mut project_details, mut migration_check) = ProjectsDetails::<T>::iter()
+		let (project_id, mut migration_info, mut project_details) = ProjectsDetails::<T>::iter()
 			.find_map(|(project_id, details)| {
-				if let Some(check @ MigrationReadinessCheck { holding_check, pallet_check }) =
-					details.migration_readiness_check
-				{
-					if holding_check.0 == query_id || pallet_check.0 == query_id {
-						return Some((project_id, details, check));
+				if let MigrationType::ParachainReceiverPallet(ref info) = details.migration_type {
+					if let Some(check) = info.migration_readiness_check {
+						if check.holding_check.0 == query_id || check.pallet_check.0 == query_id {
+							return Some((project_id, info.clone(), details));
+						}
 					}
 				}
 				None
@@ -271,16 +301,18 @@ impl<T: Config> Pallet<T> {
 		} else {
 			return Err(Error::<T>::WrongParaId.into());
 		};
+		ensure!(migration_info.parachain_id == para_id, Error::<T>::WrongParaId);
 
 		let project_metadata = ProjectsMetadata::<T>::get(project_id).ok_or(Error::<T>::ProjectMetadataNotFound)?;
 		let contribution_tokens_sold =
 			project_metadata.total_allocation_size.saturating_sub(project_details.remaining_contribution_tokens);
-		ensure!(project_details.parachain_id == Some(para_id), Error::<T>::WrongParaId);
 
-		match (response.clone(), migration_check) {
+		match (response.clone(), &mut migration_info.migration_readiness_check) {
 			(
 				Response::Assets(assets),
-				MigrationReadinessCheck { holding_check: (_, CheckOutcome::AwaitingResponse), .. },
+				&mut Some(
+					ref mut check @ MigrationReadinessCheck { holding_check: (_, CheckOutcome::AwaitingResponse), .. },
+				),
 			) => {
 				let ct_sold_as_u128: u128 = contribution_tokens_sold.try_into().map_err(|_| Error::<T>::BadMath)?;
 				let assets: Vec<MultiAsset> = assets.into_inner();
@@ -290,7 +322,7 @@ impl<T: Config> Pallet<T> {
 						id: Concrete(MultiLocation { parents: 1, interior: X1(Parachain(pid)) }),
 						fun: Fungible(amount),
 					} if amount >= ct_sold_as_u128 && pid == u32::from(para_id) => {
-						migration_check.holding_check.1 = CheckOutcome::Passed(None);
+						check.holding_check.1 = CheckOutcome::Passed(None);
 						Self::deposit_event(Event::<T>::MigrationCheckResponseAccepted {
 							project_id,
 							query_id,
@@ -298,7 +330,7 @@ impl<T: Config> Pallet<T> {
 						});
 					},
 					_ => {
-						migration_check.holding_check.1 = CheckOutcome::Failed;
+						check.holding_check.1 = CheckOutcome::Failed;
 						Self::deposit_event(Event::<T>::MigrationCheckResponseRejected {
 							project_id,
 							query_id,
@@ -310,7 +342,7 @@ impl<T: Config> Pallet<T> {
 
 			(
 				Response::PalletsInfo(pallets_info),
-				MigrationReadinessCheck { pallet_check: (_, CheckOutcome::AwaitingResponse), .. },
+				Some(ref mut check @ MigrationReadinessCheck { pallet_check: (_, CheckOutcome::AwaitingResponse), .. }),
 			) => {
 				let expected_module_name: BoundedVec<u8, MaxPalletNameLen> =
 					BoundedVec::try_from("polimec_receiver".as_bytes().to_vec()).map_err(|_| Error::<T>::NotAllowed)?;
@@ -319,17 +351,17 @@ impl<T: Config> Pallet<T> {
 				};
 				let u8_index: u8 = (*index).try_into().map_err(|_| Error::<T>::NotAllowed)?;
 				if pallets_info.len() == 1 && module_name == &expected_module_name {
-					migration_check.pallet_check.1 = CheckOutcome::Passed(Some(u8_index));
+					check.pallet_check.1 = CheckOutcome::Passed(Some(u8_index));
 					Self::deposit_event(Event::<T>::MigrationCheckResponseAccepted { project_id, query_id, response });
 				} else {
-					migration_check.pallet_check.1 = CheckOutcome::Failed;
+					check.pallet_check.1 = CheckOutcome::Failed;
 					Self::deposit_event(Event::<T>::MigrationCheckResponseRejected { project_id, query_id, response });
 				}
 			},
 			_ => return Err(Error::<T>::NotAllowed.into()),
 		};
 
-		project_details.migration_readiness_check = Some(migration_check);
+		project_details.migration_type = MigrationType::ParachainReceiverPallet(migration_info);
 		ProjectsDetails::<T>::insert(project_id, project_details);
 		Ok(())
 	}
@@ -338,11 +370,15 @@ impl<T: Config> Pallet<T> {
 	/// This entails transferring the funds from the Polimec sovereign account to the participant account, and applying
 	/// a vesting schedule if necessary.
 	#[transactional]
-	pub fn do_migrate_one_participant(project_id: ProjectId, participant: AccountIdOf<T>) -> DispatchResult {
+	pub fn do_receiver_pallet_migrate_for(project_id: ProjectId, participant: AccountIdOf<T>) -> DispatchResult {
 		// * Get variables *
 		let project_details = ProjectsDetails::<T>::get(project_id).ok_or(Error::<T>::ProjectDetailsNotFound)?;
-		let migration_readiness_check = project_details.migration_readiness_check.ok_or(Error::<T>::ChannelNotReady)?;
-		let project_para_id = project_details.parachain_id.ok_or(Error::<T>::ImpossibleState)?;
+		let migration_info = match project_details.migration_type {
+			MigrationType::ParachainReceiverPallet(info) => info,
+			_ => return Err(Error::<T>::NotAllowed.into()),
+		};
+		let migration_readiness_check = migration_info.migration_readiness_check.ok_or(Error::<T>::ChannelNotReady)?;
+		let project_para_id = migration_info.parachain_id;
 		let now = <frame_system::Pallet<T>>::block_number();
 		ensure!(
 			Self::user_has_no_participations(project_id, participant.clone()),
@@ -388,9 +424,13 @@ impl<T: Config> Pallet<T> {
 		let (project_id, participant) =
 			ActiveMigrationQueue::<T>::take(query_id).ok_or(Error::<T>::NoActiveMigrationsFound)?;
 		let project_details = ProjectsDetails::<T>::get(project_id).ok_or(Error::<T>::ProjectDetailsNotFound)?;
+		let migration_info = match project_details.migration_type {
+			MigrationType::ParachainReceiverPallet(info) => info,
+			_ => return Err(Error::<T>::NotAllowed.into()),
+		};
 
 		ensure!(
-			matches!(location, MultiLocation { parents: 1, interior: X1(Parachain(para_id))} if Some(ParaId::from(para_id)) == project_details.parachain_id),
+			matches!(location, MultiLocation { parents: 1, interior: X1(Parachain(para_id))} if ParaId::from(para_id) == migration_info.parachain_id),
 			Error::<T>::WrongParaId
 		);
 

--- a/pallets/funding/src/instantiator/chain_interactions.rs
+++ b/pallets/funding/src/instantiator/chain_interactions.rs
@@ -314,12 +314,7 @@ impl<
 			},
 			usd_bid_on_oversubscription: None,
 			funding_end_block: None,
-			parachain_id: None,
-			migration_readiness_check: None,
-			hrmp_channel_status: HRMPChannelStatus {
-				project_to_polimec: crate::ChannelStatus::Closed,
-				polimec_to_project: crate::ChannelStatus::Closed,
-			},
+			migration_type: MigrationType::Offchain,
 		};
 		assert_eq!(metadata, expected_metadata);
 		assert_eq!(details, expected_details);

--- a/pallets/funding/src/lib.rs
+++ b/pallets/funding/src/lib.rs
@@ -1098,7 +1098,7 @@ pub mod pallet {
 
 		#[pallet::call_index(22)]
 		#[pallet::weight(Weight::from_parts(1000, 0))]
-		pub fn set_para_id_for_project(
+		pub fn configure_receiver_pallet_migration(
 			origin: OriginFor<T>,
 			jwt: UntrustedToken,
 			project_id: ProjectId,
@@ -1108,7 +1108,7 @@ pub mod pallet {
 				T::InvestorOrigin::ensure_origin(origin, &jwt, T::VerifierPublicKey::get())?;
 			ensure!(investor_type == InvestorType::Institutional, Error::<T>::WrongInvestorType);
 
-			Self::do_set_para_id_for_project(&account, project_id, para_id)
+			Self::do_configure_receiver_pallet_migration(&account, project_id, para_id)
 		}
 
 		#[pallet::call_index(23)]
@@ -1139,13 +1139,13 @@ pub mod pallet {
 
 		#[pallet::call_index(26)]
 		#[pallet::weight(Weight::from_parts(1000, 0))]
-		pub fn migrate_one_participant(
+		pub fn receiver_pallet_migrate_for(
 			origin: OriginFor<T>,
 			project_id: ProjectId,
 			participant: AccountIdOf<T>,
 		) -> DispatchResult {
 			let _caller = ensure_signed(origin)?;
-			Self::do_migrate_one_participant(project_id, participant)
+			Self::do_receiver_pallet_migrate_for(project_id, participant)
 		}
 
 		#[pallet::call_index(27)]

--- a/pallets/funding/src/storage_migrations.rs
+++ b/pallets/funding/src/storage_migrations.rs
@@ -4,278 +4,278 @@ use frame_support::traits::StorageVersion;
 /// The current storage version
 pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
 pub const LOG: &str = "runtime::funding::migration";
-
-pub mod v2 {
-	use crate::{AccountIdOf, BalanceOf, Config, ProjectsMetadata};
-	use frame_support::{
-		pallet_prelude::{Decode, Encode, MaxEncodedLen, RuntimeDebug, TypeInfo},
-		traits::{Get, OnRuntimeUpgrade},
-		BoundedVec,
-	};
-	use polimec_common::USD_DECIMALS;
-	use sp_arithmetic::{FixedPointNumber, Percent};
-	use sp_core::ConstU32;
-	use sp_std::marker::PhantomData;
-
-	#[derive(Clone, Copy, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
-	pub struct OldTicketSize<Balance: PartialOrd + Copy> {
-		pub usd_minimum_per_participation: Option<Balance>,
-		pub usd_maximum_per_did: Option<Balance>,
-	}
-
-	#[derive(Clone, Copy, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
-	pub struct OldBiddingTicketSizes<Price: FixedPointNumber, Balance: PartialOrd + Copy> {
-		pub professional: OldTicketSize<Balance>,
-		pub institutional: OldTicketSize<Balance>,
-		pub phantom: PhantomData<(Price, Balance)>,
-	}
-
-	#[derive(Clone, Copy, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
-	pub struct OldContributingTicketSizes<Price: FixedPointNumber, Balance: PartialOrd + Copy> {
-		pub retail: OldTicketSize<Balance>,
-		pub professional: OldTicketSize<Balance>,
-		pub institutional: OldTicketSize<Balance>,
-		pub phantom: PhantomData<(Price, Balance)>,
-	}
-
-	type OldProjectMetadataOf<T> = OldProjectMetadata<
-		BoundedVec<u8, crate::StringLimitOf<T>>,
-		BalanceOf<T>,
-		crate::PriceOf<T>,
-		AccountIdOf<T>,
-		polimec_common::credentials::Cid,
-	>;
-	#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
-	pub struct OldProjectMetadata<BoundedString, Balance: PartialOrd + Copy, Price: FixedPointNumber, AccountId, Cid> {
-		/// Token Metadata
-		pub token_information: crate::CurrencyMetadata<BoundedString>,
-		/// Mainnet Token Max Supply
-		pub mainnet_token_max_supply: Balance,
-		/// Total allocation of Contribution Tokens available for the Funding Round.
-		pub total_allocation_size: Balance,
-		/// Percentage of the total allocation of Contribution Tokens available for the Auction Round
-		pub auction_round_allocation_percentage: Percent,
-		/// The minimum price per token in USD, decimal-aware. See [`calculate_decimals_aware_price()`](crate::traits::ProvideAssetPrice::calculate_decimals_aware_price) for more information.
-		pub minimum_price: Price,
-		/// Maximum and minimum ticket sizes for auction round
-		pub bidding_ticket_sizes: OldBiddingTicketSizes<Price, Balance>,
-		/// Maximum and minimum ticket sizes for community/remainder rounds
-		pub contributing_ticket_sizes: OldContributingTicketSizes<Price, Balance>,
-		/// Participation currencies (e.g stablecoin, DOT, KSM)
-		pub participation_currencies:
-			BoundedVec<crate::AcceptedFundingAsset, ConstU32<{ crate::AcceptedFundingAsset::VARIANT_COUNT as u32 }>>,
-		pub funding_destination_account: AccountId,
-		/// Additional metadata
-		pub policy_ipfs_cid: Option<Cid>,
-	}
-
-	pub struct UncheckedMigrationToV2<T: Config>(PhantomData<T>);
-	impl<T: Config> OnRuntimeUpgrade for UncheckedMigrationToV2<T> {
-		fn on_runtime_upgrade() -> frame_support::weights::Weight {
-			let mut items = 0;
-			let mut translate = |_key, item: OldProjectMetadataOf<T>| -> Option<crate::ProjectMetadataOf<T>> {
-				items += 1;
-				let usd_unit = sp_arithmetic::traits::checked_pow(BalanceOf::<T>::from(10u64), USD_DECIMALS as usize)?;
-				Some(crate::ProjectMetadataOf::<T> {
-					token_information: item.token_information,
-					mainnet_token_max_supply: item.mainnet_token_max_supply,
-					total_allocation_size: item.total_allocation_size,
-					auction_round_allocation_percentage: item.auction_round_allocation_percentage,
-					minimum_price: item.minimum_price,
-					bidding_ticket_sizes: crate::BiddingTicketSizes {
-						professional: crate::TicketSize {
-							usd_minimum_per_participation: item
-								.bidding_ticket_sizes
-								.professional
-								.usd_minimum_per_participation
-								.unwrap_or_else(|| usd_unit),
-							usd_maximum_per_did: item.bidding_ticket_sizes.professional.usd_maximum_per_did,
-						},
-						institutional: crate::TicketSize {
-							usd_minimum_per_participation: item
-								.bidding_ticket_sizes
-								.institutional
-								.usd_minimum_per_participation
-								.unwrap_or_else(|| usd_unit),
-							usd_maximum_per_did: item.bidding_ticket_sizes.institutional.usd_maximum_per_did,
-						},
-						phantom: Default::default(),
-					},
-					contributing_ticket_sizes: crate::ContributingTicketSizes {
-						retail: crate::TicketSize {
-							usd_minimum_per_participation: item
-								.contributing_ticket_sizes
-								.retail
-								.usd_minimum_per_participation
-								.unwrap_or_else(|| usd_unit),
-							usd_maximum_per_did: item.contributing_ticket_sizes.retail.usd_maximum_per_did,
-						},
-						professional: crate::TicketSize {
-							usd_minimum_per_participation: item
-								.contributing_ticket_sizes
-								.professional
-								.usd_minimum_per_participation
-								.unwrap_or_else(|| usd_unit),
-							usd_maximum_per_did: item.contributing_ticket_sizes.professional.usd_maximum_per_did,
-						},
-						institutional: crate::TicketSize {
-							usd_minimum_per_participation: item
-								.contributing_ticket_sizes
-								.institutional
-								.usd_minimum_per_participation
-								.unwrap_or_else(|| usd_unit),
-							usd_maximum_per_did: item.contributing_ticket_sizes.institutional.usd_maximum_per_did,
-						},
-						phantom: Default::default(),
-					},
-					participation_currencies: item.participation_currencies,
-					funding_destination_account: item.funding_destination_account,
-					policy_ipfs_cid: item.policy_ipfs_cid,
-				})
-			};
-
-			ProjectsMetadata::<T>::translate(|key, object: OldProjectMetadataOf<T>| translate(key, object));
-
-			T::DbWeight::get().reads_writes(items, items)
-		}
-	}
-
-	pub type MigrationToV2<T> = frame_support::migrations::VersionedMigration<
-		1,
-		2,
-		UncheckedMigrationToV2<T>,
-		crate::Pallet<T>,
-		<T as frame_system::Config>::DbWeight,
-	>;
-}
-
-pub mod v3 {
-	use crate::{
-		AccountIdOf, BalanceOf, Config, EvaluationRoundInfoOf, HRMPChannelStatus, MigrationReadinessCheck,
-		PhaseTransitionPoints, PriceOf, ProjectDetailsOf, ProjectStatus,
-	};
-	use frame_support::{
-		pallet_prelude::Get,
-		traits::{tokens::Balance as BalanceT, OnRuntimeUpgrade},
-	};
-	use frame_system::pallet_prelude::BlockNumberFor;
-	use polimec_common::credentials::Did;
-	use polkadot_parachain_primitives::primitives::Id as ParaId;
-	use scale_info::TypeInfo;
-	use sp_arithmetic::FixedPointNumber;
-	use sp_core::{Decode, Encode, MaxEncodedLen, RuntimeDebug};
-	use sp_std::marker::PhantomData;
-
-	#[derive(Default, Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
-	pub enum OldProjectStatus {
-		#[default]
-		Application,
-		EvaluationRound,
-		AuctionInitializePeriod,
-		AuctionOpening,
-		AuctionClosing,
-		CommunityRound,
-		RemainderRound,
-		FundingFailed,
-		AwaitingProjectDecision,
-		FundingSuccessful,
-		ReadyToStartMigration,
-		MigrationCompleted,
-	}
-	#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
-	pub struct OldProjectDetails<
-		AccountId,
-		Did,
-		BlockNumber,
-		Price: FixedPointNumber,
-		Balance: BalanceT,
-		EvaluationRoundInfo,
-	> {
-		pub issuer_account: AccountId,
-		pub issuer_did: Did,
-		/// Whether the project is frozen, so no `metadata` changes are allowed.
-		pub is_frozen: bool,
-		/// The price in USD per token decided after the Auction Round
-		pub weighted_average_price: Option<Price>,
-		/// The current status of the project
-		pub status: OldProjectStatus,
-		/// When the different project phases start and end
-		pub phase_transition_points: PhaseTransitionPoints<BlockNumber>,
-		/// Fundraising target amount in USD (6 decimals)
-		pub fundraising_target_usd: Balance,
-		/// The amount of Contribution Tokens that have not yet been sold
-		pub remaining_contribution_tokens: Balance,
-		/// Funding reached amount in USD (6 decimals)
-		pub funding_amount_reached_usd: Balance,
-		/// Information about the total amount bonded, and the outcome in regards to reward/slash/nothing
-		pub evaluation_round_info: EvaluationRoundInfo,
-		/// When the Funding Round ends
-		pub funding_end_block: Option<BlockNumber>,
-		/// ParaId of project
-		pub parachain_id: Option<ParaId>,
-		/// Migration readiness check
-		pub migration_readiness_check: Option<MigrationReadinessCheck>,
-		/// HRMP Channel status
-		pub hrmp_channel_status: HRMPChannelStatus,
-	}
-	type OldProjectDetailsOf<T> =
-		OldProjectDetails<AccountIdOf<T>, Did, BlockNumberFor<T>, PriceOf<T>, BalanceOf<T>, EvaluationRoundInfoOf<T>>;
-
-	pub struct UncheckedMigrationToV3<T: Config>(PhantomData<T>);
-	impl<T: Config> OnRuntimeUpgrade for UncheckedMigrationToV3<T> {
-		fn on_runtime_upgrade() -> frame_support::weights::Weight {
-			let mut items = 0;
-			let mut translate = |_key, item: OldProjectDetailsOf<T>| -> Option<ProjectDetailsOf<T>> {
-				items += 1;
-				let new_status = match item.status {
-					OldProjectStatus::Application => ProjectStatus::Application,
-					OldProjectStatus::EvaluationRound => ProjectStatus::EvaluationRound,
-					OldProjectStatus::AuctionInitializePeriod => ProjectStatus::AuctionInitializePeriod,
-					OldProjectStatus::AuctionOpening => ProjectStatus::AuctionOpening,
-					OldProjectStatus::AuctionClosing => ProjectStatus::AuctionClosing,
-					OldProjectStatus::CommunityRound => ProjectStatus::CommunityRound,
-					OldProjectStatus::RemainderRound => ProjectStatus::RemainderRound,
-					OldProjectStatus::FundingFailed => ProjectStatus::FundingFailed,
-					OldProjectStatus::AwaitingProjectDecision => ProjectStatus::AwaitingProjectDecision,
-					OldProjectStatus::FundingSuccessful => ProjectStatus::FundingSuccessful,
-					OldProjectStatus::ReadyToStartMigration => ProjectStatus::ReadyToStartMigration,
-					OldProjectStatus::MigrationCompleted => ProjectStatus::MigrationCompleted,
-				};
-				Some(ProjectDetailsOf::<T> {
-					issuer_account: item.issuer_account,
-					issuer_did: item.issuer_did,
-					is_frozen: item.is_frozen,
-					weighted_average_price: item.weighted_average_price,
-					status: new_status,
-					phase_transition_points: item.phase_transition_points,
-					fundraising_target_usd: item.fundraising_target_usd,
-					remaining_contribution_tokens: item.remaining_contribution_tokens,
-					funding_amount_reached_usd: item.funding_amount_reached_usd,
-					evaluation_round_info: item.evaluation_round_info,
-					usd_bid_on_oversubscription: None,
-					funding_end_block: item.funding_end_block,
-					parachain_id: item.parachain_id,
-					migration_readiness_check: item.migration_readiness_check,
-					hrmp_channel_status: item.hrmp_channel_status,
-				})
-			};
-
-			crate::ProjectsDetails::<T>::translate(|key, object: OldProjectDetailsOf<T>| translate(key, object));
-
-			T::DbWeight::get().reads_writes(items, items)
-		}
-	}
-
-	pub type MigrationToV3<T> = frame_support::migrations::VersionedMigration<
-		2,
-		3,
-		UncheckedMigrationToV3<T>,
-		crate::Pallet<T>,
-		<T as frame_system::Config>::DbWeight,
-	>;
-}
+//
+// pub mod v2 {
+// 	use crate::{AccountIdOf, BalanceOf, Config, ProjectsMetadata};
+// 	use frame_support::{
+// 		pallet_prelude::{Decode, Encode, MaxEncodedLen, RuntimeDebug, TypeInfo},
+// 		traits::{Get, OnRuntimeUpgrade},
+// 		BoundedVec,
+// 	};
+// 	use polimec_common::USD_DECIMALS;
+// 	use sp_arithmetic::{FixedPointNumber, Percent};
+// 	use sp_core::ConstU32;
+// 	use sp_std::marker::PhantomData;
+//
+// 	#[derive(Clone, Copy, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+// 	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+// 	pub struct OldTicketSize<Balance: PartialOrd + Copy> {
+// 		pub usd_minimum_per_participation: Option<Balance>,
+// 		pub usd_maximum_per_did: Option<Balance>,
+// 	}
+//
+// 	#[derive(Clone, Copy, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+// 	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+// 	pub struct OldBiddingTicketSizes<Price: FixedPointNumber, Balance: PartialOrd + Copy> {
+// 		pub professional: OldTicketSize<Balance>,
+// 		pub institutional: OldTicketSize<Balance>,
+// 		pub phantom: PhantomData<(Price, Balance)>,
+// 	}
+//
+// 	#[derive(Clone, Copy, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+// 	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+// 	pub struct OldContributingTicketSizes<Price: FixedPointNumber, Balance: PartialOrd + Copy> {
+// 		pub retail: OldTicketSize<Balance>,
+// 		pub professional: OldTicketSize<Balance>,
+// 		pub institutional: OldTicketSize<Balance>,
+// 		pub phantom: PhantomData<(Price, Balance)>,
+// 	}
+//
+// 	type OldProjectMetadataOf<T> = OldProjectMetadata<
+// 		BoundedVec<u8, crate::StringLimitOf<T>>,
+// 		BalanceOf<T>,
+// 		crate::PriceOf<T>,
+// 		AccountIdOf<T>,
+// 		polimec_common::credentials::Cid,
+// 	>;
+// 	#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+// 	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+// 	pub struct OldProjectMetadata<BoundedString, Balance: PartialOrd + Copy, Price: FixedPointNumber, AccountId, Cid> {
+// 		/// Token Metadata
+// 		pub token_information: crate::CurrencyMetadata<BoundedString>,
+// 		/// Mainnet Token Max Supply
+// 		pub mainnet_token_max_supply: Balance,
+// 		/// Total allocation of Contribution Tokens available for the Funding Round.
+// 		pub total_allocation_size: Balance,
+// 		/// Percentage of the total allocation of Contribution Tokens available for the Auction Round
+// 		pub auction_round_allocation_percentage: Percent,
+// 		/// The minimum price per token in USD, decimal-aware. See [`calculate_decimals_aware_price()`](crate::traits::ProvideAssetPrice::calculate_decimals_aware_price) for more information.
+// 		pub minimum_price: Price,
+// 		/// Maximum and minimum ticket sizes for auction round
+// 		pub bidding_ticket_sizes: OldBiddingTicketSizes<Price, Balance>,
+// 		/// Maximum and minimum ticket sizes for community/remainder rounds
+// 		pub contributing_ticket_sizes: OldContributingTicketSizes<Price, Balance>,
+// 		/// Participation currencies (e.g stablecoin, DOT, KSM)
+// 		pub participation_currencies:
+// 			BoundedVec<crate::AcceptedFundingAsset, ConstU32<{ crate::AcceptedFundingAsset::VARIANT_COUNT as u32 }>>,
+// 		pub funding_destination_account: AccountId,
+// 		/// Additional metadata
+// 		pub policy_ipfs_cid: Option<Cid>,
+// 	}
+//
+// 	pub struct UncheckedMigrationToV2<T: Config>(PhantomData<T>);
+// 	impl<T: Config> OnRuntimeUpgrade for UncheckedMigrationToV2<T> {
+// 		fn on_runtime_upgrade() -> frame_support::weights::Weight {
+// 			let mut items = 0;
+// 			let mut translate = |_key, item: OldProjectMetadataOf<T>| -> Option<crate::ProjectMetadataOf<T>> {
+// 				items += 1;
+// 				let usd_unit = sp_arithmetic::traits::checked_pow(BalanceOf::<T>::from(10u64), USD_DECIMALS as usize)?;
+// 				Some(crate::ProjectMetadataOf::<T> {
+// 					token_information: item.token_information,
+// 					mainnet_token_max_supply: item.mainnet_token_max_supply,
+// 					total_allocation_size: item.total_allocation_size,
+// 					auction_round_allocation_percentage: item.auction_round_allocation_percentage,
+// 					minimum_price: item.minimum_price,
+// 					bidding_ticket_sizes: crate::BiddingTicketSizes {
+// 						professional: crate::TicketSize {
+// 							usd_minimum_per_participation: item
+// 								.bidding_ticket_sizes
+// 								.professional
+// 								.usd_minimum_per_participation
+// 								.unwrap_or_else(|| usd_unit),
+// 							usd_maximum_per_did: item.bidding_ticket_sizes.professional.usd_maximum_per_did,
+// 						},
+// 						institutional: crate::TicketSize {
+// 							usd_minimum_per_participation: item
+// 								.bidding_ticket_sizes
+// 								.institutional
+// 								.usd_minimum_per_participation
+// 								.unwrap_or_else(|| usd_unit),
+// 							usd_maximum_per_did: item.bidding_ticket_sizes.institutional.usd_maximum_per_did,
+// 						},
+// 						phantom: Default::default(),
+// 					},
+// 					contributing_ticket_sizes: crate::ContributingTicketSizes {
+// 						retail: crate::TicketSize {
+// 							usd_minimum_per_participation: item
+// 								.contributing_ticket_sizes
+// 								.retail
+// 								.usd_minimum_per_participation
+// 								.unwrap_or_else(|| usd_unit),
+// 							usd_maximum_per_did: item.contributing_ticket_sizes.retail.usd_maximum_per_did,
+// 						},
+// 						professional: crate::TicketSize {
+// 							usd_minimum_per_participation: item
+// 								.contributing_ticket_sizes
+// 								.professional
+// 								.usd_minimum_per_participation
+// 								.unwrap_or_else(|| usd_unit),
+// 							usd_maximum_per_did: item.contributing_ticket_sizes.professional.usd_maximum_per_did,
+// 						},
+// 						institutional: crate::TicketSize {
+// 							usd_minimum_per_participation: item
+// 								.contributing_ticket_sizes
+// 								.institutional
+// 								.usd_minimum_per_participation
+// 								.unwrap_or_else(|| usd_unit),
+// 							usd_maximum_per_did: item.contributing_ticket_sizes.institutional.usd_maximum_per_did,
+// 						},
+// 						phantom: Default::default(),
+// 					},
+// 					participation_currencies: item.participation_currencies,
+// 					funding_destination_account: item.funding_destination_account,
+// 					policy_ipfs_cid: item.policy_ipfs_cid,
+// 				})
+// 			};
+//
+// 			ProjectsMetadata::<T>::translate(|key, object: OldProjectMetadataOf<T>| translate(key, object));
+//
+// 			T::DbWeight::get().reads_writes(items, items)
+// 		}
+// 	}
+//
+// 	pub type MigrationToV2<T> = frame_support::migrations::VersionedMigration<
+// 		1,
+// 		2,
+// 		UncheckedMigrationToV2<T>,
+// 		crate::Pallet<T>,
+// 		<T as frame_system::Config>::DbWeight,
+// 	>;
+// }
+//
+// pub mod v3 {
+// 	use crate::{
+// 		AccountIdOf, BalanceOf, Config, EvaluationRoundInfoOf, HRMPChannelStatus, MigrationReadinessCheck,
+// 		PhaseTransitionPoints, PriceOf, ProjectDetailsOf, ProjectStatus,
+// 	};
+// 	use frame_support::{
+// 		pallet_prelude::Get,
+// 		traits::{tokens::Balance as BalanceT, OnRuntimeUpgrade},
+// 	};
+// 	use frame_system::pallet_prelude::BlockNumberFor;
+// 	use polimec_common::credentials::Did;
+// 	use polkadot_parachain_primitives::primitives::Id as ParaId;
+// 	use scale_info::TypeInfo;
+// 	use sp_arithmetic::FixedPointNumber;
+// 	use sp_core::{Decode, Encode, MaxEncodedLen, RuntimeDebug};
+// 	use sp_std::marker::PhantomData;
+//
+// 	#[derive(Default, Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+// 	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+// 	pub enum OldProjectStatus {
+// 		#[default]
+// 		Application,
+// 		EvaluationRound,
+// 		AuctionInitializePeriod,
+// 		AuctionOpening,
+// 		AuctionClosing,
+// 		CommunityRound,
+// 		RemainderRound,
+// 		FundingFailed,
+// 		AwaitingProjectDecision,
+// 		FundingSuccessful,
+// 		ReadyToStartMigration,
+// 		MigrationCompleted,
+// 	}
+// 	#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+// 	pub struct OldProjectDetails<
+// 		AccountId,
+// 		Did,
+// 		BlockNumber,
+// 		Price: FixedPointNumber,
+// 		Balance: BalanceT,
+// 		EvaluationRoundInfo,
+// 	> {
+// 		pub issuer_account: AccountId,
+// 		pub issuer_did: Did,
+// 		/// Whether the project is frozen, so no `metadata` changes are allowed.
+// 		pub is_frozen: bool,
+// 		/// The price in USD per token decided after the Auction Round
+// 		pub weighted_average_price: Option<Price>,
+// 		/// The current status of the project
+// 		pub status: OldProjectStatus,
+// 		/// When the different project phases start and end
+// 		pub phase_transition_points: PhaseTransitionPoints<BlockNumber>,
+// 		/// Fundraising target amount in USD (6 decimals)
+// 		pub fundraising_target_usd: Balance,
+// 		/// The amount of Contribution Tokens that have not yet been sold
+// 		pub remaining_contribution_tokens: Balance,
+// 		/// Funding reached amount in USD (6 decimals)
+// 		pub funding_amount_reached_usd: Balance,
+// 		/// Information about the total amount bonded, and the outcome in regards to reward/slash/nothing
+// 		pub evaluation_round_info: EvaluationRoundInfo,
+// 		/// When the Funding Round ends
+// 		pub funding_end_block: Option<BlockNumber>,
+// 		/// ParaId of project
+// 		pub parachain_id: Option<ParaId>,
+// 		/// Migration readiness check
+// 		pub migration_readiness_check: Option<MigrationReadinessCheck>,
+// 		/// HRMP Channel status
+// 		pub hrmp_channel_status: HRMPChannelStatus,
+// 	}
+// 	type OldProjectDetailsOf<T> =
+// 		OldProjectDetails<AccountIdOf<T>, Did, BlockNumberFor<T>, PriceOf<T>, BalanceOf<T>, EvaluationRoundInfoOf<T>>;
+//
+// 	pub struct UncheckedMigrationToV3<T: Config>(PhantomData<T>);
+// 	impl<T: Config> OnRuntimeUpgrade for UncheckedMigrationToV3<T> {
+// 		fn on_runtime_upgrade() -> frame_support::weights::Weight {
+// 			let mut items = 0;
+// 			let mut translate = |_key, item: OldProjectDetailsOf<T>| -> Option<ProjectDetailsOf<T>> {
+// 				items += 1;
+// 				let new_status = match item.status {
+// 					OldProjectStatus::Application => ProjectStatus::Application,
+// 					OldProjectStatus::EvaluationRound => ProjectStatus::EvaluationRound,
+// 					OldProjectStatus::AuctionInitializePeriod => ProjectStatus::AuctionInitializePeriod,
+// 					OldProjectStatus::AuctionOpening => ProjectStatus::AuctionOpening,
+// 					OldProjectStatus::AuctionClosing => ProjectStatus::AuctionClosing,
+// 					OldProjectStatus::CommunityRound => ProjectStatus::CommunityRound,
+// 					OldProjectStatus::RemainderRound => ProjectStatus::RemainderRound,
+// 					OldProjectStatus::FundingFailed => ProjectStatus::FundingFailed,
+// 					OldProjectStatus::AwaitingProjectDecision => ProjectStatus::AwaitingProjectDecision,
+// 					OldProjectStatus::FundingSuccessful => ProjectStatus::FundingSuccessful,
+// 					OldProjectStatus::ReadyToStartMigration => ProjectStatus::ReadyToStartMigration,
+// 					OldProjectStatus::MigrationCompleted => ProjectStatus::MigrationCompleted,
+// 				};
+// 				Some(ProjectDetailsOf::<T> {
+// 					issuer_account: item.issuer_account,
+// 					issuer_did: item.issuer_did,
+// 					is_frozen: item.is_frozen,
+// 					weighted_average_price: item.weighted_average_price,
+// 					status: new_status,
+// 					phase_transition_points: item.phase_transition_points,
+// 					fundraising_target_usd: item.fundraising_target_usd,
+// 					remaining_contribution_tokens: item.remaining_contribution_tokens,
+// 					funding_amount_reached_usd: item.funding_amount_reached_usd,
+// 					evaluation_round_info: item.evaluation_round_info,
+// 					usd_bid_on_oversubscription: None,
+// 					funding_end_block: item.funding_end_block,
+// 					parachain_id: item.parachain_id,
+// 					migration_readiness_check: item.migration_readiness_check,
+// 					hrmp_channel_status: item.hrmp_channel_status,
+// 				})
+// 			};
+//
+// 			crate::ProjectsDetails::<T>::translate(|key, object: OldProjectDetailsOf<T>| translate(key, object));
+//
+// 			T::DbWeight::get().reads_writes(items, items)
+// 		}
+// 	}
+//
+// 	pub type MigrationToV3<T> = frame_support::migrations::VersionedMigration<
+// 		2,
+// 		3,
+// 		UncheckedMigrationToV3<T>,
+// 		crate::Pallet<T>,
+// 		<T as frame_system::Config>::DbWeight,
+// 	>;
+// }

--- a/pallets/funding/src/tests/2_evaluation.rs
+++ b/pallets/funding/src/tests/2_evaluation.rs
@@ -329,12 +329,7 @@ mod start_evaluation_extrinsic {
 				},
 				usd_bid_on_oversubscription: None,
 				funding_end_block: None,
-				parachain_id: None,
-				migration_readiness_check: None,
-				hrmp_channel_status: HRMPChannelStatus {
-					project_to_polimec: ChannelStatus::Closed,
-					polimec_to_project: ChannelStatus::Closed,
-				},
+				migration_type: MigrationType::Offchain,
 			};
 			assert_ok!(inst.execute(|| PolimecFunding::start_evaluation(
 				RuntimeOrigin::signed(issuer),

--- a/pallets/funding/src/tests/8_ct_migration.rs
+++ b/pallets/funding/src/tests/8_ct_migration.rs
@@ -15,18 +15,29 @@ fn para_id_for_project_can_be_set_by_issuer() {
 
 	inst.advance_time(<TestRuntime as Config>::SuccessToSettlementTime::get() + 20u64).unwrap();
 	inst.execute(|| {
-		assert_ok!(crate::Pallet::<TestRuntime>::do_set_para_id_for_project(
+		assert_ok!(crate::Pallet::<TestRuntime>::do_configure_receiver_pallet_migration(
 			&ISSUER_1,
 			project_id,
-			ParaId::from(2006u32),
+			ParaId::from(2006u32).into(),
 		));
 	});
 	let project_details = inst.get_project_details(project_id);
-	assert_eq!(project_details.parachain_id, Some(ParaId::from(2006u32)));
+
+	assert_eq!(
+		project_details.migration_type,
+		MigrationType::ParachainReceiverPallet(ParachainReceiverPalletInfo {
+			parachain_id: ParaId::from(2006u32),
+			hrmp_channel_status: HRMPChannelStatus {
+				project_to_polimec: ChannelStatus::Closed,
+				polimec_to_project: ChannelStatus::Closed
+			},
+			migration_readiness_check: None,
+		})
+	);
 }
 
 #[test]
-fn para_id_for_project_cannot_be_set_by_anyone_but_issuer() {
+fn migration_config_cannot_be_set_by_anyone_but_issuer() {
 	let mut inst = MockInstantiator::new(Some(RefCell::new(new_test_ext())));
 	let project_id = inst.create_finished_project(
 		default_project_metadata(ISSUER_1),
@@ -40,18 +51,30 @@ fn para_id_for_project_cannot_be_set_by_anyone_but_issuer() {
 
 	inst.execute(|| {
 		assert_err!(
-			crate::Pallet::<TestRuntime>::do_set_para_id_for_project(&EVALUATOR_1, project_id, ParaId::from(2006u32),),
+			crate::Pallet::<TestRuntime>::do_configure_receiver_pallet_migration(
+				&EVALUATOR_1,
+				project_id,
+				ParaId::from(2006u32),
+			),
 			Error::<TestRuntime>::NotIssuer
 		);
 		assert_err!(
-			crate::Pallet::<TestRuntime>::do_set_para_id_for_project(&BIDDER_1, project_id, ParaId::from(2006u32),),
+			crate::Pallet::<TestRuntime>::do_configure_receiver_pallet_migration(
+				&BIDDER_1,
+				project_id,
+				ParaId::from(2006u32),
+			),
 			Error::<TestRuntime>::NotIssuer
 		);
 		assert_err!(
-			crate::Pallet::<TestRuntime>::do_set_para_id_for_project(&BUYER_1, project_id, ParaId::from(2006u32),),
+			crate::Pallet::<TestRuntime>::do_configure_receiver_pallet_migration(
+				&BUYER_1,
+				project_id,
+				ParaId::from(2006u32),
+			),
 			Error::<TestRuntime>::NotIssuer
 		);
 	});
 	let project_details = inst.get_project_details(project_id);
-	assert_eq!(project_details.parachain_id, None);
+	assert_eq!(project_details.migration_type, MigrationType::Offchain);
 }

--- a/pallets/funding/src/types.rs
+++ b/pallets/funding/src/types.rs
@@ -295,6 +295,22 @@ pub mod storage_types {
 	}
 
 	#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+	pub enum MigrationType {
+		Offchain,
+		ParachainReceiverPallet(ParachainReceiverPalletInfo),
+	}
+
+	#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+	pub struct ParachainReceiverPalletInfo {
+		/// ParaId of project
+		pub parachain_id: ParaId,
+		/// HRMP Channel status
+		pub hrmp_channel_status: HRMPChannelStatus,
+		/// Migration readiness check
+		pub migration_readiness_check: Option<MigrationReadinessCheck>,
+	}
+
+	#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
 	pub struct ProjectDetails<
 		AccountId,
 		Did,
@@ -325,12 +341,7 @@ pub mod storage_types {
 		pub usd_bid_on_oversubscription: Option<Balance>,
 		/// When the Funding Round ends
 		pub funding_end_block: Option<BlockNumber>,
-		/// ParaId of project
-		pub parachain_id: Option<ParaId>,
-		/// Migration readiness check
-		pub migration_readiness_check: Option<MigrationReadinessCheck>,
-		/// HRMP Channel status
-		pub hrmp_channel_status: HRMPChannelStatus,
+		pub migration_type: MigrationType,
 	}
 	/// Tells on_initialize what to do with the project
 	#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]

--- a/scripts/chopsticks/assethub-transfers/polkadot-polimec.yml
+++ b/scripts/chopsticks/assethub-transfers/polkadot-polimec.yml
@@ -1,15 +1,15 @@
 db: ./db.sqlite
 mock-signature-host: true
 endpoint: wss://rpc.polimec.org
-import-storage:
-  System:
-    Account:
-      # Politest Sudo
-      [
-        [
-          [
-            "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
-          ],
-          { providers: 1, data: { free: "10000000000000000" } },
-        ],
-      ]
+#import-storage:
+#  System:
+#    Account:
+#      # Politest Sudo
+#      [
+#        [
+#          [
+#            "0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42",
+#          ],
+#          { providers: 1, data: { free: "10000000000000000" } },
+#        ],
+#      ]


### PR DESCRIPTION
## What?
- Issuer can decide what migration type they want to do
- Make offchain migrations the default case

## Why?
- Our first projects will do offchain migrations, and we want to test our onchain ones more before we do.
- So for now we can leave out the call that changes a migration from offchain to receiver pallet (same extrinsic that used to set the para id, now renamed to `configure_receiver_pallet_migration`

## How?
- Abstract all the receiver pallet migration stuff to an enum variant, where the default variant is the offchain one.

## Testing?
- Normal migration tests

## Anything Else?
- Next step will be to allow issuers to mark the state and all the migrations as completed when the migration type is Offchain...
