### PR TITLE
🙅🏻‍♂️ Hide instantiator behind feature flag

### DIFF
--- a/pallets/funding/Cargo.toml
+++ b/pallets/funding/Cargo.toml
@@ -124,3 +124,4 @@ try-runtime = [
 	"polimec-common/try-runtime",
 	"sp-runtime/try-runtime",
 ]
+on-chain-release-build = []

--- a/pallets/funding/src/lib.rs
+++ b/pallets/funding/src/lib.rs
@@ -109,8 +109,7 @@ pub mod mock;
 #[cfg(test)]
 pub mod tests;
 
-// TODO: This is used only in tests. Should we use #[cfg(test)]?
-// If we do that the integration-tests will complain about the missing `use` statement :(
+#[cfg(not(feature = "on-chain-release-build"))]
 pub mod instantiator;
 
 #[cfg(feature = "runtime-benchmarks")]

--- a/runtimes/polimec/Cargo.toml
+++ b/runtimes/polimec/Cargo.toml
@@ -275,6 +275,6 @@ try-runtime = [
 # A feature that should be enabled when the runtime should be built for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller, like logging for example.
-on-chain-release-build = [ "sp-api/disable-logging" ]
+on-chain-release-build = [ "sp-api/disable-logging", "pallet-funding/on-chain-release-build" ]
 
 development-settings = [ "shared-configuration/development-settings" ]


### PR DESCRIPTION
## What?
When on-chain-release-build feature is used, don't compile the instantiator

## Why?
Makes the runtime smaller

## Testing
- Successfully ran pallet tests, integration tests, benchmark tests, dry-run-benches, and srtool wasm