### PR TITLE
Unneeded TODO removal

### DIFF
--- a/pallets/linear-release/src/lib.rs
+++ b/pallets/linear-release/src/lib.rs
@@ -347,7 +347,6 @@ pub mod pallet {
 			};
 			let schedule1_index = schedule1_index as usize;
 			let schedule2_index = schedule2_index as usize;
-			// TODO: Add the different reasons check.
 
 			let schedules = Self::vesting(&who, reason).ok_or(Error::<T>::NotVesting)?;
 			let merge_action = VestingAction::Merge { index1: schedule1_index, index2: schedule2_index };


### PR DESCRIPTION
## What?
- Todo in linear release pallet was awaiting a hold reason check.

## Why?
- We don't need it because if the 2 indexes declared don't exist for that hold reason then we will just get an error.