### PR TITLE
🧪 One Token Model - Pallet Funding Tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7772,6 +7772,7 @@ dependencies = [
  "polimec-common",
  "scale-info",
  "serde",
+ "sp-core",
  "sp-io",
  "sp-runtime",
 ]

--- a/integration-tests/src/constants.rs
+++ b/integration-tests/src/constants.rs
@@ -445,7 +445,7 @@ pub mod polimec {
 			let dot = (AcceptedFundingAsset::DOT.id(), prices.dot);
 			let usdc = (AcceptedFundingAsset::USDC.id(), prices.usdc);
 			let usdt = (AcceptedFundingAsset::USDT.id(), prices.usdt);
-			let plmc = (pallet_funding::PLMC_FOREIGN_ID, prices.plmc);
+			let plmc = (polimec_common::PLMC_FOREIGN_ID, prices.plmc);
 
 			let values: BoundedVec<(u32, FixedU128), <PolimecRuntime as orml_oracle::Config>::MaxFeedValues> =
 				vec![dot, usdc, usdt, plmc].try_into().expect("benchmarks can panic");
@@ -501,8 +501,10 @@ pub mod polimec {
 
 		funded_accounts.extend(accounts::init_balances().iter().cloned().map(|k| (k, INITIAL_DEPOSIT)));
 		funded_accounts.extend(collators::initial_authorities().iter().cloned().map(|(acc, _)| (acc, 20_005 * PLMC)));
-		funded_accounts.push((TreasuryAccount::get(), 20_005 * PLMC));
+		funded_accounts.push((TreasuryAccount::get(), 20_000_000 * PLMC));
 		funded_accounts.push((BlockchainOperationTreasury::get(), 20_005 * PLMC));
+		/// Treasury account needs PLMC for the One Token Model participations
+		funded_accounts.push((polimec_runtime::FeeRecipient::get(), INITIAL_DEPOSIT));
 
 		let genesis_config = polimec_runtime::RuntimeGenesisConfig {
 			system: Default::default(),
@@ -510,20 +512,16 @@ pub mod polimec {
 			contribution_tokens: Default::default(),
 			foreign_assets: polimec_runtime::ForeignAssetsConfig {
 				assets: vec![
-					(dot_asset_id, alice_account.clone(), true, 0_0_010_000_000u128),
-					(usdt_asset_id, alice_account.clone(), true, 0_0_010_000_000u128),
-					(usdc_asset_id, alice_account.clone(), true, 0_0_010_000_000u128),
+					(dot_asset_id, alice_account.clone(), true, 100_000_000),
+					(usdt_asset_id, alice_account.clone(), true, 70_000),
+					(usdc_asset_id, alice_account.clone(), true, 70_000),
 				],
 				metadata: vec![
 					(dot_asset_id, "Local DOT".as_bytes().to_vec(), "DOT".as_bytes().to_vec(), 10),
 					(usdt_asset_id, "Local USDT".as_bytes().to_vec(), "USDT".as_bytes().to_vec(), 6),
 					(usdc_asset_id, "Local USDC".as_bytes().to_vec(), "USDC".as_bytes().to_vec(), 6),
 				],
-				accounts: vec![
-					(dot_asset_id, TreasuryAccount::get(), 0_0_010_000_000u128),
-					(usdt_asset_id, TreasuryAccount::get(), 0_0_010_000_000u128),
-					(usdc_asset_id, TreasuryAccount::get(), 0_0_010_000_000u128),
-				],
+				accounts: vec![],
 			},
 			parachain_info: polimec_runtime::ParachainInfoConfig { parachain_id: PARA_ID.into(), ..Default::default() },
 			session: polimec_runtime::SessionConfig {

--- a/integration-tests/src/tests/credentials.rs
+++ b/integration-tests/src/tests/credentials.rs
@@ -17,6 +17,7 @@
 use crate::*;
 use frame_support::{assert_err, assert_ok, dispatch::GetDispatchInfo, traits::tokens::currency::VestingSchedule};
 use macros::generate_accounts;
+use pallet_funding::ParticipationMode::{Classic, OTM};
 use polimec_common::credentials::{Did, InvestorType};
 use polimec_common_test_utils::{get_fake_jwt, get_mock_jwt_with_cid, get_test_jwt};
 use polimec_runtime::PLMC;

--- a/integration-tests/src/tests/defaults.rs
+++ b/integration-tests/src/tests/defaults.rs
@@ -17,8 +17,8 @@ use crate::PolimecRuntime;
 use frame_support::BoundedVec;
 pub use pallet_funding::instantiator::{BidParams, ContributionParams, UserToUSDBalance};
 use pallet_funding::{
-	AcceptedFundingAsset, BiddingTicketSizes, ContributingTicketSizes, CurrencyMetadata, PriceProviderOf,
-	ProjectMetadata, ProjectMetadataOf, TicketSize,
+	AcceptedFundingAsset, BiddingTicketSizes, ContributingTicketSizes, CurrencyMetadata, ParticipationMode,
+	PriceProviderOf, ProjectMetadata, ProjectMetadataOf, TicketSize,
 };
 use sp_arithmetic::{FixedPointNumber, Percent};
 
@@ -26,6 +26,7 @@ use macros::generate_accounts;
 use polimec_common::{ProvideAssetPrice, USD_DECIMALS, USD_UNIT};
 use polimec_runtime::{AccountId, PLMC};
 use sp_runtime::{traits::ConstU32, Perquintill};
+use ParticipationMode::{Classic, OTM};
 
 pub const IPFS_CID: &str = "QmeuJ24ffwLAZppQcgcggJs3n689bewednYkuc8Bx5Gngz";
 pub const CT_DECIMALS: u8 = 18;
@@ -54,11 +55,11 @@ pub fn ipfs_hash() -> BoundedVec<u8, ConstU32<96>> {
 pub fn default_weights() -> Vec<u8> {
 	vec![20u8, 15u8, 10u8, 25u8, 30u8]
 }
-pub fn default_bidder_multipliers() -> Vec<u8> {
-	vec![1u8, 6u8, 10u8, 8u8, 3u8]
+pub fn default_bidder_modes() -> Vec<ParticipationMode> {
+	vec![Classic(1u8), Classic(6u8), OTM, OTM, Classic(3u8)]
 }
-pub fn default_contributor_multipliers() -> Vec<u8> {
-	vec![1u8, 1u8, 1u8, 1u8, 1u8]
+pub fn default_contributor_modes() -> Vec<ParticipationMode> {
+	vec![Classic(1u8), Classic(1u8), OTM, OTM, Classic(3u8)]
 }
 
 pub fn default_project_metadata(issuer: AccountId) -> ProjectMetadataOf<polimec_runtime::Runtime> {
@@ -113,7 +114,7 @@ pub fn default_bids() -> Vec<BidParams<PolimecRuntime>> {
 		default_metadata.minimum_price,
 		default_weights(),
 		default_bidders(),
-		default_bidder_multipliers(),
+		default_bidder_modes(),
 	)
 }
 
@@ -134,7 +135,7 @@ pub fn default_community_contributions() -> Vec<ContributionParams<PolimecRuntim
 		default_metadata.minimum_price,
 		default_weights(),
 		default_community_contributors(),
-		default_contributor_multipliers(),
+		default_contributor_modes(),
 	)
 }
 
@@ -157,7 +158,7 @@ pub fn default_remainder_contributions() -> Vec<ContributionParams<PolimecRuntim
 		default_metadata.minimum_price,
 		vec![20u8, 15u8, 10u8, 25u8, 23u8, 7u8],
 		default_remainder_contributors(),
-		vec![1u8, 1u8, 1u8, 1u8, 1u8, 1u8],
+		default_contributor_modes(),
 	)
 }
 pub fn default_community_contributors() -> Vec<AccountId> {

--- a/integration-tests/src/tests/mod.rs
+++ b/integration-tests/src/tests/mod.rs
@@ -21,6 +21,7 @@ mod e2e;
 mod evaluator_slash_sideffects;
 mod governance;
 mod oracle;
+mod otm_edge_cases;
 mod reserve_backed_transfers;
 mod vest;
 mod xcm_config;

--- a/integration-tests/src/tests/otm_edge_cases.rs
+++ b/integration-tests/src/tests/otm_edge_cases.rs
@@ -1,0 +1,200 @@
+use crate::{
+	constants::PricesBuilder,
+	tests::defaults::{default_evaluations, default_project_metadata, ipfs_hash, IntegrationInstantiator},
+	*,
+};
+use frame_support::traits::fungibles::Inspect;
+use macros::generate_accounts;
+use pallet_funding::{AcceptedFundingAsset, MultiplierOf, ParticipationMode, PriceProviderOf};
+use polimec_common::{credentials::InvestorType, ProvideAssetPrice, PLMC_DECIMALS, PLMC_FOREIGN_ID, USD_UNIT};
+use polimec_common_test_utils::{generate_did_from_account, get_mock_jwt_with_cid};
+use polimec_runtime::OraclePriceProvider;
+use sp_arithmetic::{FixedPointNumber, FixedU128, Perbill};
+use sp_core::bounded_vec;
+use sp_runtime::TokenError;
+generate_accounts!(ISSUER, BOBERT);
+use pallet_funding::traits::BondingRequirementCalculation;
+
+#[test]
+fn otm_fee_below_min_amount_reverts() {
+	let mut inst = IntegrationInstantiator::new(None);
+	let issuer: PolimecAccountId = ISSUER.into();
+	let bobert: PolimecAccountId = BOBERT.into();
+
+	let prices = PricesBuilder::new()
+		.plmc(FixedU128::from_float(0.17f64))
+		.usdt(FixedU128::from_float(0.9999f64))
+		.usdc(FixedU128::from_float(1.0001f64))
+		.dot(FixedU128::from_float(4.0f64))
+		.build();
+
+	polimec::set_prices(prices);
+
+	PolimecNet::execute_with(|| {
+		let mut project_metadata = default_project_metadata(issuer.clone());
+		project_metadata.participation_currencies =
+			bounded_vec![AcceptedFundingAsset::USDT, AcceptedFundingAsset::USDC, AcceptedFundingAsset::DOT,];
+
+		let usdt_price = <PolimecRuntime as pallet_funding::Config>::PriceProvider::get_decimals_aware_price(
+			AcceptedFundingAsset::USDT.id(),
+			6,
+			6,
+		)
+		.unwrap();
+
+		let plmc_price = <PolimecRuntime as pallet_funding::Config>::PriceProvider::get_decimals_aware_price(
+			PLMC_FOREIGN_ID,
+			6,
+			PLMC_DECIMALS,
+		)
+		.unwrap();
+
+		let project_id = inst.create_community_contributing_project(
+			project_metadata.clone(),
+			issuer.clone(),
+			None,
+			default_evaluations(),
+			vec![],
+		);
+
+		let plmc_ed = inst.get_ed();
+
+		let min_usd_contribution = USD_UNIT;
+		let otm_multiplier: MultiplierOf<PolimecRuntime> = ParticipationMode::OTM.multiplier().try_into().unwrap();
+		let min_usd_bond =
+			otm_multiplier.calculate_usd_bonding_requirement::<PolimecRuntime>(min_usd_contribution).unwrap();
+		let min_plmc_bond = plmc_price.reciprocal().unwrap().saturating_mul_int(min_usd_bond);
+		let min_usd_otm_fee =
+			polimec_runtime::ProxyBonding::calculate_fee(min_plmc_bond, AcceptedFundingAsset::USDT.id()).unwrap();
+
+		let mut min_usdt_contribution = usdt_price.reciprocal().unwrap().saturating_mul_int(min_usd_contribution);
+		while usdt_price.saturating_mul_int(min_usdt_contribution) < min_usd_contribution {
+			min_usdt_contribution += 1;
+		}
+
+		let min_usdt_contribution_otm_fee = usdt_price.reciprocal().unwrap().saturating_mul_int(min_usd_otm_fee);
+
+		let usdt_min_balance = inst.execute(|| PolimecForeignAssets::minimum_balance(AcceptedFundingAsset::USDT.id()));
+
+		assert!(min_usdt_contribution_otm_fee < usdt_min_balance);
+
+		let ct_for_min_usdt_contribution =
+			PolimecFunding::funding_asset_to_ct_amount(project_id, AcceptedFundingAsset::USDT, min_usdt_contribution);
+
+		let jwt = get_mock_jwt_with_cid(
+			bobert.clone(),
+			InvestorType::Retail,
+			generate_did_from_account(bobert.clone()),
+			ipfs_hash(),
+		);
+
+		inst.mint_plmc_to(vec![(bobert.clone(), plmc_ed).into()]);
+		inst.mint_funding_asset_to(vec![(
+			bobert.clone(),
+			min_usdt_contribution + min_usdt_contribution_otm_fee + 10_000,
+			AcceptedFundingAsset::USDT.id(),
+		)
+			.into()]);
+
+		// Assert noop checks that storage had no changes
+		assert_noop!(
+			PolimecFunding::contribute(
+				PolimecOrigin::signed(bobert.clone()),
+				jwt.clone(),
+				project_id,
+				ct_for_min_usdt_contribution,
+				ParticipationMode::OTM,
+				AcceptedFundingAsset::USDT
+			),
+			TokenError::BelowMinimum
+		);
+	});
+}
+
+#[test]
+fn after_otm_fee_user_goes_under_ed_reverts() {
+	let mut inst = IntegrationInstantiator::new(None);
+	let issuer: PolimecAccountId = ISSUER.into();
+	let bobert: PolimecAccountId = BOBERT.into();
+
+	polimec::set_prices(PricesBuilder::default());
+	PolimecNet::execute_with(|| {
+		let mut project_metadata = default_project_metadata(issuer.clone());
+
+		let project_id = inst.create_community_contributing_project(
+			project_metadata.clone(),
+			issuer.clone(),
+			None,
+			default_evaluations(),
+			vec![],
+		);
+
+		let plmc_price = <PolimecRuntime as pallet_funding::Config>::PriceProvider::get_decimals_aware_price(
+			PLMC_FOREIGN_ID,
+			6,
+			PLMC_DECIMALS,
+		)
+		.unwrap();
+		let usdt_price = <PolimecRuntime as pallet_funding::Config>::PriceProvider::get_decimals_aware_price(
+			AcceptedFundingAsset::USDT.id(),
+			6,
+			6,
+		)
+		.unwrap();
+
+		let usd_contribution = 100 * USD_UNIT;
+		let otm_multiplier: MultiplierOf<PolimecRuntime> = ParticipationMode::OTM.multiplier().try_into().unwrap();
+		let usd_bond = otm_multiplier.calculate_usd_bonding_requirement::<PolimecRuntime>(usd_contribution).unwrap();
+		let plmc_bond = plmc_price.reciprocal().unwrap().saturating_mul_int(usd_bond);
+		let usd_otm_fee =
+			polimec_runtime::ProxyBonding::calculate_fee(plmc_bond, AcceptedFundingAsset::USDT.id()).unwrap();
+
+		let usdt_ed = inst.get_funding_asset_ed(AcceptedFundingAsset::USDT.id());
+		let usdt_contribution = usdt_price.reciprocal().unwrap().saturating_mul_int(usd_contribution);
+		let usdt_otm_fee = usdt_price.reciprocal().unwrap().saturating_mul_int(usd_otm_fee);
+
+		let ct_for_contribution =
+			PolimecFunding::funding_asset_to_ct_amount(project_id, AcceptedFundingAsset::USDT, usdt_contribution);
+		let jwt = get_mock_jwt_with_cid(
+			bobert.clone(),
+			InvestorType::Retail,
+			generate_did_from_account(bobert.clone()),
+			ipfs_hash(),
+		);
+
+		inst.mint_funding_asset_to(vec![(
+			bobert.clone(),
+			usdt_contribution + usdt_otm_fee,
+			AcceptedFundingAsset::USDT.id(),
+		)
+			.into()]);
+
+		assert_noop!(
+			PolimecFunding::contribute(
+				PolimecOrigin::signed(bobert.clone()),
+				jwt.clone(),
+				project_id,
+				ct_for_contribution,
+				ParticipationMode::OTM,
+				AcceptedFundingAsset::USDT,
+			),
+			pallet_funding::Error::<PolimecRuntime>::ParticipantNotEnoughFunds
+		);
+
+		inst.mint_funding_asset_to(vec![(
+			bobert.clone(),
+			usdt_ed,
+			AcceptedFundingAsset::USDT.id(),
+		)
+			.into()]);
+
+		assert_ok!(PolimecFunding::contribute(
+			PolimecOrigin::signed(bobert.clone()),
+			jwt.clone(),
+			project_id,
+			ct_for_contribution,
+			ParticipationMode::OTM,
+			AcceptedFundingAsset::USDT,
+		));
+	});
+}

--- a/pallets/funding/src/functions/4_contribution.rs
+++ b/pallets/funding/src/functions/4_contribution.rs
@@ -126,7 +126,7 @@ impl<T: Config> Pallet<T> {
 			contributor: contributor.clone(),
 			ct_amount: buyable_tokens,
 			usd_contribution_amount: ticket_size,
-			mode: mode.clone(),
+			mode,
 			funding_asset,
 			funding_asset_amount,
 			plmc_bond,

--- a/pallets/funding/src/functions/misc.rs
+++ b/pallets/funding/src/functions/misc.rs
@@ -32,7 +32,7 @@ impl<T: Config> Pallet<T> {
 		let plmc_usd_price =
 			<PriceProviderOf<T>>::get_decimals_aware_price(PLMC_FOREIGN_ID, USD_DECIMALS, PLMC_DECIMALS)
 				.ok_or(Error::<T>::PriceNotFound)?;
-		let usd_bond = multiplier.calculate_bonding_requirement::<T>(ticket_size).ok_or(Error::<T>::BadMath)?;
+		let usd_bond = multiplier.calculate_usd_bonding_requirement::<T>(ticket_size).ok_or(Error::<T>::BadMath)?;
 		plmc_usd_price
 			.reciprocal()
 			.ok_or(Error::<T>::BadMath)?
@@ -185,11 +185,8 @@ impl<T: Config> Pallet<T> {
 		asset_id: AssetIdOf<T>,
 	) -> DispatchResult {
 		let fund_account = Self::fund_account_id(project_id);
-		// Why `Preservation::Expendable`?
-		// the min_balance of funding assets (e.g USDT) are low enough so we don't expect users to care about their balance being dusted.
-		// We do think the UX would be bad if they cannot use all of their available tokens.
-		// Specially since a new funding asset account can be easily created by increasing the provider reference
-		T::FundingCurrency::transfer(asset_id, who, &fund_account, amount, Preservation::Expendable)
+
+		T::FundingCurrency::transfer(asset_id, who, &fund_account, amount, Preservation::Preserve)
 			.map_err(|_| Error::<T>::ParticipantNotEnoughFunds)?;
 
 		Ok(())

--- a/pallets/funding/src/instantiator/chain_interactions.rs
+++ b/pallets/funding/src/instantiator/chain_interactions.rs
@@ -145,7 +145,9 @@ impl<
 	pub fn mint_plmc_to(&mut self, mapping: Vec<UserToPLMCBalance<T>>) {
 		self.execute(|| {
 			for UserToPLMCBalance { account, plmc_amount } in mapping {
-				<T as Config>::NativeCurrency::mint_into(&account, plmc_amount).expect("Minting should work");
+				if plmc_amount > Zero::zero() {
+					<T as Config>::NativeCurrency::mint_into(&account, plmc_amount).expect("Minting should work");
+				}
 			}
 		});
 	}

--- a/pallets/funding/src/instantiator/tests.rs
+++ b/pallets/funding/src/instantiator/tests.rs
@@ -16,12 +16,12 @@ use sp_arithmetic::Percent;
 fn dry_run_wap() {
 	let mut inst = tests::MockInstantiator::new(Some(RefCell::new(new_test_ext())));
 
-	const ADAM: u32 = 60;
-	const TOM: u32 = 61;
-	const SOFIA: u32 = 62;
-	const FRED: u32 = 63;
-	const ANNA: u32 = 64;
-	const DAMIAN: u32 = 65;
+	const ADAM: AccountIdOf<TestRuntime> = 60;
+	const TOM: AccountIdOf<TestRuntime> = 61;
+	const SOFIA: AccountIdOf<TestRuntime> = 62;
+	const FRED: AccountIdOf<TestRuntime> = 63;
+	const ANNA: AccountIdOf<TestRuntime> = 64;
+	const DAMIAN: AccountIdOf<TestRuntime> = 65;
 
 	let accounts = vec![ADAM, TOM, SOFIA, FRED, ANNA, DAMIAN];
 
@@ -50,7 +50,7 @@ fn dry_run_wap() {
 			phantom: Default::default(),
 		},
 		participation_currencies: vec![AcceptedFundingAsset::USDT].try_into().unwrap(),
-		funding_destination_account: 0u32,
+		funding_destination_account: 0,
 		policy_ipfs_cid: Some(metadata_hash),
 	};
 
@@ -98,12 +98,12 @@ fn dry_run_wap() {
 fn find_bucket_for_wap() {
 	let mut inst = tests::MockInstantiator::new(Some(RefCell::new(new_test_ext())));
 
-	const ADAM: u32 = 60;
-	const TOM: u32 = 61;
-	const SOFIA: u32 = 62;
-	const FRED: u32 = 63;
-	const ANNA: u32 = 64;
-	const DAMIAN: u32 = 65;
+	const ADAM: AccountIdOf<TestRuntime> = 60;
+	const TOM: AccountIdOf<TestRuntime> = 61;
+	const SOFIA: AccountIdOf<TestRuntime> = 62;
+	const FRED: AccountIdOf<TestRuntime> = 63;
+	const ANNA: AccountIdOf<TestRuntime> = 64;
+	const DAMIAN: AccountIdOf<TestRuntime> = 65;
 
 	let accounts = vec![ADAM, TOM, SOFIA, FRED, ANNA, DAMIAN];
 
@@ -132,7 +132,7 @@ fn find_bucket_for_wap() {
 			phantom: Default::default(),
 		},
 		participation_currencies: vec![AcceptedFundingAsset::USDT].try_into().unwrap(),
-		funding_destination_account: 0u32,
+		funding_destination_account: 0,
 		policy_ipfs_cid: Some(metadata_hash),
 	};
 

--- a/pallets/funding/src/instantiator/types.rs
+++ b/pallets/funding/src/instantiator/types.rs
@@ -246,57 +246,32 @@ pub struct BidParams<T: Config> {
 	pub asset: AcceptedFundingAsset,
 }
 impl<T: Config> BidParams<T> {
-	pub fn new(bidder: AccountIdOf<T>, amount: Balance, multiplier: u8, asset: AcceptedFundingAsset) -> Self {
-		Self { bidder, amount, multiplier: multiplier.try_into().map_err(|_| ()).unwrap(), asset }
+	pub fn new(bidder: AccountIdOf<T>, amount: Balance, mode: ParticipationMode, asset: AcceptedFundingAsset) -> Self {
+		Self { bidder, amount, mode, asset }
 	}
 
 	pub fn new_with_defaults(bidder: AccountIdOf<T>, amount: Balance) -> Self {
-		Self {
-			bidder,
-			amount,
-			multiplier: 1u8.try_into().unwrap_or_else(|_| panic!("multiplier could not be created from 1u8")),
-			asset: AcceptedFundingAsset::USDT,
-		}
+		Self { bidder, amount, mode: ParticipationMode::Classic(1u8), asset: AcceptedFundingAsset::USDT }
 	}
 }
 impl<T: Config> From<(AccountIdOf<T>, Balance)> for BidParams<T> {
 	fn from((bidder, amount): (AccountIdOf<T>, Balance)) -> Self {
-		Self {
-			bidder,
-			amount,
-			multiplier: 1u8.try_into().unwrap_or_else(|_| panic!("multiplier could not be created from 1u8")),
-			asset: AcceptedFundingAsset::USDT,
-		}
+		Self { bidder, amount, mode: ParticipationMode::Classic(1u8), asset: AcceptedFundingAsset::USDT }
 	}
 }
-impl<T: Config> From<(AccountIdOf<T>, Balance, u8)> for BidParams<T> {
-	fn from((bidder, amount, multiplier): (AccountIdOf<T>, Balance, u8)) -> Self {
-		Self {
-			bidder,
-			amount,
-			multiplier: multiplier.try_into().unwrap_or_else(|_| panic!("Failed to create multiplier")),
-			asset: AcceptedFundingAsset::USDT,
-		}
+impl<T: Config> From<(AccountIdOf<T>, Balance, ParticipationMode)> for BidParams<T> {
+	fn from((bidder, amount, mode): (AccountIdOf<T>, Balance, ParticipationMode)) -> Self {
+		Self { bidder, amount, mode, asset: AcceptedFundingAsset::USDT }
 	}
 }
-impl<T: Config> From<(AccountIdOf<T>, Balance, u8, AcceptedFundingAsset)> for BidParams<T> {
-	fn from((bidder, amount, multiplier, asset): (AccountIdOf<T>, Balance, u8, AcceptedFundingAsset)) -> Self {
-		Self {
-			bidder,
-			amount,
-			multiplier: multiplier.try_into().unwrap_or_else(|_| panic!("Failed to create multiplier")),
-			asset,
-		}
+impl<T: Config> From<(AccountIdOf<T>, Balance, ParticipationMode, AcceptedFundingAsset)> for BidParams<T> {
+	fn from((bidder, amount, mode, asset): (AccountIdOf<T>, Balance, ParticipationMode, AcceptedFundingAsset)) -> Self {
+		Self { bidder, amount, mode, asset }
 	}
 }
 impl<T: Config> From<(AccountIdOf<T>, Balance, AcceptedFundingAsset)> for BidParams<T> {
 	fn from((bidder, amount, asset): (AccountIdOf<T>, Balance, AcceptedFundingAsset)) -> Self {
-		Self {
-			bidder,
-			amount,
-			multiplier: 1u8.try_into().unwrap_or_else(|_| panic!("multiplier could not be created from 1u8")),
-			asset,
-		}
+		Self { bidder, amount, mode: ParticipationMode::Classic(1u8), asset }
 	}
 }
 

--- a/pallets/funding/src/mock.rs
+++ b/pallets/funding/src/mock.rs
@@ -437,7 +437,8 @@ impl Config for TestRuntime {
 }
 
 parameter_types! {
-	pub const FeePercentage: Perbill = Perbill::from_percent(5);
+	// Means a USD Ticket fee of 1.5%, since the FeePercentage is applied on the PLMC bond with multiplier 5.
+	pub FeePercentage: Perbill = Perbill::from_rational(75u32, 100u32);
 	pub const FeeRecipient: AccountId = 80085;
 	pub const RootId: PalletId = PalletId(*b"treasury");
 }
@@ -484,7 +485,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 				(<TestRuntime as Config>::PalletId::get().into_account_truncating(), ed),
 				(<TestRuntime as Config>::ContributionTreasury::get(), ed),
 				(<TestRuntime as Config>::BlockchainOperationTreasury::get(), ed),
-				/// Treasury account needs PLMC for the One Token Model participations
+				// Treasury account needs PLMC for the One Token Model participations
 				(ProxyBondingTreasuryAccount::get(), 1_000_000 * PLMC),
 				(FeeRecipient::get(), ed),
 			],
@@ -496,19 +497,19 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 					<TestRuntime as Config>::PalletId::get().into_account_truncating(),
 					// asset is sufficient, i.e. participants can hold only this asset to participate with OTM
 					true,
-					10,
+					70_000,
 				),
 				(
 					AcceptedFundingAsset::USDC.id(),
 					<TestRuntime as Config>::PalletId::get().into_account_truncating(),
 					true,
-					10,
+					70_000,
 				),
 				(
 					AcceptedFundingAsset::DOT.id(),
 					<TestRuntime as Config>::PalletId::get().into_account_truncating(),
 					true,
-					10,
+					100_000_000,
 				),
 			],
 			metadata: vec![

--- a/pallets/funding/src/tests/2_evaluation.rs
+++ b/pallets/funding/src/tests/2_evaluation.rs
@@ -764,7 +764,7 @@ mod evaluate_extrinsic {
 			let mut inst = MockInstantiator::new(Some(RefCell::new(new_test_ext())));
 			let project_metadata = default_project_metadata(ISSUER_1);
 			let evaluations = (0u32..<TestRuntime as Config>::MaxEvaluationsPerProject::get())
-				.map(|i| UserToUSDBalance::<TestRuntime>::new(i as u32 + 420u32, (100u128 * CT_UNIT).into()))
+				.map(|i| UserToUSDBalance::<TestRuntime>::new(i as u64 + 420, (100u128 * CT_UNIT).into()))
 				.collect_vec();
 			let failing_evaluation = UserToUSDBalance::new(EVALUATOR_1, 1000 * CT_UNIT);
 

--- a/pallets/funding/src/tests/misc.rs
+++ b/pallets/funding/src/tests/misc.rs
@@ -66,23 +66,23 @@ mod helper_functions {
 	#[test]
 	fn calculate_evaluation_plmc_spent() {
 		let mut inst = MockInstantiator::new(Some(RefCell::new(new_test_ext())));
-		const EVALUATOR_1: AccountIdOf<TestRuntime> = 1u32;
+		const EVALUATOR_1: AccountIdOf<TestRuntime> = 1;
 		const USD_AMOUNT_1: Balance = 150_000 * USD_UNIT;
 		const EXPECTED_PLMC_AMOUNT_1: f64 = 17_857.1428571428f64;
 
-		const EVALUATOR_2: AccountIdOf<TestRuntime> = 2u32;
+		const EVALUATOR_2: AccountIdOf<TestRuntime> = 2;
 		const USD_AMOUNT_2: Balance = 50_000 * USD_UNIT;
 		const EXPECTED_PLMC_AMOUNT_2: f64 = 5_952.3809523809f64;
 
-		const EVALUATOR_3: AccountIdOf<TestRuntime> = 3u32;
+		const EVALUATOR_3: AccountIdOf<TestRuntime> = 3;
 		const USD_AMOUNT_3: Balance = 75_000 * USD_UNIT;
 		const EXPECTED_PLMC_AMOUNT_3: f64 = 8_928.5714285714f64;
 
-		const EVALUATOR_4: AccountIdOf<TestRuntime> = 4u32;
+		const EVALUATOR_4: AccountIdOf<TestRuntime> = 4;
 		const USD_AMOUNT_4: Balance = 100 * USD_UNIT;
 		const EXPECTED_PLMC_AMOUNT_4: f64 = 11.9047619047f64;
 
-		const EVALUATOR_5: AccountIdOf<TestRuntime> = 5u32;
+		const EVALUATOR_5: AccountIdOf<TestRuntime> = 5;
 
 		// 123.7 USD
 		const USD_AMOUNT_5: Balance = 1237 * USD_UNIT / 10;
@@ -139,11 +139,11 @@ mod helper_functions {
 		const CT_AMOUNT_4: u128 = 6000 * CT_UNIT;
 		const CT_AMOUNT_5: u128 = 2000 * CT_UNIT;
 
-		let bid_1 = BidParams::new(BIDDER_1, CT_AMOUNT_1, 1u8, AcceptedFundingAsset::USDT);
-		let bid_2 = BidParams::new(BIDDER_2, CT_AMOUNT_2, 1u8, AcceptedFundingAsset::USDT);
-		let bid_3 = BidParams::new(BIDDER_1, CT_AMOUNT_3, 1u8, AcceptedFundingAsset::USDT);
-		let bid_4 = BidParams::new(BIDDER_3, CT_AMOUNT_4, 1u8, AcceptedFundingAsset::USDT);
-		let bid_5 = BidParams::new(BIDDER_4, CT_AMOUNT_5, 1u8, AcceptedFundingAsset::USDT);
+		let bid_1 = BidParams::new(BIDDER_1, CT_AMOUNT_1, ParticipationMode::Classic(1u8), AcceptedFundingAsset::USDT);
+		let bid_2 = BidParams::new(BIDDER_2, CT_AMOUNT_2, ParticipationMode::Classic(1u8), AcceptedFundingAsset::USDT);
+		let bid_3 = BidParams::new(BIDDER_1, CT_AMOUNT_3, ParticipationMode::Classic(1u8), AcceptedFundingAsset::USDT);
+		let bid_4 = BidParams::new(BIDDER_3, CT_AMOUNT_4, ParticipationMode::Classic(1u8), AcceptedFundingAsset::USDT);
+		let bid_5 = BidParams::new(BIDDER_4, CT_AMOUNT_5, ParticipationMode::Classic(1u8), AcceptedFundingAsset::USDT);
 
 		// post bucketing, the bids look like this:
 		// (BIDDER_1, 5k) - (BIDDER_2, 40k) - (BIDDER_1, 5k) - (BIDDER_1, 5k) - (BIDDER_3 - 5k) - (BIDDER_3 - 1k) - (BIDDER_4 - 2k)
@@ -246,31 +246,31 @@ mod helper_functions {
 		const PLMC_PRICE: f64 = 8.4f64;
 		const CT_PRICE: f64 = 16.32f64;
 
-		const CONTRIBUTOR_1: AccountIdOf<TestRuntime> = 1u32;
+		const CONTRIBUTOR_1: AccountIdOf<TestRuntime> = 1;
 		const TOKEN_AMOUNT_1: u128 = 120 * CT_UNIT;
 		const MULTIPLIER_1: u8 = 1u8;
 		const _TICKET_SIZE_USD_1: u128 = 1_958_4_000_000_000_u128;
 		const EXPECTED_PLMC_AMOUNT_1: f64 = 233.1_428_571_428f64;
 
-		const CONTRIBUTOR_2: AccountIdOf<TestRuntime> = 2u32;
+		const CONTRIBUTOR_2: AccountIdOf<TestRuntime> = 2;
 		const TOKEN_AMOUNT_2: u128 = 5023 * CT_UNIT;
 		const MULTIPLIER_2: u8 = 2u8;
 		const _TICKET_SIZE_USD_2: u128 = 81_975_3_600_000_000_u128;
 		const EXPECTED_PLMC_AMOUNT_2: f64 = 4_879.4_857_142_857f64;
 
-		const CONTRIBUTOR_3: AccountIdOf<TestRuntime> = 3u32;
+		const CONTRIBUTOR_3: AccountIdOf<TestRuntime> = 3;
 		const TOKEN_AMOUNT_3: u128 = 20_000 * CT_UNIT;
 		const MULTIPLIER_3: u8 = 17u8;
 		const _TICKET_SIZE_USD_3: u128 = 326_400_0_000_000_000_u128;
 		const EXPECTED_PLMC_AMOUNT_3: f64 = 2_285.7_142_857_142f64;
 
-		const CONTRIBUTOR_4: AccountIdOf<TestRuntime> = 4u32;
+		const CONTRIBUTOR_4: AccountIdOf<TestRuntime> = 4;
 		const TOKEN_AMOUNT_4: u128 = 1_000_000 * CT_UNIT;
 		const MULTIPLIER_4: u8 = 25u8;
 		const _TICKET_SIZE_4: u128 = 16_320_000_0_000_000_000_u128;
 		const EXPECTED_PLMC_AMOUNT_4: f64 = 77_714.2_857_142_857f64;
 
-		const CONTRIBUTOR_5: AccountIdOf<TestRuntime> = 5u32;
+		const CONTRIBUTOR_5: AccountIdOf<TestRuntime> = 5;
 		// 0.1233 CTs
 		const TOKEN_AMOUNT_5: u128 = 1_233 * CT_UNIT / 10_000;
 		const MULTIPLIER_5: u8 = 10u8;

--- a/pallets/funding/src/tests/mod.rs
+++ b/pallets/funding/src/tests/mod.rs
@@ -18,6 +18,7 @@ use sp_arithmetic::{traits::Zero, Percent, Perquintill};
 use sp_runtime::TokenError;
 use sp_std::cell::RefCell;
 use std::iter::zip;
+use ParticipationMode::{Classic, OTM};
 
 #[path = "1_application.rs"]
 mod application;
@@ -198,20 +199,20 @@ pub mod defaults {
 
 	pub fn default_bids() -> Vec<BidParams<TestRuntime>> {
 		vec![
-			BidParams::new(BIDDER_1, 400_000 * CT_UNIT, 1u8, AcceptedFundingAsset::USDT),
-			BidParams::new(BIDDER_2, 50_000 * CT_UNIT, 1u8, AcceptedFundingAsset::USDT),
+			BidParams::new(BIDDER_1, 400_000 * CT_UNIT, ParticipationMode::Classic(1u8), AcceptedFundingAsset::USDT),
+			BidParams::new(BIDDER_2, 50_000 * CT_UNIT, ParticipationMode::OTM, AcceptedFundingAsset::USDT),
 		]
 	}
 
 	pub fn knowledge_hub_bids() -> Vec<BidParams<TestRuntime>> {
 		// This should reflect the bidding currency, which currently is USDT
 		vec![
-			BidParams::new(BIDDER_1, 10_000 * CT_UNIT, 1u8, AcceptedFundingAsset::USDT),
-			BidParams::new(BIDDER_2, 20_000 * CT_UNIT, 1u8, AcceptedFundingAsset::USDT),
-			BidParams::new(BIDDER_3, 20_000 * CT_UNIT, 1u8, AcceptedFundingAsset::USDT),
-			BidParams::new(BIDDER_4, 10_000 * CT_UNIT, 1u8, AcceptedFundingAsset::USDT),
-			BidParams::new(BIDDER_5, 5_000 * CT_UNIT, 1u8, AcceptedFundingAsset::USDT),
-			BidParams::new(BIDDER_6, 5_000 * CT_UNIT, 1u8, AcceptedFundingAsset::USDT),
+			BidParams::new(BIDDER_1, 10_000 * CT_UNIT, ParticipationMode::Classic(1u8), AcceptedFundingAsset::USDT),
+			BidParams::new(BIDDER_2, 20_000 * CT_UNIT, ParticipationMode::Classic(1u8), AcceptedFundingAsset::USDT),
+			BidParams::new(BIDDER_3, 20_000 * CT_UNIT, ParticipationMode::Classic(1u8), AcceptedFundingAsset::USDT),
+			BidParams::new(BIDDER_4, 10_000 * CT_UNIT, ParticipationMode::Classic(1u8), AcceptedFundingAsset::USDT),
+			BidParams::new(BIDDER_5, 5_000 * CT_UNIT, ParticipationMode::Classic(1u8), AcceptedFundingAsset::USDT),
+			BidParams::new(BIDDER_6, 5_000 * CT_UNIT, ParticipationMode::Classic(1u8), AcceptedFundingAsset::USDT),
 		]
 	}
 
@@ -226,27 +227,17 @@ pub mod defaults {
 			ContributionParams::new(
 				BUYER_2,
 				130_000 * CT_UNIT,
-				ParticipationMode::Classic(1u8),
+				ParticipationMode::Classic(5u8),
 				AcceptedFundingAsset::USDT,
 			),
-			ContributionParams::new(
-				BUYER_3,
-				30_000 * CT_UNIT,
-				ParticipationMode::Classic(1u8),
-				AcceptedFundingAsset::USDT,
-			),
+			ContributionParams::new(BUYER_3, 30_000 * CT_UNIT, ParticipationMode::OTM, AcceptedFundingAsset::USDT),
 			ContributionParams::new(
 				BUYER_4,
 				210_000 * CT_UNIT,
-				ParticipationMode::Classic(1u8),
+				ParticipationMode::Classic(3u8),
 				AcceptedFundingAsset::USDT,
 			),
-			ContributionParams::new(
-				BUYER_5,
-				10_000 * CT_UNIT,
-				ParticipationMode::Classic(1u8),
-				AcceptedFundingAsset::USDT,
-			),
+			ContributionParams::new(BUYER_5, 10_000 * CT_UNIT, ParticipationMode::OTM, AcceptedFundingAsset::USDT),
 		]
 	}
 
@@ -264,12 +255,7 @@ pub mod defaults {
 				ParticipationMode::Classic(1u8),
 				AcceptedFundingAsset::USDT,
 			),
-			ContributionParams::new(
-				BIDDER_1,
-				30_000 * CT_UNIT,
-				ParticipationMode::Classic(1u8),
-				AcceptedFundingAsset::USDT,
-			),
+			ContributionParams::new(BIDDER_1, 30_000 * CT_UNIT, ParticipationMode::OTM, AcceptedFundingAsset::USDT),
 		]
 	}
 
@@ -340,17 +326,17 @@ pub mod defaults {
 	pub fn default_bidders() -> Vec<AccountId> {
 		vec![BIDDER_1, BIDDER_2, BIDDER_3, BIDDER_4, BIDDER_5]
 	}
-	pub fn default_multipliers() -> Vec<u8> {
-		vec![1u8, 1u8, 1u8, 1u8, 1u8]
+	pub fn default_modes() -> Vec<ParticipationMode> {
+		vec![Classic(1u8), Classic(1u8), Classic(1u8), OTM, OTM]
 	}
-	pub fn default_bidder_multipliers() -> Vec<u8> {
-		vec![10u8, 3u8, 8u8, 1u8, 4u8]
+	pub fn default_bidder_modes() -> Vec<ParticipationMode> {
+		vec![Classic(10u8), OTM, Classic(8u8), OTM, Classic(4u8)]
 	}
-	pub fn default_community_contributor_multipliers() -> Vec<u8> {
-		vec![1u8, 1u8, 1u8, 1u8, 1u8]
+	pub fn default_community_contributor_modes() -> Vec<ParticipationMode> {
+		vec![Classic(1u8), Classic(1u8), OTM, Classic(1u8), OTM]
 	}
-	pub fn default_remainder_contributor_multipliers() -> Vec<u8> {
-		vec![1u8, 1u8, 1u8, 1u8, 1u8]
+	pub fn default_remainder_contributor_modes() -> Vec<ParticipationMode> {
+		vec![Classic(1u8), Classic(1u8), Classic(1u8), OTM, Classic(1u8)]
 	}
 
 	pub fn default_community_contributors() -> Vec<AccountId> {
@@ -385,14 +371,14 @@ pub mod defaults {
 			min_price,
 			default_weights(),
 			default_bidders(),
-			default_multipliers(),
+			default_modes(),
 		);
 		let contributions = instantiator.generate_contributions_from_total_usd(
 			Percent::from_percent(50u8) * usd_to_reach,
 			min_price,
 			default_weights(),
 			default_community_contributors(),
-			default_multipliers(),
+			default_modes(),
 		);
 		instantiator.create_finished_project(project_metadata, ISSUER_1, None, evaluations, bids, contributions, vec![])
 	}
@@ -406,7 +392,7 @@ pub mod defaults {
 			percent,
 			default_weights(),
 			default_bidders(),
-			default_bidder_multipliers(),
+			default_bidder_modes(),
 		)
 	}
 
@@ -419,7 +405,7 @@ pub mod defaults {
 			percent,
 			default_weights(),
 			default_community_contributors(),
-			default_community_contributor_multipliers(),
+			default_community_contributor_modes(),
 		)
 	}
 
@@ -432,7 +418,7 @@ pub mod defaults {
 			percent,
 			default_weights(),
 			default_remainder_contributors(),
-			default_remainder_contributor_multipliers(),
+			default_remainder_contributor_modes(),
 		)
 	}
 }
@@ -452,14 +438,14 @@ pub fn create_project_with_funding_percentage(
 		min_price,
 		default_weights(),
 		default_bidders(),
-		default_multipliers(),
+		default_modes(),
 	);
 	let contributions = inst.generate_contributions_from_total_usd(
 		Percent::from_percent(50u8) * percentage_funded_usd,
 		min_price,
 		default_weights(),
 		default_community_contributors(),
-		default_multipliers(),
+		default_modes(),
 	);
 	let project_id =
 		inst.create_finished_project(project_metadata, ISSUER_1, None, evaluations, bids, contributions, vec![]);
@@ -482,7 +468,7 @@ pub fn create_finished_project_with_usd_raised(
 	usd_raised: Balance,
 	usd_target: Balance,
 ) -> (MockInstantiator, ProjectId) {
-	let issuer = inst.get_new_nonce() as u32;
+	let issuer = inst.get_new_nonce();
 	let mut project_metadata = default_project_metadata(issuer);
 	project_metadata.total_allocation_size =
 		project_metadata.minimum_price.reciprocal().unwrap().saturating_mul_int(usd_target);
@@ -505,7 +491,7 @@ pub fn create_finished_project_with_usd_raised(
 
 	let evaluations = default_evaluations();
 
-	let bids = inst.generate_bids_that_take_price_to(project_metadata.clone(), required_price, 420, |acc| acc + 1u32);
+	let bids = inst.generate_bids_that_take_price_to(project_metadata.clone(), required_price, 420, |acc| acc + 1);
 
 	let project_id = inst.create_community_contributing_project(project_metadata, issuer, None, evaluations, bids);
 
@@ -520,7 +506,7 @@ pub fn create_finished_project_with_usd_raised(
 		wap,
 		default_weights(),
 		default_community_contributors(),
-		default_multipliers(),
+		default_modes(),
 	);
 	let plmc_required = inst.calculate_contributed_plmc_spent(community_contributions.clone(), required_price, true);
 	let usdt_required = inst.calculate_contributed_funding_asset_spent(community_contributions.clone(), required_price);

--- a/pallets/funding/src/tests/runtime_api.rs
+++ b/pallets/funding/src/tests/runtime_api.rs
@@ -363,7 +363,7 @@ fn funding_asset_to_ct_amount() {
 		PriceProviderOf::<TestRuntime>::calculate_decimals_aware_price(new_price, USD_DECIMALS, CT_DECIMALS).unwrap();
 
 	let bids =
-		inst.generate_bids_that_take_price_to(project_metadata_2.clone(), decimal_aware_price, 420u32, |acc| acc + 1);
+		inst.generate_bids_that_take_price_to(project_metadata_2.clone(), decimal_aware_price, 420, |acc| acc + 1);
 	let project_id_2 = inst.create_community_contributing_project(
 		project_metadata_2.clone(),
 		ISSUER_2,
@@ -403,7 +403,7 @@ fn funding_asset_to_ct_amount() {
 	let bids = inst.generate_bids_from_bucket(
 		project_metadata_3.clone(),
 		bucket,
-		420u32,
+		420,
 		|acc| acc + 1,
 		AcceptedFundingAsset::USDT,
 	);
@@ -478,9 +478,9 @@ fn get_next_vesting_schedule_merge_candidates() {
 		UserToUSDBalance::new(BIDDER_1, 320_000 * USD_UNIT),
 	];
 	let bids = vec![
-		BidParams::new(BIDDER_1, 50_000 * CT_UNIT, 10u8, AcceptedFundingAsset::USDT),
-		BidParams::new(BIDDER_1, 400_000 * CT_UNIT, 5u8, AcceptedFundingAsset::USDT),
-		BidParams::new(BIDDER_2, 50_000 * CT_UNIT, 1u8, AcceptedFundingAsset::USDT),
+		BidParams::new(BIDDER_1, 50_000 * CT_UNIT, ParticipationMode::Classic(10u8), AcceptedFundingAsset::USDT),
+		BidParams::new(BIDDER_1, 400_000 * CT_UNIT, ParticipationMode::Classic(5u8), AcceptedFundingAsset::USDT),
+		BidParams::new(BIDDER_2, 50_000 * CT_UNIT, ParticipationMode::Classic(1u8), AcceptedFundingAsset::USDT),
 	];
 	let remaining_contributions = vec![
 		ContributionParams::new(BIDDER_1, 1_000 * CT_UNIT, ParticipationMode::Classic(5u8), AcceptedFundingAsset::USDT),
@@ -564,8 +564,8 @@ fn all_project_participations_by_did() {
 		UserToUSDBalance::new(EVALUATOR_3, 320_000 * USD_UNIT),
 	];
 	let bids = vec![
-		BidParams::new(BIDDER_1, 400_000 * CT_UNIT, 1u8, AcceptedFundingAsset::USDT),
-		BidParams::new(BIDDER_2, 50_000 * CT_UNIT, 1u8, AcceptedFundingAsset::USDT),
+		BidParams::new(BIDDER_1, 400_000 * CT_UNIT, ParticipationMode::Classic(1u8), AcceptedFundingAsset::USDT),
+		BidParams::new(BIDDER_2, 50_000 * CT_UNIT, ParticipationMode::Classic(1u8), AcceptedFundingAsset::USDT),
 	];
 	let community_contributions = vec![
 		ContributionParams::new(BUYER_1, 50_000 * CT_UNIT, ParticipationMode::Classic(1u8), AcceptedFundingAsset::USDT),
@@ -657,15 +657,8 @@ fn all_project_participations_by_did() {
 	for bid in bids[1..].to_vec() {
 		let jwt = get_mock_jwt_with_cid(bid.bidder, InvestorType::Institutional, did_user.clone(), cid.clone());
 		inst.execute(|| {
-			PolimecFunding::bid(
-				RuntimeOrigin::signed(bid.bidder),
-				jwt,
-				project_id,
-				bid.amount,
-				bid.multiplier,
-				bid.asset,
-			)
-			.unwrap();
+			PolimecFunding::bid(RuntimeOrigin::signed(bid.bidder), jwt, project_id, bid.amount, bid.mode, bid.asset)
+				.unwrap();
 		});
 	}
 

--- a/pallets/funding/src/traits.rs
+++ b/pallets/funding/src/traits.rs
@@ -20,7 +20,7 @@ use frame_system::pallet_prelude::BlockNumberFor;
 use sp_runtime::DispatchError;
 
 pub trait BondingRequirementCalculation {
-	fn calculate_bonding_requirement<T: Config>(&self, ticket_size: Balance) -> Option<Balance>;
+	fn calculate_usd_bonding_requirement<T: Config>(&self, ticket_size: Balance) -> Option<Balance>;
 }
 
 pub trait VestingDurationCalculation {

--- a/pallets/funding/src/types.rs
+++ b/pallets/funding/src/types.rs
@@ -66,9 +66,9 @@ pub mod config {
 	}
 
 	impl BondingRequirementCalculation for Multiplier {
-		fn calculate_bonding_requirement<T: Config>(&self, ticket_size: Balance) -> Option<Balance> {
+		fn calculate_usd_bonding_requirement<T: Config>(&self, usd_ticket_size: Balance) -> Option<Balance> {
 			let balance_multiplier = Balance::from(self.0);
-			ticket_size.checked_div(balance_multiplier)
+			usd_ticket_size.checked_div(balance_multiplier)
 		}
 	}
 
@@ -823,8 +823,8 @@ pub mod inner {
 
 pub mod extrinsic {
 	use crate::{
-		AcceptedFundingAsset, AccountIdOf, Balance, Config, MultiplierOf, ParticipationMode, PriceOf, ProjectDetailsOf,
-		ProjectId, TicketSize,
+		AcceptedFundingAsset, AccountIdOf, Balance, Config, ParticipationMode, PriceOf, ProjectDetailsOf, ProjectId,
+		TicketSize,
 	};
 	use frame_system::pallet_prelude::BlockNumberFor;
 	use polimec_common::credentials::{Cid, Did, InvestorType};

--- a/pallets/on-slash-vesting/src/mock.rs
+++ b/pallets/on-slash-vesting/src/mock.rs
@@ -7,7 +7,7 @@ use frame_support::{
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
-use sp_runtime::traits::{ConvertInto, Identity};
+use sp_runtime::traits::ConvertInto;
 
 frame_support::construct_runtime!(
 	pub enum TestRuntime {
@@ -82,11 +82,6 @@ pub struct ExtBuilder {
 }
 
 impl ExtBuilder {
-	pub fn existential_deposit(mut self, existential_deposit: u128) -> Self {
-		self.existential_deposit = existential_deposit;
-		self
-	}
-
 	pub fn build(self) -> sp_io::TestExternalities {
 		EXISTENTIAL_DEPOSIT.with(|v| *v.borrow_mut() = self.existential_deposit);
 		let mut t = frame_system::GenesisConfig::<TestRuntime>::default().build_storage().unwrap();

--- a/pallets/on-slash-vesting/src/test.rs
+++ b/pallets/on-slash-vesting/src/test.rs
@@ -2,7 +2,7 @@ extern crate alloc;
 use super::{mock::*, *};
 use frame_support::{
 	assert_ok,
-	traits::tokens::fungible::{BalancedHold, Inspect, Mutate, MutateHold},
+	traits::tokens::fungible::{BalancedHold, Mutate, MutateHold},
 };
 use mock::{Balances as PalletBalances, System as PalletSystem, Vesting as PalletVesting};
 use pallet_balances::AccountData;
@@ -25,7 +25,7 @@ fn one_schedule() {
 		assert_eq!(PalletBalances::usable_balance(1), 20);
 
 		// Slash 30
-		<PalletBalances as BalancedHold<u64>>::slash(&MockRuntimeHoldReason::Reason, &1u64, 30u128);
+		let _ = <PalletBalances as BalancedHold<u64>>::slash(&MockRuntimeHoldReason::Reason, &1u64, 30u128);
 		<PalletVesting as OnSlash<u64, u128>>::on_slash(&1, 30);
 
 		// After calling on_slash, the previously unlocked 20 should be available again
@@ -65,7 +65,7 @@ fn multiple_schedules() {
 		assert_ok!(PalletVesting::vest(RuntimeOrigin::signed(1)));
 		assert_eq!(PalletBalances::usable_balance(1), 200);
 
-		<PalletBalances as BalancedHold<u64>>::slash(&MockRuntimeHoldReason::Reason, &1u64, 65u128);
+		let _ = <PalletBalances as BalancedHold<u64>>::slash(&MockRuntimeHoldReason::Reason, &1u64, 65u128);
 		<PalletVesting as OnSlash<u64, u128>>::on_slash(&1, 65);
 
 		let schedules = <pallet_vesting::Vesting<TestRuntime>>::get(1).unwrap().to_vec();

--- a/pallets/proxy-bonding/Cargo.toml
+++ b/pallets/proxy-bonding/Cargo.toml
@@ -21,6 +21,7 @@ polimec-common.workspace = true
 parity-scale-codec.workspace = true
 scale-info.workspace = true
 serde = { workspace = true, features = ["derive"] }
+sp-core.workspace = true
 
 [dev-dependencies]
 sp-io.workspace = true

--- a/pallets/proxy-bonding/src/functions.rs
+++ b/pallets/proxy-bonding/src/functions.rs
@@ -1,13 +1,10 @@
 use crate::{AccountIdOf, AssetId, BalanceOf, Config, Error, Pallet, PriceProviderOf, ReleaseType, Releases};
-use frame_support::{
-	ensure,
-	traits::{
-		fungible,
-		fungible::{Inspect, Mutate, MutateHold},
-		fungibles,
-		fungibles::Mutate as FungiblesMutate,
-		tokens::{Fortitude, Precision, Preservation},
-	},
+use frame_support::traits::{
+	fungible,
+	fungible::{Inspect, Mutate, MutateHold},
+	fungibles,
+	fungibles::Mutate as FungiblesMutate,
+	tokens::{Fortitude, Precision, Preservation},
 };
 use frame_system::pallet_prelude::BlockNumberFor;
 use polimec_common::ProvideAssetPrice;
@@ -91,19 +88,16 @@ impl<T: Config> Pallet<T> {
 		Releases::<T>::insert(derivation_path, hold_reason, release_type);
 	}
 
-	/// Refund the fee paid by a user to lock up some treasury tokens. It is this function's caller responsibility to ensure that the fee is not refunded twice.
+	/// Refund the fee paid by a user to lock up some treasury tokens. It is this function's caller responsibility to
+	/// ensure that the fee should be refunded, and is not refunded twice
 	pub fn refund_fee(
 		derivation_path: u32,
-		hold_reason: T::RuntimeHoldReason,
 		account: &T::AccountId,
 		bond_amount: BalanceOf<T>,
 		fee_asset: AssetId,
 	) -> Result<(), DispatchError> {
 		let bonding_account: AccountIdOf<T> = T::RootId::get().into_sub_account_truncating(derivation_path);
 		let fee_in_fee_asset = Self::calculate_fee(bond_amount, fee_asset)?;
-		let release_type = Releases::<T>::get(derivation_path, hold_reason).ok_or(Error::<T>::ReleaseTypeNotSet)?;
-
-		ensure!(release_type == ReleaseType::Refunded, Error::<T>::FeeRefundDisallowed);
 
 		// We know this fee token account is existing thanks to the provider reference of the ED of the native asset, so we can fully move all the funds.
 		// FYI same cannot be said of the `account`. We assume they only hold the fee token so their fee asset balance must not go below the min_balance.

--- a/pallets/proxy-bonding/src/tests.rs
+++ b/pallets/proxy-bonding/src/tests.rs
@@ -149,7 +149,7 @@ fn refunded_outcome() {
 			Error::<TestRuntime>::FeeToRecipientDisallowed
 		);
 
-		assert_ok!(ProxyBonding::refund_fee(derivation_path, hold_reason.clone(), user, bond_amount, fee_asset));
+		assert_ok!(ProxyBonding::refund_fee(derivation_path, &user, bond_amount, fee_asset));
 		assert_eq!(<Assets as FungiblesInspect<u64>>::balance(fee_asset, &user), 100 + expected_fee);
 	});
 }

--- a/runtimes/polimec/Cargo.toml
+++ b/runtimes/polimec/Cargo.toml
@@ -25,8 +25,8 @@ scale-info = { workspace= true, default-features = false, features = [
 	"derive",
 ] }
 
-# Uncomment this to see variables instead of <wasm:stripped> in the console output
-# sp-debug-derive = { workspace = true, features = ["force-debug"]}
+# Uncomment this and the std feature below to see variables instead of <wasm:stripped> in the console output
+#sp-debug-derive = { workspace = true, features = ["force-debug"]}
 
 
 # Polimec specific
@@ -175,7 +175,7 @@ std = [
 	"sp-block-builder/std",
 	"sp-consensus-aura/std",
 	"sp-core/std",
-	# "sp-debug-derive/std",
+#	"sp-debug-derive/std",
 	"sp-genesis-builder/std",
 	"sp-inherents/std",
 	"sp-offchain/std",

--- a/runtimes/polimec/src/lib.rs
+++ b/runtimes/polimec/src/lib.rs
@@ -1086,7 +1086,7 @@ parameter_types! {
 	pub FeePercentage: Perbill = Perbill::from_rational(75u32, 1000u32);
 	// TODO: add a real account here
 	pub FeeRecipient: AccountId = [0u8; 32].into();
-	pub const RootId: PalletId = PalletId(*b"treasury");
+	pub RootId: PalletId = PalletId(*b"treasury");
 }
 impl pallet_proxy_bonding::Config for Runtime {
 	type BondingToken = Balances;


### PR DESCRIPTION
## What?
- Change mock AccountId from u32 to u64
- Test the OTM flow inside pallet-funding

## Why?
- PalletId account derivations start with a 32bit constant, so that meant the proxy-bonding escrow and the project_id escrow had the same account
- So far we only tested the proxy-bonding in a vacuum.

## Testing?
- `one_token_mode_bid_funding_success`
- `one_token_mode_bid_funding_failed`
- `one_token_mode_contribution_funding_success`
- `one_token_mode_contribution_funding_failed`

## Anything Else?
e2e tests need to be updated with OTM values. In another PR