### PR TITLE
🗑️ Remove unnecessary bid fields

### DIFF
--- a/pallets/funding/src/functions/2_evaluation.rs
+++ b/pallets/funding/src/functions/2_evaluation.rs
@@ -117,7 +117,6 @@ impl<T: Config> Pallet<T> {
 		project_id: ProjectId,
 		usd_amount: BalanceOf<T>,
 		did: Did,
-		investor_type: InvestorType,
 		whitelisted_policy: Cid,
 	) -> DispatchResultWithPostInfo {
 		// * Get variables *
@@ -142,15 +141,6 @@ impl<T: Config> Pallet<T> {
 		ensure!(total_evaluations_count < T::MaxEvaluationsPerProject::get(), Error::<T>::TooManyProjectParticipations);
 		ensure!(user_evaluations_count < T::MaxEvaluationsPerUser::get(), Error::<T>::TooManyUserParticipations);
 
-		// * Calculate new variables *
-		if investor_type == InvestorType::Retail {
-			RetailParticipations::<T>::mutate(&did, |project_participations| {
-				if project_participations.contains(&project_id).not() {
-					// We don't care if it fails, since it means the user already has access to the max multiplier
-					let _ = project_participations.try_push(project_id);
-				}
-			});
-		}
 		let plmc_bond = plmc_usd_price
 			.reciprocal()
 			.ok_or(Error::<T>::BadMath)?

--- a/pallets/funding/src/functions/3_auction.rs
+++ b/pallets/funding/src/functions/3_auction.rs
@@ -251,8 +251,6 @@ impl<T: Config> Pallet<T> {
 			status: BidStatus::YetUnknown,
 			original_ct_amount: ct_amount,
 			original_ct_usd_price: ct_usd_price,
-			final_ct_amount: ct_amount,
-			final_ct_usd_price: ct_usd_price,
 			funding_asset,
 			funding_asset_amount_locked,
 			multiplier,

--- a/pallets/funding/src/functions/4_contribution.rs
+++ b/pallets/funding/src/functions/4_contribution.rs
@@ -78,19 +78,11 @@ impl<T: Config> Pallet<T> {
 			InvestorType::Retail => project_metadata.contributing_ticket_sizes.retail,
 		};
 		let max_multiplier = match investor_type {
-			InvestorType::Retail => {
-				RetailParticipations::<T>::mutate(&did, |project_participations| {
-					if project_participations.contains(&project_id).not() {
-						// We don't care if it fails, since it means the user already has access to the max multiplier
-						let _ = project_participations.try_push(project_id);
-					}
-					retail_max_multiplier_for_participations(project_participations.len() as u8)
-				})
-			},
-
+			InvestorType::Retail => RETAIL_MAX_MULTIPLIER,
 			InvestorType::Professional => PROFESSIONAL_MAX_MULTIPLIER,
 			InvestorType::Institutional => INSTITUTIONAL_MAX_MULTIPLIER,
 		};
+
 		// * Validity checks *
 		ensure!(project_policy == whitelisted_policy, Error::<T>::PolicyMismatch);
 		ensure!(multiplier.into() <= max_multiplier && multiplier.into() > 0u8, Error::<T>::ForbiddenMultiplier);

--- a/pallets/funding/src/instantiator/chain_interactions.rs
+++ b/pallets/funding/src/instantiator/chain_interactions.rs
@@ -443,7 +443,6 @@ impl<
 					project_id,
 					usd_amount,
 					generate_did_from_account(account),
-					InvestorType::Professional,
 					project_policy.clone(),
 				)
 			})?;
@@ -816,7 +815,7 @@ impl<
 		for bid in bids {
 			let account = bid.bidder.clone();
 			assert_eq!(self.execute(|| { Bids::<T>::iter_prefix_values((&project_id, &account)).count() }), 0);
-			let amount: BalanceOf<T> = if is_successful { bid.final_ct_amount } else { 0u64.into() };
+			let amount: BalanceOf<T> = bid.final_ct_amount();
 			self.assert_migration(project_id, account, amount, bid.id, ParticipationType::Bid, is_successful);
 		}
 	}

--- a/pallets/funding/src/instantiator/types.rs
+++ b/pallets/funding/src/instantiator/types.rs
@@ -399,12 +399,6 @@ impl<T: Config> BidInfoFilter<T> {
 		if self.original_ct_usd_price.is_some() && self.original_ct_usd_price.unwrap() != bid.original_ct_usd_price {
 			return false;
 		}
-		if self.final_ct_amount.is_some() && self.final_ct_amount.unwrap() != bid.final_ct_amount {
-			return false;
-		}
-		if self.final_ct_usd_price.is_some() && self.final_ct_usd_price.unwrap() != bid.final_ct_usd_price {
-			return false;
-		}
 		if self.funding_asset.is_some() && self.funding_asset.unwrap() != bid.funding_asset {
 			return false;
 		}

--- a/pallets/funding/src/lib.rs
+++ b/pallets/funding/src/lib.rs
@@ -521,10 +521,6 @@ pub mod pallet {
 		BalanceOf<T>,
 		ValueQuery,
 	>;
-	#[pallet::storage]
-	// After 25 participations, the retail user has access to the max multiplier of 10x, so no need to keep tracking it
-	pub type RetailParticipations<T: Config> =
-		StorageMap<_, Blake2_128Concat, Did, BoundedVec<ProjectId, MaxParticipationsForMaxMultiplier>, ValueQuery>;
 
 	#[pallet::storage]
 	pub type UserMigrations<T: Config> = StorageNMap<
@@ -629,7 +625,8 @@ pub mod pallet {
 			project_id: ProjectId,
 			account: AccountIdOf<T>,
 			id: u32,
-			ct_amount: BalanceOf<T>,
+			final_ct_amount: BalanceOf<T>,
+			final_ct_price: PriceOf<T>,
 		},
 		ContributionSettled {
 			project_id: ProjectId,
@@ -869,10 +866,10 @@ pub mod pallet {
 			project_id: ProjectId,
 			#[pallet::compact] usd_amount: BalanceOf<T>,
 		) -> DispatchResultWithPostInfo {
-			let (account, did, investor_type, whitelisted_policy) =
+			let (account, did, _investor_type, whitelisted_policy) =
 				T::InvestorOrigin::ensure_origin(origin, &jwt, T::VerifierPublicKey::get())?;
 
-			Self::do_evaluate(&account, project_id, usd_amount, did, investor_type, whitelisted_policy)
+			Self::do_evaluate(&account, project_id, usd_amount, did, whitelisted_policy)
 		}
 
 		#[pallet::call_index(5)]

--- a/pallets/funding/src/runtime_api.rs
+++ b/pallets/funding/src/runtime_api.rs
@@ -70,7 +70,7 @@ impl<T: Config> Pallet<T> {
 
 	pub fn top_bids(project_id: ProjectId, amount: u32) -> Vec<BidInfoOf<T>> {
 		Bids::<T>::iter_prefix_values((project_id,))
-			.sorted_by(|a, b| b.final_ct_amount.cmp(&a.final_ct_amount))
+			.sorted_by(|a, b| b.final_ct_amount().cmp(&a.final_ct_amount()))
 			.take(amount as usize)
 			.collect_vec()
 	}


### PR DESCRIPTION
## What?
- Remove fields in `BidInfo` which were not needed
- Make retail multiplier limits a fixed range

## Why?
- Less storage bloat
- Simplified logic, less storage overhead to keep track of past participations

## Testing?
- In the next PR

