### PR TITLE
💥 Remove AuctionClosingDuration

### DIFF
--- a/pallets/funding/src/functions/2_evaluation.rs
+++ b/pallets/funding/src/functions/2_evaluation.rs
@@ -37,7 +37,7 @@ impl<T: Config> Pallet<T> {
 			project_details,
 			ProjectStatus::Application,
 			ProjectStatus::EvaluationRound,
-			Some(T::EvaluationDuration::get()),
+			Some(T::EvaluationRoundDuration::get()),
 			false,
 		)
 	}

--- a/pallets/funding/src/functions/3_auction.rs
+++ b/pallets/funding/src/functions/3_auction.rs
@@ -35,7 +35,7 @@ impl<T: Config> Pallet<T> {
 			project_details,
 			ProjectStatus::AuctionInitializePeriod,
 			ProjectStatus::AuctionRound,
-			Some(T::AuctionOpeningDuration::get()),
+			Some(T::AuctionRoundDuration::get()),
 			skip_round_end_check,
 		)
 	}
@@ -71,8 +71,8 @@ impl<T: Config> Pallet<T> {
 					project_id,
 					updated_project_details,
 					ProjectStatus::AuctionRound,
-					ProjectStatus::CommunityRound(now.saturating_add(T::CommunityFundingDuration::get())),
-					Some(T::CommunityFundingDuration::get() + T::RemainderFundingDuration::get()),
+					ProjectStatus::CommunityRound(now.saturating_add(T::CommunityRoundDuration::get())),
+					Some(T::CommunityRoundDuration::get() + T::RemainderRoundDuration::get()),
 					false,
 				)?;
 				Ok(PostDispatchInfo {

--- a/pallets/funding/src/lib.rs
+++ b/pallets/funding/src/lib.rs
@@ -244,13 +244,9 @@ pub mod pallet {
 		/// The length (expressed in number of blocks) of the Auction Round, Closing period.
 		type BlockNumberToBalance: Convert<BlockNumberFor<Self>, BalanceOf<Self>>;
 
-		/// The length (expressed in number of blocks) of the Auction Round, Closing period.
-		#[pallet::constant]
-		type AuctionClosingDuration: Get<BlockNumberFor<Self>>;
-
 		/// The length (expressed in number of blocks) of the Community Round.
 		#[pallet::constant]
-		type CommunityFundingDuration: Get<BlockNumberFor<Self>>;
+		type CommunityRoundDuration: Get<BlockNumberFor<Self>>;
 
 		/// The currency used for minting contribution tokens as fungible assets (i.e pallet-assets)
 		type ContributionTokenCurrency: fungibles::Create<AccountIdOf<Self>, AssetId = ProjectId, Balance = BalanceOf<Self>>
@@ -270,13 +266,13 @@ pub mod pallet {
 		/// Convert 24 hours as FixedU128, to the corresponding amount of blocks in the same type as frame_system
 		type DaysToBlocks: Convert<FixedU128, BlockNumberFor<Self>>;
 
-		/// The length (expressed in number of blocks) of the Auction Round, Opening period.
+		/// The length (expressed in number of blocks) of the Auction Round.
 		#[pallet::constant]
-		type AuctionOpeningDuration: Get<BlockNumberFor<Self>>;
+		type AuctionRoundDuration: Get<BlockNumberFor<Self>>;
 
 		/// The length (expressed in number of blocks) of the evaluation period.
 		#[pallet::constant]
-		type EvaluationDuration: Get<BlockNumberFor<Self>>;
+		type EvaluationRoundDuration: Get<BlockNumberFor<Self>>;
 
 		/// What percentage of the target funding amount is required to be reached in the evaluation, for it to continue to the funding round.
 		#[pallet::constant]
@@ -303,10 +299,6 @@ pub mod pallet {
 			<Self as frame_system::Config>::RuntimeOrigin,
 			Success = (AccountIdOf<Self>, Did, InvestorType, Cid),
 		>;
-
-		/// How long an issuer has to accept or reject the funding of a project if the funding is between two thresholds.
-		#[pallet::constant]
-		type ManualAcceptanceDuration: Get<BlockNumberFor<Self>>;
 
 		/// Max individual bids per project. Used to estimate worst case weight for price calculation
 		#[pallet::constant]
@@ -375,7 +367,7 @@ pub mod pallet {
 
 		/// The length (expressed in number of blocks) of the Remainder Round.
 		#[pallet::constant]
-		type RemainderFundingDuration: Get<BlockNumberFor<Self>>;
+		type RemainderRoundDuration: Get<BlockNumberFor<Self>>;
 
 		/// max_capacity config required for the channel from polimec to the project
 		#[pallet::constant]

--- a/pallets/funding/src/mock.rs
+++ b/pallets/funding/src/mock.rs
@@ -294,14 +294,12 @@ pub const HOURS: BlockNumber = 300u64;
 // REMARK: In the production configuration we use DAYS instead of HOURS.
 // We need all durations to use different times to catch bugs in the tests.
 parameter_types! {
-	pub const EvaluationDuration: BlockNumber = 10u64;
-	pub const AuctionInitializePeriodDuration: BlockNumber = 11u64;
-	pub const AuctionOpeningDuration: BlockNumber = 12u64;
-	pub const AuctionClosingDuration: BlockNumber = 13u64;
-	pub const CommunityRoundDuration: BlockNumber = 14u64;
-	pub const RemainderFundingDuration: BlockNumber = 15u64;
-	pub const ManualAcceptanceDuration: BlockNumber = 16u64;
-	pub const SuccessToSettlementTime: BlockNumber = 17u64;
+	pub const EvaluationRoundDuration: BlockNumber = 10u64;
+	pub const AuctionInitializePeriodDuration: BlockNumber = 12u64;
+	pub const AuctionRoundDuration: BlockNumber = 15u64;
+	pub const CommunityRoundDuration: BlockNumber = 18u64;
+	pub const RemainderRoundDuration: BlockNumber = 6u64;
+	pub const SuccessToSettlementTime: BlockNumber = 4u64;
 
 	pub const FundingPalletId: PalletId = PalletId(*b"py/cfund");
 	pub FeeBrackets: Vec<(Percent, Balance)> = vec![
@@ -399,25 +397,23 @@ impl Config for TestRuntime {
 	type AccountId32Conversion = DummyConverter;
 	type AllPalletsWithoutSystem =
 		(Balances, ContributionTokens, ForeignAssets, PolimecFunding, LinearRelease, RandomnessCollectiveFlip);
-	type AuctionClosingDuration = AuctionClosingDuration;
 	type AuctionInitializePeriodDuration = AuctionInitializePeriodDuration;
-	type AuctionOpeningDuration = AuctionOpeningDuration;
+	type AuctionRoundDuration = AuctionRoundDuration;
 	type Balance = Balance;
 	type BlockNumber = BlockNumber;
 	type BlockNumberToBalance = ConvertInto;
 	type BlockchainOperationTreasury = BlockchainOperationTreasuryAccount;
-	type CommunityFundingDuration = CommunityRoundDuration;
+	type CommunityRoundDuration = CommunityRoundDuration;
 	type ContributionTokenCurrency = ContributionTokens;
 	type ContributionTreasury = ContributionTreasury;
 	type DaysToBlocks = DaysToBlocks;
-	type EvaluationDuration = EvaluationDuration;
+	type EvaluationRoundDuration = EvaluationRoundDuration;
 	type EvaluationSuccessThreshold = EarlyEvaluationThreshold;
 	type EvaluatorSlash = EvaluatorSlash;
 	type FeeBrackets = FeeBrackets;
 	type FundingCurrency = ForeignAssets;
 	type FundingSuccessThreshold = FundingSuccessThreshold;
 	type InvestorOrigin = EnsureInvestor<TestRuntime>;
-	type ManualAcceptanceDuration = ManualAcceptanceDuration;
 	type MaxBidsPerProject = ConstU32<512>;
 	type MaxBidsPerUser = ConstU32<25>;
 	type MaxCapacityThresholds = MaxCapacityThresholds;
@@ -432,7 +428,7 @@ impl Config for TestRuntime {
 	type Price = FixedU128;
 	type PriceProvider = ConstPriceProvider;
 	type Randomness = RandomnessCollectiveFlip;
-	type RemainderFundingDuration = RemainderFundingDuration;
+	type RemainderRoundDuration = RemainderRoundDuration;
 	type RequiredMaxCapacity = RequiredMaxCapacity;
 	type RequiredMaxMessageSize = RequiredMaxMessageSize;
 	type RuntimeCall = RuntimeCall;

--- a/pallets/funding/src/tests/2_evaluation.rs
+++ b/pallets/funding/src/tests/2_evaluation.rs
@@ -288,7 +288,10 @@ mod start_evaluation_extrinsic {
 				is_frozen: true,
 				weighted_average_price: None,
 				status: ProjectStatus::EvaluationRound,
-				round_duration: BlockNumberPair::new(Some(1), Some(<TestRuntime as Config>::EvaluationDuration::get())),
+				round_duration: BlockNumberPair::new(
+					Some(1),
+					Some(<TestRuntime as Config>::EvaluationRoundDuration::get()),
+				),
 				random_end_block: None,
 				fundraising_target_usd: project_metadata
 					.minimum_price

--- a/pallets/funding/src/tests/misc.rs
+++ b/pallets/funding/src/tests/misc.rs
@@ -397,9 +397,9 @@ fn project_state_transition_event() {
 		ProjectStatus::AuctionInitializePeriod,
 		ProjectStatus::AuctionRound,
 		ProjectStatus::CommunityRound(
-			EvaluationDuration::get() +
+			EvaluationRoundDuration::get() +
 				AuctionInitializePeriodDuration::get() +
-				AuctionOpeningDuration::get() +
+				AuctionRoundDuration::get() +
 				CommunityRoundDuration::get() +
 				1u64,
 		),

--- a/runtimes/polimec/src/lib.rs
+++ b/runtimes/polimec/src/lib.rs
@@ -1023,25 +1023,23 @@ impl pallet_funding::Config for Runtime {
 	#[cfg(any(test, feature = "runtime-benchmarks", feature = "std"))]
 	type AllPalletsWithoutSystem =
 		(Balances, ContributionTokens, ForeignAssets, Oracle, Funding, LinearRelease, Random);
-	type AuctionClosingDuration = AuctionClosingDuration;
 	type AuctionInitializePeriodDuration = AuctionInitializePeriodDuration;
-	type AuctionOpeningDuration = AuctionOpeningDuration;
+	type AuctionRoundDuration = AuctionRoundDuration;
 	type Balance = Balance;
 	type BlockNumber = BlockNumber;
 	type BlockNumberToBalance = ConvertInto;
 	type BlockchainOperationTreasury = BlockchainOperationTreasury;
-	type CommunityFundingDuration = CommunityFundingDuration;
+	type CommunityRoundDuration = CommunityRoundDuration;
 	type ContributionTokenCurrency = ContributionTokens;
 	type ContributionTreasury = ContributionTreasuryAccount;
 	type DaysToBlocks = DaysToBlocks;
-	type EvaluationDuration = EvaluationDuration;
+	type EvaluationRoundDuration = EvaluationRoundDuration;
 	type EvaluationSuccessThreshold = EarlyEvaluationThreshold;
 	type EvaluatorSlash = EvaluatorSlash;
 	type FeeBrackets = FeeBrackets;
 	type FundingCurrency = ForeignAssets;
 	type FundingSuccessThreshold = FundingSuccessThreshold;
 	type InvestorOrigin = EnsureInvestor<Runtime>;
-	type ManualAcceptanceDuration = ManualAcceptanceDuration;
 	type MaxBidsPerProject = ConstU32<512>;
 	type MaxBidsPerUser = ConstU32<16>;
 	type MaxCapacityThresholds = MaxCapacityThresholds;
@@ -1056,7 +1054,7 @@ impl pallet_funding::Config for Runtime {
 	type Price = Price;
 	type PriceProvider = OraclePriceProvider<AssetId, Price, Oracle>;
 	type Randomness = Random;
-	type RemainderFundingDuration = RemainderFundingDuration;
+	type RemainderRoundDuration = RemainderRoundDuration;
 	type RequiredMaxCapacity = RequiredMaxCapacity;
 	type RequiredMaxMessageSize = RequiredMaxMessageSize;
 	type RuntimeCall = RuntimeCall;

--- a/runtimes/shared-configuration/src/funding.rs
+++ b/runtimes/shared-configuration/src/funding.rs
@@ -27,11 +27,11 @@ use sp_std::{collections::btree_map::BTreeMap, vec, vec::Vec};
 use parachains_common::HOURS;
 
 #[cfg(feature = "instant-mode")]
-pub const EVALUATION_DURATION: BlockNumber = 3;
+pub const EVALUATION_ROUND_DURATION: BlockNumber = 3;
 #[cfg(feature = "fast-mode")]
-pub const EVALUATION_DURATION: BlockNumber = 10 * crate::MINUTES;
+pub const EVALUATION_ROUND_DURATION: BlockNumber = 10 * crate::MINUTES;
 #[cfg(not(any(feature = "fast-mode", feature = "instant-mode")))]
-pub const EVALUATION_DURATION: BlockNumber = 28 * crate::DAYS;
+pub const EVALUATION_ROUND_DURATION: BlockNumber = 28 * crate::DAYS;
 
 #[cfg(feature = "instant-mode")]
 pub const AUCTION_INITIALIZE_PERIOD_DURATION: BlockNumber = 3;
@@ -41,32 +41,25 @@ pub const AUCTION_INITIALIZE_PERIOD_DURATION: BlockNumber = 10 * crate::MINUTES;
 pub const AUCTION_INITIALIZE_PERIOD_DURATION: BlockNumber = 7 * crate::DAYS;
 
 #[cfg(feature = "instant-mode")]
-pub const AUCTION_OPENING_DURATION: BlockNumber = 2;
+pub const AUCTION_ROUND_DURATION: BlockNumber = 2;
 #[cfg(feature = "fast-mode")]
-pub const AUCTION_OPENING_DURATION: BlockNumber = 7 * crate::MINUTES;
+pub const AUCTION_ROUND_DURATION: BlockNumber = 7 * crate::MINUTES;
 #[cfg(not(any(feature = "fast-mode", feature = "instant-mode")))]
-pub const AUCTION_OPENING_DURATION: BlockNumber = 4 * crate::DAYS;
+pub const AUCTION_ROUND_DURATION: BlockNumber = 5 * crate::DAYS;
 
 #[cfg(feature = "instant-mode")]
-pub const AUCTION_CLOSING_DURATION: BlockNumber = 2;
+pub const COMMUNITY_ROUND_DURATION: BlockNumber = 3;
 #[cfg(feature = "fast-mode")]
-pub const AUCTION_CLOSING_DURATION: BlockNumber = 7 * crate::MINUTES;
+pub const COMMUNITY_ROUND_DURATION: BlockNumber = 15 * crate::MINUTES;
 #[cfg(not(any(feature = "fast-mode", feature = "instant-mode")))]
-pub const AUCTION_CLOSING_DURATION: BlockNumber = 1 * crate::DAYS;
+pub const COMMUNITY_ROUND_DURATION: BlockNumber = 5 * crate::DAYS;
 
 #[cfg(feature = "instant-mode")]
-pub const COMMUNITY_FUNDING_DURATION: BlockNumber = 3;
+pub const REMAINDER_ROUND_DURATION: BlockNumber = 3;
 #[cfg(feature = "fast-mode")]
-pub const COMMUNITY_FUNDING_DURATION: BlockNumber = 15 * crate::MINUTES;
+pub const REMAINDER_ROUND_DURATION: BlockNumber = 15 * crate::MINUTES;
 #[cfg(not(any(feature = "fast-mode", feature = "instant-mode")))]
-pub const COMMUNITY_FUNDING_DURATION: BlockNumber = 5 * crate::DAYS;
-
-#[cfg(feature = "instant-mode")]
-pub const REMAINDER_FUNDING_DURATION: BlockNumber = 3;
-#[cfg(feature = "fast-mode")]
-pub const REMAINDER_FUNDING_DURATION: BlockNumber = 15 * crate::MINUTES;
-#[cfg(not(any(feature = "fast-mode", feature = "instant-mode")))]
-pub const REMAINDER_FUNDING_DURATION: BlockNumber = crate::DAYS;
+pub const REMAINDER_ROUND_DURATION: BlockNumber = crate::DAYS;
 
 #[cfg(feature = "instant-mode")]
 pub const CONTRIBUTION_VESTING_DURATION: BlockNumber = 5;
@@ -92,12 +85,11 @@ pub const SUCCESS_TO_SETTLEMENT_TIME: BlockNumber = 1 * HOURS;
 pub type ProjectIdentifier = u32;
 
 parameter_types! {
-	pub const EvaluationDuration: BlockNumber = EVALUATION_DURATION;
+	pub const EvaluationRoundDuration: BlockNumber = EVALUATION_ROUND_DURATION;
 	pub const AuctionInitializePeriodDuration: BlockNumber = AUCTION_INITIALIZE_PERIOD_DURATION;
-	pub const AuctionOpeningDuration: BlockNumber = AUCTION_OPENING_DURATION;
-	pub const AuctionClosingDuration: BlockNumber = AUCTION_CLOSING_DURATION;
-	pub const CommunityFundingDuration: BlockNumber = COMMUNITY_FUNDING_DURATION;
-	pub const RemainderFundingDuration: BlockNumber = REMAINDER_FUNDING_DURATION;
+	pub const AuctionRoundDuration: BlockNumber = AUCTION_ROUND_DURATION;
+	pub const CommunityRoundDuration: BlockNumber = COMMUNITY_ROUND_DURATION;
+	pub const RemainderRoundDuration: BlockNumber = REMAINDER_ROUND_DURATION;
 	pub const ManualAcceptanceDuration: BlockNumber = MANUAL_ACCEPTANCE_DURATION;
 	pub const SuccessToSettlementTime: BlockNumber = SUCCESS_TO_SETTLEMENT_TIME;
 	pub const FundingPalletId: PalletId = PalletId(*b"plmc/fun");


### PR DESCRIPTION
## What?
- There's no more candle period, so AuctionOpening and AuctionClosing durations should be merged
- Naming of durations are now more consistent

## How?
- Removed both Auction periods and replaced them for one called `AuctionRoundDuration`
- Merged the durations in the shared-configuration

## Testing?
We moved from transitioning using the durations to the simple extrinsic `inst.go_to_next_state(project_id)` so no text fixes needed.

## Anything Else?
- Made all mock durations different to potentially catch some bugs. Had a problem before where I was assuming a closing duration was going on and it was the auctionInitializePeriod.