### PR TITLE
🔖 Runtime Upgrade

### DIFF
--- a/pallets/funding/src/storage_migrations.rs
+++ b/pallets/funding/src/storage_migrations.rs
@@ -1,5 +1,334 @@
 //! A module that is responsible for migration of storage.
 use frame_support::traits::StorageVersion;
 /// The current storage version
-pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(4);
+pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(5);
 pub const LOG: &str = "runtime::funding::migration";
+
+pub mod v5 {
+	use crate::{
+		AccountIdOf, BalanceOf, BlockNumberPair, CheckOutcome, Config, EvaluationRoundInfoOf, EvaluatorsOutcome,
+		FixedPointNumber, FundingOutcome, HRMPChannelStatus, Pallet, PriceOf, ProjectDetailsOf, ProjectStatus,
+		RewardInfo,
+	};
+	use core::marker::PhantomData;
+	use frame_support::traits::{tokens::Balance as BalanceT, UncheckedOnRuntimeUpgrade};
+	use frame_system::pallet_prelude::BlockNumberFor;
+	use polimec_common::credentials::Did;
+	use polkadot_parachain_primitives::primitives::Id as ParaId;
+	use scale_info::TypeInfo;
+	use serde::{Deserialize, Serialize};
+	use sp_core::{Decode, Encode, Get, MaxEncodedLen, RuntimeDebug};
+	use sp_runtime::traits::One;
+
+	#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+	pub struct OldProjectDetails<
+		AccountId,
+		Did,
+		BlockNumber,
+		Price: FixedPointNumber,
+		Balance: BalanceT,
+		EvaluationRoundInfo,
+	> {
+		pub issuer_account: AccountId,
+		pub issuer_did: Did,
+		/// Whether the project is frozen, so no `metadata` changes are allowed.
+		pub is_frozen: bool,
+		/// The price in USD per token decided after the Auction Round
+		pub weighted_average_price: Option<Price>,
+		/// The current status of the project
+		pub status: OldProjectStatus,
+		/// When the different project phases start and end
+		pub phase_transition_points: OldPhaseTransitionPoints<BlockNumber>,
+		/// Fundraising target amount in USD (6 decimals)
+		pub fundraising_target_usd: Balance,
+		/// The amount of Contribution Tokens that have not yet been sold
+		pub remaining_contribution_tokens: Balance,
+		/// Funding reached amount in USD (6 decimals)
+		pub funding_amount_reached_usd: Balance,
+		/// Information about the total amount bonded, and the outcome in regards to reward/slash/nothing
+		pub evaluation_round_info: EvaluationRoundInfo,
+		/// If the auction was oversubscribed, how much USD was raised across all winning bids
+		pub usd_bid_on_oversubscription: Option<Balance>,
+		/// When the Funding Round ends
+		pub funding_end_block: Option<BlockNumber>,
+		pub migration_type: Option<OldMigrationType>,
+	}
+	#[derive(
+		Default, Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen, Serialize, Deserialize,
+	)]
+	pub enum OldProjectStatus {
+		#[default]
+		Application,
+		EvaluationRound,
+		AuctionInitializePeriod,
+		AuctionOpening,
+		AuctionClosing,
+		CalculatingWAP,
+		CommunityRound,
+		RemainderRound,
+		FundingFailed,
+		AwaitingProjectDecision,
+		FundingSuccessful,
+		SettlementStarted(OldFundingOutcome),
+		SettlementFinished(OldFundingOutcome),
+		CTMigrationStarted,
+		CTMigrationFinished,
+	}
+
+	#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen, Serialize, Deserialize)]
+	pub enum OldFundingOutcome {
+		FundingSuccessful,
+		FundingFailed,
+	}
+
+	#[derive(Default, Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+	pub struct OldPhaseTransitionPoints<BlockNumber> {
+		pub application: OldBlockNumberPair<BlockNumber>,
+		pub evaluation: OldBlockNumberPair<BlockNumber>,
+		pub auction_initialize_period: OldBlockNumberPair<BlockNumber>,
+		pub auction_opening: OldBlockNumberPair<BlockNumber>,
+		pub random_closing_ending: Option<BlockNumber>,
+		pub auction_closing: OldBlockNumberPair<BlockNumber>,
+		pub community: OldBlockNumberPair<BlockNumber>,
+		pub remainder: OldBlockNumberPair<BlockNumber>,
+	}
+
+	#[derive(Default, Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+	pub struct OldBlockNumberPair<BlockNumber> {
+		pub start: Option<BlockNumber>,
+		pub end: Option<BlockNumber>,
+	}
+
+	#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+	pub struct OldEvaluationRoundInfo<Balance> {
+		pub total_bonded_usd: Balance,
+		pub total_bonded_plmc: Balance,
+		pub evaluators_outcome: OldEvaluatorsOutcome<Balance>,
+	}
+
+	#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+	pub enum OldEvaluatorsOutcome<Balance> {
+		Unchanged,
+		Rewarded(RewardInfo<Balance>),
+		Slashed,
+	}
+
+	#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+	pub enum OldMigrationType {
+		Offchain,
+		Pallet(OldPalletMigrationInfo),
+	}
+
+	#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+	pub struct OldPalletMigrationInfo {
+		/// ParaId of project
+		pub parachain_id: ParaId,
+		/// HRMP Channel status
+		pub hrmp_channel_status: HRMPChannelStatus,
+		/// Migration readiness check
+		pub migration_readiness_check: Option<OldPalletMigrationReadinessCheck>,
+	}
+
+	#[derive(Clone, Copy, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+	pub struct OldPalletMigrationReadinessCheck {
+		pub holding_check: (xcm::v3::QueryId, CheckOutcome),
+		pub pallet_check: (xcm::v3::QueryId, CheckOutcome),
+	}
+
+	type OldProjectDetailsOf<T> = OldProjectDetails<
+		AccountIdOf<T>,
+		Did,
+		BlockNumberFor<T>,
+		PriceOf<T>,
+		BalanceOf<T>,
+		OldEvaluationRoundInfo<BalanceOf<T>>,
+	>;
+
+	pub struct UncheckedMigrationToV5<T: Config>(PhantomData<T>);
+	impl<T: Config> UncheckedOnRuntimeUpgrade for UncheckedMigrationToV5<T> {
+		fn on_runtime_upgrade() -> frame_support::weights::Weight {
+			let mut items = 0;
+			log::info!("Starting migration to V5");
+			let mut translate_project_details = |key, item: OldProjectDetailsOf<T>| -> Option<ProjectDetailsOf<T>> {
+				items += 1;
+				log::info!("project_details item {:?}", items);
+				let round_duration: BlockNumberPair<BlockNumberFor<T>>;
+				let new_status = match item.status {
+					OldProjectStatus::Application => {
+						let start =
+							item.phase_transition_points.application.start.expect("Application start block is missing");
+						let end =
+							item.phase_transition_points.application.end.expect("Application end block is missing");
+						round_duration = BlockNumberPair::new(Some(start), Some(end));
+						ProjectStatus::Application
+					},
+					OldProjectStatus::EvaluationRound => {
+						let start =
+							item.phase_transition_points.evaluation.start.expect("Evaluation start block is missing");
+						let end = item.phase_transition_points.evaluation.end.expect("Evaluation end block is missing");
+						round_duration = BlockNumberPair::new(Some(start), Some(end));
+						ProjectStatus::EvaluationRound
+					},
+					OldProjectStatus::AuctionInitializePeriod => {
+						let now = frame_system::Pallet::<T>::block_number();
+						let start = now;
+						let end = now + <T as Config>::AuctionRoundDuration::get();
+						round_duration = BlockNumberPair::new(Some(start), Some(end));
+						debug_assert!(false, "AuctionInitializePeriod is not supported in V5, no project should be in this state when upgrading storage");
+						log::error!("AuctionInitializePeriod is not supported in V5, no project should be in this state when upgrading storage");
+						ProjectStatus::AuctionRound
+					},
+					OldProjectStatus::AuctionOpening => {
+						let start = item
+							.phase_transition_points
+							.auction_opening
+							.start
+							.expect("AuctionOpening start block is missing");
+						let end = start + <T as Config>::AuctionRoundDuration::get();
+						round_duration = BlockNumberPair::new(Some(start), Some(end));
+						debug_assert!(false, "AuctionOpening is not supported in V5, no project should be in this state when upgrading storage");
+						log::error!("AuctionOpening is not supported in V5, no project should be in this state when upgrading storage");
+						ProjectStatus::AuctionRound
+					},
+					OldProjectStatus::AuctionClosing => {
+						let start = item
+							.phase_transition_points
+							.auction_opening
+							.start
+							.expect("AuctionOpening start block is missing");
+						let end = start + <T as Config>::AuctionRoundDuration::get();
+						round_duration = BlockNumberPair::new(Some(start), Some(end));
+						debug_assert!(false, "AuctionClosing is not supported in V5, no project should be in this state when upgrading storage");
+						log::error!("AuctionClosing is not supported in V5, no project should be in this state when upgrading storage");
+						ProjectStatus::AuctionRound
+					},
+					OldProjectStatus::CalculatingWAP => {
+						let start = item
+							.phase_transition_points
+							.auction_opening
+							.start
+							.expect("AuctionOpening start block is missing");
+						let end = start + <T as Config>::AuctionRoundDuration::get();
+						round_duration = BlockNumberPair::new(Some(start), Some(end));
+						debug_assert!(false, "CalculatingWAP is not supported in V5, no project should be in this state when upgrading storage");
+						log::error!("CalculatingWAP is not supported in V5, no project should be in this state when upgrading storage");
+						ProjectStatus::AuctionRound
+					},
+					OldProjectStatus::CommunityRound => {
+						let start = item
+							.phase_transition_points
+							.community
+							.start
+							.expect("CommunityRound start block is missing");
+						let end = start +
+							<T as Config>::CommunityRoundDuration::get() +
+							<T as Config>::RemainderRoundDuration::get();
+						round_duration = BlockNumberPair::new(Some(start), Some(end));
+						debug_assert!(
+							false,
+							"We should not upgrade runtime while a project is still in community round"
+						);
+						ProjectStatus::CommunityRound(
+							item.phase_transition_points.community.end.expect("CommunityRound end block is missing") +
+								One::one(),
+						)
+					},
+					OldProjectStatus::RemainderRound => {
+						let start = item
+							.phase_transition_points
+							.community
+							.start
+							.expect("CommunityRound start block is missing");
+						let end = start +
+							<T as Config>::CommunityRoundDuration::get() +
+							<T as Config>::RemainderRoundDuration::get();
+						round_duration = BlockNumberPair::new(Some(start), Some(end));
+						ProjectStatus::CommunityRound(
+							item.phase_transition_points.remainder.start.expect("Remainder start block is missing"),
+						)
+					},
+					OldProjectStatus::FundingFailed => {
+						round_duration = BlockNumberPair::new(None, None);
+						ProjectStatus::SettlementStarted(FundingOutcome::Failure)
+					},
+					OldProjectStatus::AwaitingProjectDecision => {
+						round_duration = BlockNumberPair::new(None, None);
+						debug_assert!(false, "AwaitingProjectDecision is not supported in V5, no project should be in this state when upgrading storage");
+						log::error!("AwaitingProjectDecision is not supported in V5, no project should be in this state when upgrading storage");
+						ProjectStatus::FundingSuccessful
+					},
+					OldProjectStatus::FundingSuccessful => {
+						round_duration = BlockNumberPair::new(None, None);
+						ProjectStatus::SettlementStarted(FundingOutcome::Success)
+					},
+					OldProjectStatus::SettlementStarted(old_outcome) => {
+						round_duration = BlockNumberPair::new(None, None);
+						let outcome = match old_outcome {
+							OldFundingOutcome::FundingSuccessful => FundingOutcome::Success,
+							OldFundingOutcome::FundingFailed => FundingOutcome::Failure,
+						};
+						ProjectStatus::SettlementStarted(outcome)
+					},
+					OldProjectStatus::SettlementFinished(old_outcome) => {
+						round_duration = BlockNumberPair::new(None, None);
+						let outcome = match old_outcome {
+							OldFundingOutcome::FundingSuccessful => FundingOutcome::Success,
+							OldFundingOutcome::FundingFailed => FundingOutcome::Failure,
+						};
+						ProjectStatus::SettlementFinished(outcome)
+					},
+					OldProjectStatus::CTMigrationStarted => {
+						round_duration = BlockNumberPair::new(None, None);
+						ProjectStatus::CTMigrationStarted
+					},
+					OldProjectStatus::CTMigrationFinished => {
+						round_duration = BlockNumberPair::new(None, None);
+						ProjectStatus::CTMigrationFinished
+					},
+				};
+
+				let evaluators_outcome = Some(match item.evaluation_round_info.evaluators_outcome {
+					OldEvaluatorsOutcome::Unchanged => EvaluatorsOutcome::Rewarded(
+						<Pallet<T>>::generate_evaluator_rewards_info(key)
+							.expect("Evaluator rewards info should be generated"),
+					),
+					OldEvaluatorsOutcome::Rewarded(info) => EvaluatorsOutcome::<BalanceOf<T>>::Rewarded(info),
+					OldEvaluatorsOutcome::Slashed => EvaluatorsOutcome::<BalanceOf<T>>::Slashed,
+				});
+				let evaluation_round_info = EvaluationRoundInfoOf::<T> {
+					total_bonded_usd: item.evaluation_round_info.total_bonded_usd,
+					total_bonded_plmc: item.evaluation_round_info.total_bonded_plmc,
+					evaluators_outcome,
+				};
+				Some(ProjectDetailsOf::<T> {
+					issuer_account: item.issuer_account,
+					issuer_did: item.issuer_did,
+					is_frozen: item.is_frozen,
+					weighted_average_price: item.weighted_average_price,
+					status: new_status,
+					round_duration,
+					fundraising_target_usd: item.fundraising_target_usd,
+					remaining_contribution_tokens: item.remaining_contribution_tokens,
+					funding_amount_reached_usd: item.funding_amount_reached_usd,
+					evaluation_round_info,
+					usd_bid_on_oversubscription: item.usd_bid_on_oversubscription,
+					funding_end_block: item.funding_end_block,
+					migration_type: None,
+				})
+			};
+			crate::ProjectsDetails::<T>::translate(|key, object: OldProjectDetailsOf<T>| {
+				translate_project_details(key, object)
+			});
+
+			T::DbWeight::get().reads_writes(items, items)
+		}
+	}
+
+	pub type MigrationToV5<T> = frame_support::migrations::VersionedMigration<
+		4,
+		5,
+		UncheckedMigrationToV5<T>,
+		crate::Pallet<T>,
+		<T as frame_system::Config>::DbWeight,
+	>;
+}

--- a/pallets/funding/src/tests/4_contribution.rs
+++ b/pallets/funding/src/tests/4_contribution.rs
@@ -1758,14 +1758,17 @@ mod contribute_extrinsic {
 			let glutton_contribution = ContributionParams::new(BUYER_1, remaining_cts, 4u8, AcceptedFundingAsset::USDT);
 			let wap = project_details.weighted_average_price.unwrap();
 			let plmc_mint = inst.calculate_contributed_plmc_spent(vec![glutton_contribution.clone()], wap, true);
-			let funding_asset_mint = inst.calculate_contributed_funding_asset_spent(vec![glutton_contribution.clone()], wap);
+			let funding_asset_mint =
+				inst.calculate_contributed_funding_asset_spent(vec![glutton_contribution.clone()], wap);
 			inst.mint_plmc_to(plmc_mint);
 			inst.mint_funding_asset_to(funding_asset_mint);
 			inst.contribute_for_users(project_id, vec![glutton_contribution.clone()]).unwrap();
 
-			let failing_contribution = ContributionParams::<TestRuntime>::new(BUYER_2, 1000 * CT_UNIT, 1u8, AcceptedFundingAsset::USDT);
+			let failing_contribution =
+				ContributionParams::<TestRuntime>::new(BUYER_2, 1000 * CT_UNIT, 1u8, AcceptedFundingAsset::USDT);
 			let plmc_mint = inst.calculate_contributed_plmc_spent(vec![glutton_contribution.clone()], wap, true);
-			let funding_asset_mint = inst.calculate_contributed_funding_asset_spent(vec![glutton_contribution.clone()], wap);
+			let funding_asset_mint =
+				inst.calculate_contributed_funding_asset_spent(vec![glutton_contribution.clone()], wap);
 			inst.mint_plmc_to(plmc_mint);
 			inst.mint_funding_asset_to(funding_asset_mint);
 			inst.execute(|| {

--- a/runtimes/polimec/src/custom_migrations/funding_holds.rs
+++ b/runtimes/polimec/src/custom_migrations/funding_holds.rs
@@ -1,0 +1,91 @@
+use crate::{Balance, Funding, Runtime, RuntimeHoldReason};
+use alloc::vec::Vec;
+use frame_support::traits::{GetStorageVersion, OnRuntimeUpgrade, VariantCount, VariantCountOf};
+use pallet_balances::IdAmount;
+use pallet_funding::ProjectId;
+use parity_scale_codec::{Decode, Encode};
+use scale_info::TypeInfo;
+use sp_core::{MaxEncodedLen, RuntimeDebug};
+use sp_runtime::BoundedVec;
+
+#[derive(Clone, Copy, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+pub enum OldFundingHoldReason {
+	Evaluation(ProjectId),
+	Participation(ProjectId),
+}
+
+#[derive(Clone, Copy, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+pub enum OldRuntimeHoldReason {
+	#[codec(index = 25u8)]
+	ParachainStaking(pallet_parachain_staking::HoldReason),
+
+	#[codec(index = 41u8)]
+	Democracy(pallet_democracy::HoldReason),
+
+	#[codec(index = 44u8)]
+	Elections(pallet_elections_phragmen::HoldReason),
+
+	#[codec(index = 45u8)]
+	Preimage(pallet_preimage::HoldReason),
+
+	#[codec(index = 80u8)]
+	Funding(OldFundingHoldReason),
+}
+
+impl VariantCount for OldRuntimeHoldReason {
+	const VARIANT_COUNT: u32 = 2 + 1 + 1 + 1 + 2;
+}
+
+type OldIdAmount = IdAmount<OldRuntimeHoldReason, Balance>;
+type NewIdAmount = IdAmount<RuntimeHoldReason, Balance>;
+type OldHoldsItem = BoundedVec<OldIdAmount, VariantCountOf<OldRuntimeHoldReason>>;
+type NewHoldsItem = BoundedVec<NewIdAmount, VariantCountOf<RuntimeHoldReason>>;
+
+pub struct FromFundingV4Migration;
+impl OnRuntimeUpgrade for FromFundingV4Migration {
+	fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		let on_chain_version = Funding::on_chain_storage_version();
+		if on_chain_version != 4 {
+			log::warn!("Funding Holds migration can be removed. Skipping it now...",);
+			return <Runtime as frame_system::Config>::DbWeight::get().reads(1)
+		}
+		let mut items = 0;
+		let mut translate = |_key, old_user_holds: OldHoldsItem| -> Option<NewHoldsItem> {
+			items += 1;
+			log::info!("Migrating hold {:?}", items);
+			let mut new_user_holds = Vec::new();
+			for user_hold in old_user_holds.iter() {
+				let new_id = match user_hold.id {
+					OldRuntimeHoldReason::ParachainStaking(reason) => RuntimeHoldReason::ParachainStaking(reason),
+					OldRuntimeHoldReason::Democracy(reason) => RuntimeHoldReason::Democracy(reason),
+					OldRuntimeHoldReason::Elections(reason) => RuntimeHoldReason::Elections(reason),
+					OldRuntimeHoldReason::Preimage(reason) => RuntimeHoldReason::Preimage(reason),
+					OldRuntimeHoldReason::Funding(OldFundingHoldReason::Evaluation(_)) =>
+						RuntimeHoldReason::Funding(pallet_funding::HoldReason::Evaluation),
+					OldRuntimeHoldReason::Funding(OldFundingHoldReason::Participation(_)) =>
+						RuntimeHoldReason::Funding(pallet_funding::HoldReason::Participation),
+				};
+				new_user_holds.push(IdAmount { id: new_id, amount: user_hold.amount })
+			}
+			let output = NewHoldsItem::try_from(new_user_holds);
+
+			debug_assert!(output.is_ok(), "Failed to convert holds");
+			if let Err(err) = &output {
+				log::error!(
+					"Holds conversion failed with err {:?} for the following user holds: {:?}",
+					err,
+					old_user_holds
+				);
+			}
+			// If we failed to convert the holds, we delete them
+			output.ok()
+		};
+
+		pallet_balances::Holds::<Runtime>::translate(|key, object: OldHoldsItem| translate(key, object));
+
+		log::info!("Number of users migrated: {}", items);
+		let weight = <Runtime as frame_system::Config>::DbWeight::get().reads_writes(items, items);
+		log::info!("holds weight: {:?}", weight);
+		weight
+	}
+}

--- a/runtimes/polimec/src/custom_migrations/mod.rs
+++ b/runtimes/polimec/src/custom_migrations/mod.rs
@@ -16,3 +16,5 @@
 
 // the generated files do not pass clippy
 #![allow(clippy::all)]
+
+pub mod funding_holds;

--- a/runtimes/polimec/src/lib.rs
+++ b/runtimes/polimec/src/lib.rs
@@ -162,10 +162,15 @@ pub type Migrations = migrations::Unreleased;
 /// The runtime migrations per release.
 #[allow(missing_docs)]
 pub mod migrations {
+	use crate::Runtime;
 
 	/// Unreleased migrations. Add new ones here:
 	#[allow(unused_parens)]
-	pub type Unreleased = ();
+	pub type Unreleased = (
+		cumulus_pallet_xcmp_queue::migration::v5::MigrateV4ToV5<Runtime>,
+		crate::custom_migrations::funding_holds::FromFundingV4Migration,
+		pallet_funding::storage_migrations::v5::MigrationToV5<Runtime>,
+	);
 }
 
 /// Executive: handles dispatch to the various modules.
@@ -211,10 +216,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("polimec-mainnet"),
 	impl_name: create_runtime_str!("polimec-mainnet"),
 	authoring_version: 1,
-	spec_version: 0_007_006,
+	spec_version: 0_008_000,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 4,
+	transaction_version: 5,
 	state_version: 1,
 };
 

--- a/runtimes/polimec/src/xcm_config.rs
+++ b/runtimes/polimec/src/xcm_config.rs
@@ -470,3 +470,8 @@ impl<T: Contains<Location>> ShouldExecute for AllowHrmpNotifications<T> {
 		Ok(())
 	}
 }
+
+impl cumulus_pallet_xcmp_queue::migration::v5::V5Config for Runtime {
+	// This must be the same as the `ChannelInfo` from the `Config`:
+	type ChannelList = ParachainSystem;
+}

--- a/scripts/chopsticks/genesis-polimec.yml
+++ b/scripts/chopsticks/genesis-polimec.yml
@@ -1,0 +1,34 @@
+db: ./db.sqlite
+mock-signature-host: true
+genesis: ./chain-specs/paseo/polimec-paseo.spec.raw.json
+
+import-storage:
+  System:
+    Account:
+      - - - 5EYCAe5ij8xKJ2WTFRZeeUsfaED5wz6z5XFv5LUw9Ni7VCea # Fund the Dispenser account
+        - providers: 1
+          data:
+            free: '230000000000000000'
+      - - - '0xba143e2096e073cb9cddc78e6f4969d8a02160d716a69e08214caf5339d88c42' # Fund the Asset Owner account
+        - providers: 1
+          data:
+            free: '10000000000000000'
+      - - - '5CojJLdz8ers6HBoEo7avwupYhZavXjTmCsUAe8w6aYcasq4' # Fund Felix account with PLMC
+        - providers: 1
+          data:
+            free: '320000000000000'
+  ForeignAssets:
+    Account: [
+      [
+        [10, 5CojJLdz8ers6HBoEo7avwupYhZavXjTmCsUAe8w6aYcasq4],
+        { balance: 200000000000000 }, # Give to Felix 20k DOT
+      ],
+      [
+        [1337, 5CojJLdz8ers6HBoEo7avwupYhZavXjTmCsUAe8w6aYcasq4],
+        { balance: 330000000000 }, # Give to Felix 33k USDC
+      ],
+      [
+        [1984, 5CojJLdz8ers6HBoEo7avwupYhZavXjTmCsUAe8w6aYcasq4],
+        { balance: 1000000000 }, # Give to Felix 100k USDT
+      ],
+    ]


### PR DESCRIPTION
## What?
- Increase version of pallet_funding storage and polimec runtime
- Write storage migration for new holds without project id at runtime level, and ProjectDetails changes at pallet level

## Why?
- New storage would be undecodable otherwise

## Testing
We need to test it with chopsticks before merging. Try-runtime works

## Anything Else?
I compared the old vs new holds and the only change was the participation

I compared the old vs new ProjectDetails and the difference was the phaseTransitionPoints being replaced with `roundDuration: {
        start: null
        end: null
      }`
and the status changed to `SettlementStarted: Failure` in the case of `FundingFailed`, and `SettlementStarted:Success` in the case of `SettlementStarted(FundingSuccessful)` 

Files are here: https://linear.app/polimec/issue/PLMC-601/manual-tests#comment-9b3008c7