### PR TITLE
👨🏻‍💻 Tightly couple linear-release to funding pallet

### DIFF
--- a/pallets/funding/Cargo.toml
+++ b/pallets/funding/Cargo.toml
@@ -27,6 +27,8 @@ scale-info = { workspace = true, default-features = false, features = [
 log.workspace = true
 variant_count = "1.1.0"
 
+pallet-linear-release.workspace = true
+
 # Substrate dependencies
 frame-support.workspace = true
 frame-system.workspace = true

--- a/pallets/funding/src/benchmarking.rs
+++ b/pallets/funding/src/benchmarking.rs
@@ -1451,7 +1451,7 @@ mod benchmarks {
 			HoldReason::Participation.into(),
 		);
 		assert_eq!(
-			<T as Config>::Vesting::total_scheduled_amount(&contributor, HoldReason::Participation.into()),
+			VestingOf::<T>::total_scheduled_amount(&contributor, HoldReason::Participation.into()),
 			Some(contribution_to_settle.plmc_bond)
 		);
 		let funding_account = project_metadata.funding_destination_account;

--- a/pallets/funding/src/functions/6_settlement.rs
+++ b/pallets/funding/src/functions/6_settlement.rs
@@ -160,7 +160,7 @@ impl<T: Config> Pallet<T> {
 				Self::calculate_vesting_info(&bid.bidder, bid.multiplier, bid.plmc_bond.saturating_sub(refunded_plmc))
 					.map_err(|_| Error::<T>::BadMath)?;
 
-			T::Vesting::add_release_schedule(
+			VestingOf::<T>::add_release_schedule(
 				&bid.bidder,
 				plmc_vesting_info.total_amount,
 				plmc_vesting_info.amount_per_block,
@@ -257,7 +257,7 @@ impl<T: Config> Pallet<T> {
 			)
 			.map_err(|_| Error::<T>::BadMath)?;
 
-			T::Vesting::add_release_schedule(
+			VestingOf::<T>::add_release_schedule(
 				&contribution.contributor,
 				vest_info.total_amount,
 				vest_info.amount_per_block,

--- a/pallets/funding/src/mock.rs
+++ b/pallets/funding/src/mock.rs
@@ -398,7 +398,6 @@ impl Config for TestRuntime {
 	type AuctionRoundDuration = AuctionRoundDuration;
 	type Balance = Balance;
 	type BlockNumber = BlockNumber;
-	type BlockNumberToBalance = ConvertInto;
 	type BlockchainOperationTreasury = BlockchainOperationTreasuryAccount;
 	type CommunityRoundDuration = CommunityRoundDuration;
 	type ContributionTokenCurrency = ContributionTokens;
@@ -436,7 +435,6 @@ impl Config for TestRuntime {
 	type SetPrices = ();
 	type StringLimit = ConstU32<64>;
 	type VerifierPublicKey = VerifierPublicKey;
-	type Vesting = LinearRelease;
 	type WeightInfo = weights::SubstrateWeight<TestRuntime>;
 }
 

--- a/pallets/funding/src/tests/6_settlement.rs
+++ b/pallets/funding/src/tests/6_settlement.rs
@@ -1124,7 +1124,7 @@ mod settle_contribution_extrinsic {
 			let issuer_usdt_balance =
 				inst.get_free_funding_asset_balance_for(stored_contribution.funding_asset.id(), issuer);
 			let unvested_amount = inst.execute(|| {
-				<TestRuntime as Config>::Vesting::total_scheduled_amount(&BUYER_6, HoldReason::Participation.into())
+				VestingOf::<TestRuntime>::total_scheduled_amount(&BUYER_6, HoldReason::Participation.into())
 			});
 
 			assert_eq!(plmc_free_amount, inst.get_ed());
@@ -1144,7 +1144,7 @@ mod settle_contribution_extrinsic {
 			let issuer_usdt_balance =
 				inst.get_free_funding_asset_balance_for(stored_contribution.funding_asset.id(), issuer);
 			let unvested_amount = inst.execute(|| {
-				<TestRuntime as Config>::Vesting::total_scheduled_amount(&BUYER_6, HoldReason::Participation.into())
+				VestingOf::<TestRuntime>::total_scheduled_amount(&BUYER_6, HoldReason::Participation.into())
 			});
 
 			assert_eq!(plmc_free_amount, inst.get_ed() + stored_contribution.plmc_bond);
@@ -1170,7 +1170,7 @@ mod settle_contribution_extrinsic {
 			let issuer_usdt_balance_2 =
 				inst.get_free_funding_asset_balance_for(stored_contribution.funding_asset.id(), issuer);
 			let unvested_amount = inst.execute(|| {
-				<TestRuntime as Config>::Vesting::total_scheduled_amount(&BUYER_7, HoldReason::Participation.into())
+				VestingOf::<TestRuntime>::total_scheduled_amount(&BUYER_7, HoldReason::Participation.into())
 			});
 			assert_eq!(plmc_free_amount, inst.get_ed());
 			assert_eq!(plmc_held_amount, stored_contribution.plmc_bond);
@@ -1189,7 +1189,7 @@ mod settle_contribution_extrinsic {
 			let issuer_usdt_balance_2 =
 				inst.get_free_funding_asset_balance_for(stored_contribution.funding_asset.id(), issuer);
 			let unvested_amount = inst.execute(|| {
-				<TestRuntime as Config>::Vesting::total_scheduled_amount(&BUYER_7, HoldReason::Participation.into())
+				VestingOf::<TestRuntime>::total_scheduled_amount(&BUYER_7, HoldReason::Participation.into())
 			});
 
 			assert_eq!(plmc_free_amount, inst.get_ed() + stored_contribution.plmc_bond);

--- a/runtimes/polimec/src/lib.rs
+++ b/runtimes/polimec/src/lib.rs
@@ -1037,7 +1037,6 @@ impl pallet_funding::Config for Runtime {
 	type AuctionRoundDuration = AuctionRoundDuration;
 	type Balance = Balance;
 	type BlockNumber = BlockNumber;
-	type BlockNumberToBalance = ConvertInto;
 	type BlockchainOperationTreasury = BlockchainOperationTreasury;
 	type CommunityRoundDuration = CommunityRoundDuration;
 	type ContributionTokenCurrency = ContributionTokens;
@@ -1075,7 +1074,6 @@ impl pallet_funding::Config for Runtime {
 	type SetPrices = benchmark_helpers::SetOraclePrices;
 	type StringLimit = ConstU32<64>;
 	type VerifierPublicKey = VerifierPublicKey;
-	type Vesting = LinearRelease;
 	type WeightInfo = weights::pallet_funding::WeightInfo<Runtime>;
 }
 


### PR DESCRIPTION
## What?
- Title
## Why?
- Solving the schedule merging problem requires some functions not exposed through the trait, and we anyway don't care about making the funding pallet reusable. So easier to tightly couple our vesting pallet

## How?
- Remove duplicated config types
- Remove Vesting config type
- Add linear release Config to funding config required traits 
