### PR TITLE
🔧 Fix migration test

### DIFF
--- a/pallets/funding/src/functions/misc.rs
+++ b/pallets/funding/src/functions/misc.rs
@@ -579,8 +579,7 @@ impl<T: Config> Pallet<T> {
 	) -> Xcm<()> {
 		// TODO: adjust this as benchmarks for polimec-receiver are written
 		const MAX_WEIGHT: Weight = Weight::from_parts(10_000, 0);
-		const MAX_RESPONSE_WEIGHT: Weight = Weight::from_parts(700_000_000, 10_000);
-		// const MAX_WEIGHT: Weight = Weight::from_parts(100_003_000_000_000, 10_000_196_608);
+		const MAX_RESPONSE_WEIGHT: Weight = Weight::from_parts(1_000_000_000, 50_000);
 		let migrations_item = Migrations::from(migrations.into());
 
 		// First byte is the pallet index, second byte is the call index

--- a/pallets/polimec-receiver/src/lib.rs
+++ b/pallets/polimec-receiver/src/lib.rs
@@ -77,7 +77,7 @@ pub mod pallet {
 	{
 		/// A Migration executed sucessfully
 		MigrationExecuted { migration: Migration },
-		/// A Migration was found which wa already executed, and was skipped.
+		/// A Migration was found which was already executed, and was skipped.
 		DuplicatedMigrationSkipped { migration: Migration },
 	}
 


### PR DESCRIPTION
## What?
- Fix our pallet migration integration test

## Why?
- We added a real benchmarked weight to the `confirm_pallet_migrations` extrinsic, but forgot to reflect that change when setting the max weight for the `ReportTransactStatus` message appended at the end of a migration.

## How?
The xcm logs showed that the message was overweight:
```
 events::Polimec: RuntimeEvent::PolkadotXcm(Event::NotifyOverweight { query_id: 2, pallet_index: 80, call_index: 30, actual_weight: Weight { ref_time: 573050100, proof_size: 33831 }, max_budgeted_weight: Weight { ref_time: 700000000, proof_size: 10000 } })    
```

As you can see the actual weight was:
- `Weight { ref_time: 573050100, proof_size: 33831 }`

And the max weight we set was
- `Weight { ref_time: 700000000, proof_size: 10000 }`

Therefore we now increase the max weight to `1_000_000_000` and `50_000`

## Testing?
run `full_pallet_migration_test`
