### PR TITLE
🔖 Release 0.7.5

### DIFF
--- a/runtimes/polimec/src/lib.rs
+++ b/runtimes/polimec/src/lib.rs
@@ -205,7 +205,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("polimec-mainnet"),
 	impl_name: create_runtime_str!("polimec-mainnet"),
 	authoring_version: 1,
-	spec_version: 0_007_004,
+	spec_version: 0_007_005,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 3,
@@ -251,7 +251,13 @@ impl Contains<RuntimeCall> for BaseCallFilter {
 							pallet_funding::Call::root_do_remainder_funding { .. } |
 							pallet_funding::Call::root_do_end_funding { .. } |
 							pallet_funding::Call::root_do_project_decision { .. } |
-							pallet_funding::Call::root_do_start_settlement { .. }
+							pallet_funding::Call::root_do_start_settlement { .. } |
+							pallet_funding::Call::settle_successful_evaluation { .. } |
+							pallet_funding::Call::settle_failed_evaluation { .. } |
+							pallet_funding::Call::settle_successful_bid { .. } |
+							pallet_funding::Call::settle_failed_bid { .. } |
+							pallet_funding::Call::settle_successful_contribution { .. } |
+							pallet_funding::Call::settle_failed_contribution { .. }
 					)
 				},
 			_ => true,

--- a/runtimes/shared-configuration/src/funding.rs
+++ b/runtimes/shared-configuration/src/funding.rs
@@ -17,13 +17,11 @@
 use crate::{Balance, BlockNumber};
 use frame_support::{parameter_types, PalletId};
 use pallet_funding::types::AcceptedFundingAsset;
-use parachains_common::AssetIdForTrustBackedAssets;
+#[allow(unused)]
+use parachains_common::{AssetIdForTrustBackedAssets, HOURS};
 use polimec_common::USD_UNIT;
 use sp_arithmetic::{FixedU128, Percent};
 use sp_std::{collections::btree_map::BTreeMap, vec, vec::Vec};
-
-#[cfg(feature = "fast-mode")]
-use parachains_common::HOURS;
 
 #[cfg(feature = "instant-mode")]
 pub const EVALUATION_DURATION: BlockNumber = 3;
@@ -86,7 +84,7 @@ pub const SUCCESS_TO_SETTLEMENT_TIME: BlockNumber = 4;
 #[cfg(feature = "fast-mode")]
 pub const SUCCESS_TO_SETTLEMENT_TIME: BlockNumber = 5 * crate::MINUTES;
 #[cfg(not(any(feature = "fast-mode", feature = "instant-mode")))]
-pub const SUCCESS_TO_SETTLEMENT_TIME: BlockNumber = 4 * crate::DAYS;
+pub const SUCCESS_TO_SETTLEMENT_TIME: BlockNumber = 1 * HOURS;
 
 pub type ProjectIdentifier = u32;
 

--- a/runtimes/shared-configuration/src/funding.rs
+++ b/runtimes/shared-configuration/src/funding.rs
@@ -17,11 +17,13 @@
 use crate::{Balance, BlockNumber};
 use frame_support::{parameter_types, PalletId};
 use pallet_funding::types::AcceptedFundingAsset;
-#[allow(unused)]
-use parachains_common::{AssetIdForTrustBackedAssets, HOURS};
+use parachains_common::AssetIdForTrustBackedAssets;
 use polimec_common::USD_UNIT;
 use sp_arithmetic::{FixedU128, Percent};
 use sp_std::{collections::btree_map::BTreeMap, vec, vec::Vec};
+
+#[cfg(any(feature = "fast-mode", not(any(feature = "fast-mode", feature = "instant-mode"))))]
+use parachains_common::HOURS;
 
 #[cfg(feature = "instant-mode")]
 pub const EVALUATION_DURATION: BlockNumber = 3;


### PR DESCRIPTION
## What?
- Whitelist settlement calls
- Reduce `SuccessToSettlementTime` from 4 days to 1 hour

## Why?
- Apillon is close to funding end
- We don't need the long settlement time as of now, so better UX to make it short.

## Anything Else?
try-runtime check
```
❯ try-runtime --runtime ./target/release/wbuild/polimec-runtime/polimec_runtime.compact.compressed.wasm on-runtime-upgrade live --uri wss://rpc.polimec.org:443
[2024-07-01T07:52:40Z INFO  remote-ext] replacing wss:// in uri with https://: "https://rpc.polimec.org:443" (ws is currently unstable for fetching remote storage, for more see https://github.com/paritytech/jsonrpsee/issues/1086)
[2024-07-01T07:52:41Z INFO  remote-ext] since no at is provided, setting it to latest finalized head, 0x85720c8380e26e02746101835cecd8d7d62f64705d4b854f7bb9ff7bb8af753a
[2024-07-01T07:52:41Z INFO  remote-ext] since no prefix is filtered, the data for all pallets will be downloaded
[2024-07-01T07:52:41Z INFO  remote-ext] scraping key-pairs from remote at block height 0x85720c8380e26e02746101835cecd8d7d62f64705d4b854f7bb9ff7bb8af753a
✅ Found 12019 keys (0.28s)
[00:00:01] ✅ Downloaded key values 9,491.0273/s [===========================================] 12019/12019 (0s)
✅ Inserted keys into DB (0.03s)
[2024-07-01T07:52:42Z INFO  remote-ext] adding data for hashed prefix: , took 1.68s
[2024-07-01T07:52:42Z INFO  remote-ext] adding data for hashed key: 3a636f6465
[2024-07-01T07:52:42Z INFO  remote-ext] adding data for hashed key: 26aa394eea5630e07c48ae0c9558cef7f9cce9c888469bb1a0dceaa129672ef8
[2024-07-01T07:52:42Z INFO  remote-ext] adding data for hashed key: 26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac
[2024-07-01T07:52:42Z INFO  remote-ext] 👩‍👦 no child roots found to scrape
[2024-07-01T07:52:42Z INFO  remote-ext] initialized state externalities with storage root 0x284750853cdb7764bc82d04644b77ac36e506ef920fbb109b4af311610d716cf and state_version V1
[2024-07-01T07:52:42Z INFO  try-runtime::cli] Original runtime [Name: RuntimeString::Owned("polimec-mainnet")] [Version: 7004] [Code hash: 0xb792...82cb]
[2024-07-01T07:52:43Z INFO  try-runtime::cli] New runtime      [Name: RuntimeString::Owned("polimec-mainnet")] [Version: 7005] [Code hash: 0xd190...1eef]
[2024-07-01T07:52:43Z INFO  try-runtime::cli] 🚀 Speed up your workflow by using snapshots instead of live state. See `try-runtime create-snapshot --help`.
[2024-07-01T07:52:43Z INFO  try_runtime_core::common::misc_logging] ------------------------------------------------------------------


[2024-07-01T07:52:43Z INFO  try_runtime_core::common::misc_logging] 🔬 Running TryRuntime_on_runtime_upgrade with checks: PreAndPost


[2024-07-01T07:52:43Z INFO  try_runtime_core::common::misc_logging] ------------------------------------------------------------------


[2024-07-01T07:52:43Z INFO  runtime::executive] ✅ Entire runtime state decodes without error. 710565 bytes total.
[2024-07-01T07:52:43Z INFO  try_runtime_core::common::misc_logging] ------------------------------------------------------------------------------------------------------


[2024-07-01T07:52:43Z INFO  try_runtime_core::common::misc_logging] 🔬 TryRuntime_on_runtime_upgrade succeeded! Running it again without checks for weight measurements.


[2024-07-01T07:52:43Z INFO  try_runtime_core::common::misc_logging] ------------------------------------------------------------------------------------------------------


[2024-07-01T07:52:43Z INFO  try_runtime_core::common::misc_logging] ---------------------------------------------------------------------------------


[2024-07-01T07:52:43Z INFO  try_runtime_core::common::misc_logging] 🔬 Running TryRuntime_on_runtime_upgrade again to check idempotency: PreAndPost


[2024-07-01T07:52:43Z INFO  try_runtime_core::common::misc_logging] ---------------------------------------------------------------------------------


[2024-07-01T07:52:43Z INFO  runtime::executive] ✅ Entire runtime state decodes without error. 710565 bytes total.
[2024-07-01T07:52:43Z INFO  try-runtime::cli] PoV size (zstd-compressed compact proof): 7.8 KB. For parachains, it's your responsibility to verify that a PoV of this size fits within any relaychain constraints.
[2024-07-01T07:52:43Z INFO  try-runtime::cli] Consumed ref_time: 0.000925s (0.19% of max 0.5s)
[2024-07-01T07:52:43Z INFO  try-runtime::cli] ✅ No weight safety issues detected. Please note this does not guarantee a successful runtime upgrade. Always test your runtime upgrade with recent state, and ensure that the weight usage of your migrations will not drastically differ between testing and actual on-chain execution.
```

srtool build:
```
✨ Your Substrate WASM Runtime is ready! ✨
✨ WASM  : runtimes/polimec/target/srtool/production/wbuild/polimec-runtime/polimec_runtime.compact.wasm
✨ Z_WASM: runtimes/polimec/target/srtool/production/wbuild/polimec-runtime/polimec_runtime.compact.compressed.wasm
Summary generated with srtool v0.15.0 using the docker image paritytech/srtool:1.77.0:
 Package     : polimec-runtime v0.7.0
 GIT commit  :
 GIT tag     :
 GIT branch  :
 Rustc       : rustc 1.77.0 (aedd173a2 2024-03-17)
 Time        : 2024-07-01T07:47:51Z

== Compact
 Version          : polimec-mainnet-7005 (polimec-mainnet-0.tx3.au1)
 Metadata         : V14
 Size             : 5.06 MB (5309914 bytes)
 setCode          : 0x4e19806a0538dd155cf0edcff169144fda61375c122626e7f4f452f09b274f1a
 authorizeUpgrade : 0x6b648a6d7b7d893588e29efe4474366fcc53b3fe9142d75c739083d28c504068
 IPFS             : QmSLpRoYhif86JxfeHQGFw4jNXkcnz11TcAGQP296uL7Zs
 BLAKE2_256       : 0x475ead3983d691ed9c72718150be6db573d73a3e2006843a9c8079d495e714f2
 Wasm             : runtimes/polimec/target/srtool/production/wbuild/polimec-runtime/polimec_runtime.compact.wasm

== Compressed
 Version          : polimec-mainnet-7005 (polimec-mainnet-0.tx3.au1)
 Metadata         : V14
 Size             : 1.26 MB (1318513 bytes)
 Compression      : 75.17%
 setCode          : 0x0ab2b9fcd4590690425f0691e2475988d78c50ac198c91a3dbb591df4ec92c62
 authorizeUpgrade : 0xc13a8d359299caa86c263d97f556a650372f65a51433584907bcdf14afc50310
 IPFS             : QmYWgW5jU61HEKVvzMFSeHNNHSjBskEgzjb1Pv4pPyeuYY
 BLAKE2_256       : 0xc25383084c81d8f4fe34c387277b24a1bee2c588b14cfced2ec797f14f2b8877
 Wasm             : runtimes/polimec/target/srtool/production/wbuild/polimec-runtime/polimec_runtime.compact.compressed.wasm

```

subwasm info:
```
❯ subwasm info ./runtimes/polimec/target/srtool/production/wbuild/polimec-runtime/polimec_runtime.compact.compressed.wasm                  
🏋️  Runtime size:             1.257 MB (1,318,513 bytes)
🗜  Compressed:               Yes, 75.17%
✨ Reserved meta:            OK - [6D, 65, 74, 61]
🎁 Metadata version:         V14
🔥 Core version:             polimec-mainnet-7005 (polimec-mainnet-0.tx3.au1)
🗳️  system.setCode hash:      0x0ab2b9fcd4590690425f0691e2475988d78c50ac198c91a3dbb591df4ec92c62
🗳️  authorizeUpgrade hash:    0xc13a8d359299caa86c263d97f556a650372f65a51433584907bcdf14afc50310
🗳️  Blake2-256 hash:          0xc25383084c81d8f4fe34c387277b24a1bee2c588b14cfced2ec797f14f2b8877
📦 IPFS:                     https://www.ipfs.io/ipfs/QmYWgW5jU61HEKVvzMFSeHNNHSjBskEgzjb1Pv4pPyeuYY

```

subwasm diff
```
[≠] pallet 0: System -> 1 change(s)
  - constants changes:
    [≠] Version: [ 60, 112, 111, 108, 105, 109, 101, 99, 45, 109, 97, 105, 110, 110, 101, 116, 60, 112, 111, 108, 105, 109, 101, 99, 45, 109, 97, 105, 110, 110, 101, 116, ... ]
        [Value([Changed(36, U8Change(92, 93))])]

[≠] pallet 80: Funding -> 1 change(s)
  - constants changes:
    [≠] SuccessToSettlementTime: [128, 112, 0, 0]
        [Value([Changed(0, U8Change(128, 44)), Changed(1, U8Change(112, 1))])]

SUMMARY:
- Compatible.......................: true
- Require transaction_version bump.: false
```
