### PR TITLE
chore: change tokenSymbol in chain-spec

### DIFF
--- a/chain-specs/paseo/polimec-paseo.spec.plain.json
+++ b/chain-specs/paseo/polimec-paseo.spec.plain.json
@@ -8,7 +8,7 @@
   "properties": {
     "ss58Format": 41,
     "tokenDecimals": 10,
-    "tokenSymbol": "PLMC"
+    "tokenSymbol": "TPLMC"
   },
   "relay_chain": "paseo",
   "para_id": 3344,

--- a/chain-specs/paseo/polimec-paseo.spec.raw.json
+++ b/chain-specs/paseo/polimec-paseo.spec.raw.json
@@ -8,7 +8,7 @@
   "properties": {
     "ss58Format": 41,
     "tokenDecimals": 10,
-    "tokenSymbol": "PLMC"
+    "tokenSymbol": "TPLMC"
   },
   "relay_chain": "paseo",
   "para_id": 3344,


### PR DESCRIPTION
## What?

Change the `tokenSymbol` in the Paseo's chain-spec to avoid possible confusion. 