### PR TITLE
📄 Small comment about Y variable

### DIFF
--- a/pallets/funding/src/functions/misc.rs
+++ b/pallets/funding/src/functions/misc.rs
@@ -459,6 +459,8 @@ impl<T: Config> Pallet<T> {
 		let total_fee_allocation = total_issuer_fees * token_sold;
 
 		// Calculate the percentage of target funding based on available documentation.
+		// A.K.A variable "Y" in the documentation. We mean it to saturate to 1 even if the ratio is above 1 when funding raised
+		// is above the target.
 		let percentage_of_target_funding = Perquintill::from_rational(funding_amount_reached, fundraising_target);
 
 		// Calculate rewards.
@@ -515,7 +517,8 @@ impl<T: Config> Pallet<T> {
 		let total_fee_allocation = total_issuer_fees * token_sold;
 
 		// Calculate the percentage of target funding based on available documentation.
-		// A.K.A variable "Y" in the documentation.
+		// A.K.A variable "Y" in the documentation. We mean it to saturate to 1 even if the ratio is above 1 when funding raised
+		// is above the target.
 		let percentage_of_target_funding = Perquintill::from_rational(funding_amount_reached, fundraising_target);
 		let inverse_percentage_of_target_funding = Perquintill::from_percent(100) - percentage_of_target_funding;
 


### PR DESCRIPTION
## What?
- Add comment to Y variable calculation to avoid confusion.

## Why?
- There was confusion that the Y variable could become higher than 1 when the funding amount reached was higher than the target funding (USD). This is not possible because `Perquintill` saturates to 1, but if we don't add a comment it might appear unintented.

## How?
- 2 identical comments on the Y calculations in `generate_evaluator_rewards_info` and `generate_liquidity_pools_and_long_term_holder_rewards`
