### PR TITLE
✌️ Fix project transition event

### DIFF
--- a/pallets/funding/src/functions/2_evaluation.rs
+++ b/pallets/funding/src/functions/2_evaluation.rs
@@ -37,7 +37,7 @@ impl<T: Config> Pallet<T> {
 			project_details,
 			ProjectStatus::Application,
 			ProjectStatus::EvaluationRound,
-			T::EvaluationDuration::get(),
+			Some(T::EvaluationDuration::get()),
 			false,
 		)
 	}
@@ -91,7 +91,7 @@ impl<T: Config> Pallet<T> {
 				project_details,
 				ProjectStatus::EvaluationRound,
 				ProjectStatus::AuctionInitializePeriod,
-				T::AuctionInitializePeriodDuration::get(),
+				Some(T::AuctionInitializePeriodDuration::get()),
 				false,
 			)
 		// Unsuccessful path
@@ -104,7 +104,7 @@ impl<T: Config> Pallet<T> {
 				project_details,
 				ProjectStatus::EvaluationRound,
 				ProjectStatus::FundingFailed,
-				One::one(),
+				Some(One::one()),
 				false,
 			)
 		}

--- a/pallets/funding/src/functions/3_auction.rs
+++ b/pallets/funding/src/functions/3_auction.rs
@@ -35,7 +35,7 @@ impl<T: Config> Pallet<T> {
 			project_details,
 			ProjectStatus::AuctionInitializePeriod,
 			ProjectStatus::AuctionRound,
-			T::AuctionOpeningDuration::get(),
+			Some(T::AuctionOpeningDuration::get()),
 			skip_round_end_check,
 		)
 	}
@@ -72,7 +72,7 @@ impl<T: Config> Pallet<T> {
 					updated_project_details,
 					ProjectStatus::AuctionRound,
 					ProjectStatus::CommunityRound(now.saturating_add(T::CommunityFundingDuration::get())),
-					T::CommunityFundingDuration::get() + T::RemainderFundingDuration::get(),
+					Some(T::CommunityFundingDuration::get() + T::RemainderFundingDuration::get()),
 					false,
 				)?;
 				Ok(PostDispatchInfo {

--- a/pallets/funding/src/functions/5_funding_end.rs
+++ b/pallets/funding/src/functions/5_funding_end.rs
@@ -73,10 +73,14 @@ impl<T: Config> Pallet<T> {
 			)
 		};
 
-		let round_end = now.saturating_add(duration).saturating_sub(One::one());
-		project_details.round_duration.update(Some(now), Some(round_end));
-		project_details.status = next_status;
-		ProjectsDetails::<T>::insert(project_id, project_details);
+		Self::transition_project(
+			project_id,
+			project_details.clone(),
+			project_details.status,
+			next_status,
+			Some(duration),
+			true,
+		)?;
 
 		Ok(PostDispatchInfo { actual_weight: Some(actual_weight), pays_fee: Pays::Yes })
 	}

--- a/pallets/funding/src/lib.rs
+++ b/pallets/funding/src/lib.rs
@@ -574,7 +574,7 @@ pub mod pallet {
 		/// Project transitioned to a new phase.
 		ProjectPhaseTransition {
 			project_id: ProjectId,
-			phase: ProjectPhases,
+			phase: ProjectStatus<BlockNumberFor<T>>,
 		},
 		/// A `bonder` bonded an `amount` of PLMC for `project_id`.
 		Evaluation {

--- a/pallets/funding/src/mock.rs
+++ b/pallets/funding/src/mock.rs
@@ -292,15 +292,16 @@ impl pallet_timestamp::Config for TestRuntime {
 pub const HOURS: BlockNumber = 300u64;
 
 // REMARK: In the production configuration we use DAYS instead of HOURS.
+// We need all durations to use different times to catch bugs in the tests.
 parameter_types! {
 	pub const EvaluationDuration: BlockNumber = 10u64;
-	pub const AuctionInitializePeriodDuration: BlockNumber = 10u64;
-	pub const AuctionOpeningDuration: BlockNumber = 10u64;
-	pub const AuctionClosingDuration: BlockNumber = 10u64;
-	pub const CommunityRoundDuration: BlockNumber = 10u64;
-	pub const RemainderFundingDuration: BlockNumber = 10u64;
-	pub const ManualAcceptanceDuration: BlockNumber = 10u64;
-	pub const SuccessToSettlementTime: BlockNumber = 10u64;
+	pub const AuctionInitializePeriodDuration: BlockNumber = 11u64;
+	pub const AuctionOpeningDuration: BlockNumber = 12u64;
+	pub const AuctionClosingDuration: BlockNumber = 13u64;
+	pub const CommunityRoundDuration: BlockNumber = 14u64;
+	pub const RemainderFundingDuration: BlockNumber = 15u64;
+	pub const ManualAcceptanceDuration: BlockNumber = 16u64;
+	pub const SuccessToSettlementTime: BlockNumber = 17u64;
 
 	pub const FundingPalletId: PalletId = PalletId(*b"py/cfund");
 	pub FeeBrackets: Vec<(Percent, Balance)> = vec![


### PR DESCRIPTION
## What?
- We now emit project transition events
- We do it in the transition project function
- We now use the transition project function for every transition (before was used only till community round)

## How?
- We now use the same project status enum in the event as in the project details
- Events are emitted in the transition project function only
- Transition function is now always used when changing the project state in project_details

## Testing?
- `project_state_transition_event`
