### PR TITLE
✅ New e2e tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4627,6 +4627,7 @@ dependencies = [
  "pallet-membership",
  "pallet-message-queue",
  "pallet-parachain-staking",
+ "pallet-proxy-bonding",
  "pallet-scheduler",
  "pallet-session",
  "pallet-staking",

--- a/bacon.toml
+++ b/bacon.toml
@@ -1,0 +1,101 @@
+# This is a configuration file for the bacon tool
+#
+# Bacon repository: https://github.com/Canop/bacon
+# Complete help on configuration: https://dystroy.org/bacon/config/
+# You can also check bacon's own bacon.toml file
+#  as an example: https://github.com/Canop/bacon/blob/main/bacon.toml
+
+default_job = "check"
+
+[jobs.check]
+command = ["cargo", "check", "--profile=test", "--workspace", "--color", "always"]
+need_stdout = false
+
+[jobs.check-all]
+command = ["cargo", "check", "--all-targets", "--color", "always"]
+need_stdout = false
+
+# Run clippy on the default target
+[jobs.clippy]
+command = [
+    "cargo", "clippy",
+    "--color", "always",
+]
+need_stdout = false
+
+# Run clippy on all targets
+# To disable some lints, you may change the job this way:
+#    [jobs.clippy-all]
+#    command = [
+#        "cargo", "clippy",
+#        "--all-targets",
+#        "--color", "always",
+#    	 "--",
+#    	 "-A", "clippy::bool_to_int_with_if",
+#    	 "-A", "clippy::collapsible_if",
+#    	 "-A", "clippy::derive_partial_eq_without_eq",
+#    ]
+# need_stdout = false
+[jobs.clippy-all]
+command = [
+    "cargo", "clippy",
+    "--all-targets",
+    "--color", "always",
+]
+need_stdout = false
+
+# This job lets you run
+# - all tests: bacon test
+# - a specific test: bacon test -- config::test_default_files
+# - the tests of a package: bacon test -- -- -p config
+[jobs.test]
+command = [
+    "cargo", "test", "--color", "always",
+    "--", "--color", "always", # see https://github.com/Canop/bacon/issues/124
+]
+need_stdout = true
+
+[jobs.doc]
+command = ["cargo", "doc", "--color", "always", "--no-deps"]
+need_stdout = false
+
+# If the doc compiles, then it opens in your browser and bacon switches
+# to the previous job
+[jobs.doc-open]
+command = ["cargo", "doc", "--color", "always", "--no-deps", "--open"]
+need_stdout = false
+on_success = "back" # so that we don't open the browser at each change
+
+# You can run your application and have the result displayed in bacon,
+# *if* it makes sense for this crate.
+# Don't forget the `--color always` part or the errors won't be
+# properly parsed.
+# If your program never stops (eg a server), you may set `background`
+# to false to have the cargo run output immediately displayed instead
+# of waiting for program's end.
+[jobs.run]
+command = [
+    "cargo", "run",
+    "--color", "always",
+    # put launch parameters for your program behind a `--` separator
+]
+need_stdout = true
+allow_warnings = true
+background = true
+
+# This parameterized job runs the example of your choice, as soon
+# as the code compiles.
+# Call it as
+#    bacon ex -- my-example
+[jobs.ex]
+command = ["cargo", "run", "--color", "always", "--example"]
+need_stdout = true
+allow_warnings = true
+
+# You may define here keybindings that would be specific to
+# a project, for example a shortcut to launch a specific job.
+# Shortcuts to internal functions (scrolling, toggling, etc.)
+# should go in your personal global prefs.toml file instead.
+[keybindings]
+# alt-m = "job:my-job"
+c = "job:clippy-all" # comment this to have 'c' run clippy on only the default target

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -76,14 +76,17 @@ pallet-scheduler.workspace = true
 pallet-treasury.workspace = true
 frame-metadata-hash-extension.workspace = true
 pallet-asset-tx-payment.workspace = true
+sp-consensus-aura.workspace = true
+pallet-aura.workspace = true
+pallet-session.workspace = true
+pallet-proxy-bonding.workspace = true
+
 # Runtimes
 polkadot-runtime.workspace = true
 asset-hub-polkadot-runtime.workspace = true
 polimec-runtime.workspace = true
 penpal-runtime = { path = "penpal", default-features = false }
-sp-consensus-aura.workspace = true
-pallet-aura.workspace = true
-pallet-session.workspace = true
+
 
 [features]
 default = [ "development-settings", "instant-mode", "std" ]

--- a/integration-tests/src/constants.rs
+++ b/integration-tests/src/constants.rs
@@ -503,7 +503,7 @@ pub mod polimec {
 		funded_accounts.extend(collators::initial_authorities().iter().cloned().map(|(acc, _)| (acc, 20_005 * PLMC)));
 		funded_accounts.push((TreasuryAccount::get(), 20_000_000 * PLMC));
 		funded_accounts.push((BlockchainOperationTreasury::get(), 20_005 * PLMC));
-		/// Treasury account needs PLMC for the One Token Model participations
+		// Treasury account needs PLMC for the One Token Model participations
 		funded_accounts.push((polimec_runtime::FeeRecipient::get(), INITIAL_DEPOSIT));
 
 		let genesis_config = polimec_runtime::RuntimeGenesisConfig {

--- a/integration-tests/src/tests/credentials.rs
+++ b/integration-tests/src/tests/credentials.rs
@@ -15,18 +15,13 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::*;
-use frame_support::{assert_err, assert_ok, dispatch::GetDispatchInfo, traits::tokens::currency::VestingSchedule};
+use frame_support::{assert_ok, dispatch::GetDispatchInfo, traits::tokens::currency::VestingSchedule};
 use macros::generate_accounts;
 use pallet_funding::ParticipationMode::{Classic, OTM};
 use polimec_common::credentials::{Did, InvestorType};
 use polimec_common_test_utils::{get_fake_jwt, get_mock_jwt_with_cid, get_test_jwt};
 use polimec_runtime::PLMC;
-use sp_runtime::{
-	generic::Era,
-	traits::SignedExtension,
-	transaction_validity::{InvalidTransaction::Payment, TransactionValidityError},
-	AccountId32, DispatchError,
-};
+use sp_runtime::{generic::Era, traits::SignedExtension, AccountId32, DispatchError};
 use tests::defaults::*;
 
 #[test]

--- a/pallets/proxy-bonding/src/functions.rs
+++ b/pallets/proxy-bonding/src/functions.rs
@@ -38,6 +38,11 @@ impl<T: Config> Pallet<T> {
 		Ok(fee_in_fee_asset)
 	}
 
+	pub fn get_bonding_account(derivation_path: u32) -> AccountIdOf<T> {
+		// We need to add 1 since 0u32 means no derivation from root.
+		T::RootId::get().into_sub_account_truncating(derivation_path.saturating_add(1u32))
+	}
+
 	/// Put some tokens on hold from the treasury into a sub-account, on behalf of a user.
 	/// User pays a fee for this functionality, which can be later refunded.
 	pub fn bond_on_behalf_of(
@@ -48,7 +53,7 @@ impl<T: Config> Pallet<T> {
 		hold_reason: T::RuntimeHoldReason,
 	) -> Result<(), DispatchError> {
 		let treasury = T::Treasury::get();
-		let bonding_account: AccountIdOf<T> = T::RootId::get().into_sub_account_truncating(derivation_path);
+		let bonding_account: AccountIdOf<T> = Self::get_bonding_account(derivation_path);
 		let existential_deposit = <T::BondingToken as fungible::Inspect<T::AccountId>>::minimum_balance();
 
 		let fee_in_fee_asset = Self::calculate_fee(bond_amount, fee_asset)?;
@@ -96,7 +101,7 @@ impl<T: Config> Pallet<T> {
 		bond_amount: BalanceOf<T>,
 		fee_asset: AssetId,
 	) -> Result<(), DispatchError> {
-		let bonding_account: AccountIdOf<T> = T::RootId::get().into_sub_account_truncating(derivation_path);
+		let bonding_account = Self::get_bonding_account(derivation_path);
 		let fee_in_fee_asset = Self::calculate_fee(bond_amount, fee_asset)?;
 
 		// We know this fee token account is existing thanks to the provider reference of the ED of the native asset, so we can fully move all the funds.

--- a/pallets/proxy-bonding/src/lib.rs
+++ b/pallets/proxy-bonding/src/lib.rs
@@ -40,7 +40,7 @@ pub mod pallet {
 	};
 	use frame_system::pallet_prelude::*;
 	use polimec_common::ProvideAssetPrice;
-	use sp_runtime::{traits::AccountIdConversion, Perbill, TypeId};
+	use sp_runtime::{Perbill, TypeId};
 
 	pub type AssetId = u32;
 	pub type BalanceOf<T> = <<T as Config>::BondingToken as fungible::Inspect<AccountIdOf<T>>>::Balance;
@@ -160,7 +160,7 @@ pub mod pallet {
 			let _caller = ensure_signed(origin)?;
 
 			let treasury = T::Treasury::get();
-			let bonding_account: AccountIdOf<T> = T::RootId::get().into_sub_account_truncating(derivation_path);
+			let bonding_account = Self::get_bonding_account(derivation_path);
 			let now = frame_system::Pallet::<T>::block_number();
 
 			let release_block =
@@ -196,7 +196,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			let _caller = ensure_signed(origin)?;
 			let fee_recipient = T::FeeRecipient::get();
-			let bonding_account: AccountIdOf<T> = T::RootId::get().into_sub_account_truncating(derivation_path);
+			let bonding_account = Self::get_bonding_account(derivation_path);
 			let release_type = Releases::<T>::get(derivation_path, hold_reason).ok_or(Error::<T>::ReleaseTypeNotSet)?;
 			ensure!(release_type != ReleaseType::Refunded, Error::<T>::FeeToRecipientDisallowed);
 

--- a/runtimes/polimec/src/lib.rs
+++ b/runtimes/polimec/src/lib.rs
@@ -90,11 +90,9 @@ use sp_version::NativeVersion;
 
 use crate::xcm_config::PriceForSiblingParachainDelivery;
 use polimec_common::{ProvideAssetPrice, USD_UNIT};
+use sp_runtime::transaction_validity::InvalidTransaction;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
-use sp_runtime::{
-	transaction_validity::{InvalidTransaction},
-};
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmark_helpers;
 mod custom_migrations;

--- a/runtimes/shared-configuration/src/fee.rs
+++ b/runtimes/shared-configuration/src/fee.rs
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 extern crate alloc;
 use crate::{currency::MILLI_PLMC, Balance, StakingPalletId};
+use core::{fmt::Debug, marker::PhantomData};
 use frame_support::{
 	ord_parameter_types,
 	pallet_prelude::{MaybeSerializeDeserialize, Weight},
@@ -45,7 +46,6 @@ use sp_runtime::{
 	traits::{DispatchInfoOf, Get, One, PostDispatchInfoOf, Zero},
 	transaction_validity::{InvalidTransaction, TransactionValidityError},
 };
-use core::{fmt::Debug, marker::PhantomData};
 
 #[allow(clippy::module_name_repetitions)]
 pub struct WeightToFee;


### PR DESCRIPTION
## What?
Add new e2e tests

## Why?
OTM Flow and simplifications were added, so we needed to recheck all the numbers.

## How?
Delete everything and start over with this spreadsheet:
https://docs.google.com/spreadsheets/d/1BiKZCf50S9U_jiPPShTqmL6A_DUlFqwx/edit?gid=114355434#gid=114355434

## Testing?
Only one test in the e2e.rs file that goes over everything.

## Anything Else?
I added a bacon.toml config file. [bacon](https://dystroy.org/bacon/) is the [successor](https://www.reddit.com/r/rust/comments/1ftc7cj/cargo_watch_is_on_life_support/) to cargo watch. Its a program you leave running in the background and dynamically shows you errors from the compiler instead of having to constantly call cargo check or cargo test.

Kind of what rust-analyzer does, but I usually have it disabled because it makes everything mega slow.