### PR TITLE
add dwellir bootnode to polimec

### DIFF
--- a/chain-specs/polkadot/polimec-raw-chain-spec.json
+++ b/chain-specs/polkadot/polimec-raw-chain-spec.json
@@ -10,7 +10,9 @@
     "/dns/polimec.bootnode.amforc.com/tcp/29999/wss/p2p/12D3KooWSNA6RHfNC9XPCoftFDsuXM2JkVHJEejHWSe3X8Jf9v9Y",
     "/dns/polimec.bootnode.amforc.com/tcp/30016/p2p/12D3KooWSNA6RHfNC9XPCoftFDsuXM2JkVHJEejHWSe3X8Jf9v9Y",
     "/dns/polimec.boot.stake.plus/tcp/30332/wss/p2p/12D3KooWFq12Wd69TRzwLy3gFx33JDEoJqMxpZ7ApYAPSLHGfXM8",
-    "/dns/polimec.boot.stake.plus/tcp/31332/wss/p2p/12D3KooWDb6fapSji27VZKN2MseDjV4EfmSNQiNVLBTBqb5ueDZk"
+    "/dns/polimec.boot.stake.plus/tcp/31332/wss/p2p/12D3KooWDb6fapSji27VZKN2MseDjV4EfmSNQiNVLBTBqb5ueDZk",
+    "/dns/polimec-boot-ng.dwellir.com/tcp/443/wss/p2p/12D3KooWDWbXpHidJLEqpUwyttAfkFubUxDN4APsFi9gUutxSoqm",
+    "/dns/polimec-boot-ng.dwellir.com/tcp/30370/p2p/12D3KooWDWbXpHidJLEqpUwyttAfkFubUxDN4APsFi9gUutxSoqm"
   ],
   "telemetryEndpoints": null,
   "protocolId": "polimec",


### PR DESCRIPTION
## What?
Add dwellir bootnode

## Why?
To improve network distribution and reslience
## How?
Via Infra
## Testing?
```
./polimec-node --chain=polimec --reserved-nodes=/dns/polimec-boot-ng.dwellir.com/tcp/443/wss/p2p/12D3KooWDWbXpHidJLEqpUwyttAfkFubUxDN4APsFi9gUutxSoqm
```
```
./polimec-node --chain=polimec --reserved-nodes=/dns/polimec-boot-ng.dwellir.com/tcp/30370/p2p/12D3KooWDWbXpHidJLEqpUwyttAfkFubUxDN4APsFi9gUutxSoqm
```
## Screenshots (optional)
![Screenshot from 2024-10-09 07-42-00](https://github.com/user-attachments/assets/a7977c33-6651-4678-8a84-9b8ec5883789)

## Anything Else?
