### PR TITLE
💥 Switch to MultiLocation in the SignedExtension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13216,6 +13216,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-runtime",
  "sp-std",
+ "staging-xcm",
 ]
 
 [[package]]

--- a/integration-tests/src/tests/transaction_payment.rs
+++ b/integration-tests/src/tests/transaction_payment.rs
@@ -21,7 +21,7 @@ use sp_runtime::{
 use xcm_emulator::TestExt;
 generate_accounts!(ALICE, AUTHOR);
 use frame_support::traits::fungible::Inspect;
-
+use xcm::v3::{Junction::*, Junctions::*, MultiLocation};
 // Setup code inspired by pallet-authorship tests
 fn seal_header(mut header: Header, aura_index: u64) -> Header {
 	{
@@ -60,6 +60,8 @@ fn fee_paid_with_foreign_assets() {
 		assert_eq!(polimec_runtime::Authorship::author(), Some(block_author.clone()));
 
 		let usdt_id = AcceptedFundingAsset::USDT.id();
+		let usdt_multilocation =
+			MultiLocation { parents: 1, interior: X3(Parachain(1000), PalletInstance(50), GeneralIndex(1984)) };
 		let usdt_decimals = <PolimecForeignAssets as fungibles::metadata::Inspect<PolimecAccountId>>::decimals(usdt_id);
 		let usdt_unit = 10u128.pow(usdt_decimals as u32);
 		let plmc_decimals = PLMC_DECIMALS;
@@ -79,10 +81,12 @@ fn fee_paid_with_foreign_assets() {
 		let paid_call_len = paid_call.encode().len();
 		type TxPaymentExtension = pallet_asset_tx_payment::ChargeAssetTxPayment<PolimecRuntime>;
 
-		// Tips are always defined in the native asset, and then converted to the fee asset if the second field is `Some`.
-		// Here a user wants to tip 10 PLMC in USDT.
-		let signed_extension =
-			pallet_asset_tx_payment::ChargeAssetTxPayment::<PolimecRuntime>::from(10 * plmc_unit, Some(usdt_id));
+        // Tips are always defined in the native asset, and then converted to the fee asset if the second field is `Some`.
+        // Here a user wants to tip 10 PLMC in USDT.
+		let signed_extension = pallet_asset_tx_payment::ChargeAssetTxPayment::<PolimecRuntime>::from(
+			10 * plmc_unit,
+			Some(usdt_multilocation),
+		);
 
 		let dispatch_info = paid_call.get_dispatch_info();
 		let FeeDetails { inclusion_fee, tip } =
@@ -126,7 +130,7 @@ fn fee_paid_with_foreign_assets() {
 		let post_block_author_plmc_balance = PolimecBalances::balance(&block_author.clone());
 
 		assert_eq!(prev_alice_usdt_balance - post_alice_usdt_balance, expected_usd_fee + expected_usd_tip);
-		assert_eq!(post_alice_plmc_balance, prev_alice_plmc_balance,);
+		assert_eq!(post_alice_plmc_balance, prev_alice_plmc_balance);
 		assert_eq!(
 			post_blockchain_operation_treasury_usdt_balance - prev_blockchain_operation_treasury_usdt_balance,
 			expected_usd_fee

--- a/runtimes/polimec/Cargo.toml
+++ b/runtimes/polimec/Cargo.toml
@@ -206,6 +206,7 @@ runtime-benchmarks = [
 	"frame-system/runtime-benchmarks",
 	"on-slash-vesting/runtime-benchmarks",
 	"orml-oracle/runtime-benchmarks",
+	"pallet-asset-tx-payment/runtime-benchmarks",
 	"pallet-assets/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks",
 	"pallet-collective/runtime-benchmarks",
@@ -237,7 +238,6 @@ runtime-benchmarks = [
 	"sp-runtime/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
-	"pallet-asset-tx-payment/runtime-benchmarks"
 ]
 
 try-runtime = [

--- a/runtimes/polimec/src/custom_migrations/funding_holds.rs
+++ b/runtimes/polimec/src/custom_migrations/funding_holds.rs
@@ -1,5 +1,4 @@
 use crate::{Balance, Funding, Runtime, RuntimeHoldReason};
-use alloc::vec::Vec;
 use frame_support::traits::{GetStorageVersion, OnRuntimeUpgrade, VariantCount, VariantCountOf};
 use pallet_balances::IdAmount;
 use pallet_funding::ProjectId;
@@ -7,6 +6,7 @@ use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_core::{MaxEncodedLen, RuntimeDebug};
 use sp_runtime::BoundedVec;
+use sp_std::vec::Vec;
 
 #[derive(Clone, Copy, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub enum OldFundingHoldReason {

--- a/runtimes/shared-configuration/Cargo.toml
+++ b/runtimes/shared-configuration/Cargo.toml
@@ -41,7 +41,7 @@ pallet-parachain-staking.workspace = true
 pallet-oracle-ocw.workspace = true
 pallet-treasury = {workspace = true, optional = true}
 pallet-asset-tx-payment.workspace = true
-
+xcm.workspace = true
 [features]
 default = [ "std" ]
 fast-mode = []
@@ -50,6 +50,7 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"orml-traits/std",
+	"pallet-asset-tx-payment/std",
 	"pallet-authorship/std",
 	"pallet-balances/std",
 	"pallet-funding/std",
@@ -64,11 +65,12 @@ std = [
 	"sp-arithmetic/std",
 	"sp-runtime/std",
 	"sp-std/std",
-	"pallet-asset-tx-payment/std"
+	"xcm/std",
 ]
 runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
+	"pallet-asset-tx-payment/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks",
 	"pallet-funding/runtime-benchmarks",
 	"pallet-oracle-ocw/runtime-benchmarks",
@@ -77,11 +79,11 @@ runtime-benchmarks = [
 	"parachains-common/runtime-benchmarks",
 	"polimec-common/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
-	"pallet-asset-tx-payment/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
+	"pallet-asset-tx-payment/try-runtime",
 	"pallet-authorship/try-runtime",
 	"pallet-balances/try-runtime",
 	"pallet-funding/try-runtime",
@@ -91,6 +93,5 @@ try-runtime = [
 	"pallet-treasury?/try-runtime",
 	"polimec-common/try-runtime",
 	"sp-runtime/try-runtime",
-	"pallet-asset-tx-payment/try-runtime"
 ]
 development-settings = []


### PR DESCRIPTION
## What?
- Make our Asset fee-paying Signed Extension compatible with `@polkadot/api` JS packages.

## Why?
- The  `@polkadot/api` JS packages work better if the `assetId` is a `MultiLocation`/`Location`, so our initial `u32` based solution didn't work

## How?
- Make the signed extension accept a `xcm::v3::MultiLocation`, and convert it internally to a `u32`.
