### PR TITLE
🩹 Upgrade Rust and cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,15 +711,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
-]
-
-[[package]]
 name = "atomic-take"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1865,12 +1856,6 @@ checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "critical-section"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "crossbeam-deque"
@@ -3792,9 +3777,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3807,9 +3792,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3817,15 +3802,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3835,9 +3820,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -3869,9 +3854,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3891,15 +3876,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-timer"
@@ -3909,9 +3894,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4130,9 +4115,9 @@ dependencies = [
 
 [[package]]
 name = "hash32"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
@@ -4177,15 +4162,12 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.7.17"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "atomic-polyfill",
  "hash32",
- "rustc_version",
  "serde",
- "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -6558,7 +6540,6 @@ dependencies = [
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
- "log",
  "pallet-balances",
  "pallet-vesting",
  "parity-scale-codec",
@@ -7183,7 +7164,6 @@ dependencies = [
  "polimec-common",
  "polimec-common-test-utils",
  "scale-info",
- "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-std",
@@ -7291,13 +7271,11 @@ dependencies = [
 name = "pallet-funding"
 version = "0.8.0"
 dependencies = [
- "env_logger",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "itertools 0.11.0",
  "log",
- "macros",
  "on-slash-vesting",
  "pallet-assets",
  "pallet-balances",
@@ -7412,17 +7390,13 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
  "pallet-balances",
  "parity-scale-codec",
  "polimec-common",
  "scale-info",
- "serde",
- "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-std",
- "staging-xcm-builder",
 ]
 
 [[package]]
@@ -7763,7 +7737,6 @@ dependencies = [
  "polimec-common",
  "scale-info",
  "serde",
- "sp-core",
  "sp-io",
  "sp-runtime",
 ]
@@ -8705,7 +8678,6 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "itertools 0.11.0",
  "jwt-compact",
  "pallet-timestamp",
  "parity-scale-codec",
@@ -8745,7 +8717,6 @@ dependencies = [
  "cumulus-relay-chain-interface",
  "frame-benchmarking",
  "frame-benchmarking-cli",
- "frame-support",
  "futures",
  "hex-literal",
  "itertools 0.11.0",
@@ -8779,7 +8750,6 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus-aura",
  "sp-core",
- "sp-io",
  "sp-keystore",
  "sp-runtime",
  "sp-timestamp",
@@ -8814,7 +8784,6 @@ dependencies = [
 name = "polimec-runtime"
 version = "0.8.0"
 dependencies = [
- "array-bytes",
  "assets-common",
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -8834,7 +8803,6 @@ dependencies = [
  "frame-try-runtime",
  "hex-literal",
  "log",
- "on-slash-vesting",
  "orml-oracle",
  "pallet-asset-tx-payment",
  "pallet-assets",
@@ -14393,9 +14361,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "spinning_top"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,22 +13,19 @@ resolver = "2"
 
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1}
-#all = { level = "allow", priority = -1}
-#pedantic = { level = "warn", priority = -1}
-#pedantic = { level = "allow", priority = -1}
-
 inconsistent_digit_grouping = "allow"
 zero_prefixed_literal = "allow"
 missing_errors_doc = "allow"
 must_use_candidate = "allow"
 identity_op = "allow"
+tabs_in_doc_comments= "allow"
 
 [workspace.lints.rust]
 unreachable_patterns = "deny"
 
 [workspace.package]
 authors = ['Polimec Foundation <info@polimec.org>']
-documentation = "https://wiki.polimec.org/"
+documentation = "https://hub.polimec.org/"
 edition = "2021"
 homepage = "https://www.polimec.org/"
 license-file = "LICENSE"
@@ -89,23 +86,23 @@ substrate-fixed = { git = "https://github.com/encointer/substrate-fixed", defaul
 # External (without extra features and with default disabled if necessary)
 parity-scale-codec = { version = "3.6.12", default-features = false }
 clap = { version = "4.5.3" }
-futures = { version = "0.3.28" }
-scale-info = { version = "2.11.1", default-features = false, features = [
+futures = { version = "0.3.31" }
+scale-info = { version = "2.11.3", default-features = false, features = [
     "derive",
 ] }
-jsonrpsee = { version = "0.22", features = ["server"] }
+jsonrpsee = { version = "0.22.5", features = ["server"] }
 hex-literal = "0.4.1"
-serde = { version = "1.0.197", default-features = false }
-serde_json = "1.0.114"
-smallvec = "1.11.0"
-log = { version = "0.4.17", default-features = false }
+serde = { version = "1.0.204", default-features = false }
+serde_json = "1.0.120"
+smallvec = "1.13.2"
+log = { version = "0.4.22", default-features = false }
 itertools = { version = "0.11", default-features = false, features = [
     "use_alloc",
 ] }
-array-bytes = { version = "6.2.2", default-features = false }
+array-bytes = { version = "6.2.3", default-features = false }
 serde-json-core = { version = '0.5.1', default-features = false }
-heapless = { version = "0.7", default-features = false }
-color-print = "0.3.5"
+heapless = { version = "0.8", default-features = false }
+color-print = "0.3.6"
 
 # Emulations
 xcm-emulator = { version = "0.12.0", default-features = false }
@@ -202,7 +199,6 @@ cumulus-primitives-utility = { version = "0.14.0", default-features = false }
 parachain-info = { version = "0.14.0", package = 'staging-parachain-info', default-features = false }
 parachains-common = { version = "14.0.0", default-features = false }
 cumulus-primitives-aura = { version = "0.14.0", default-features = false }
-
 
 # Client-only (with default enabled)
 cumulus-client-cli = { version = "0.14.0" }

--- a/integration-tests/src/constants.rs
+++ b/integration-tests/src/constants.rs
@@ -72,7 +72,7 @@ pub struct Prices {
 }
 
 // PricesBuilder for optional fields before building Prices
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 pub struct PricesBuilder {
 	dot: Option<FixedU128>,
 	usdc: Option<FixedU128>,
@@ -463,17 +463,17 @@ pub mod polimec {
 			];
 
 			frame_support::assert_ok!(orml_oracle::Pallet::<PolimecRuntime>::feed_values(
-				PolimecOrigin::signed(alice.clone().into()),
+				PolimecOrigin::signed(alice.into()),
 				values.clone()
 			));
 
 			frame_support::assert_ok!(orml_oracle::Pallet::<PolimecRuntime>::feed_values(
-				PolimecOrigin::signed(bob.clone().into()),
+				PolimecOrigin::signed(bob.into()),
 				values.clone()
 			));
 
 			frame_support::assert_ok!(orml_oracle::Pallet::<PolimecRuntime>::feed_values(
-				PolimecOrigin::signed(charlie.clone().into()),
+				PolimecOrigin::signed(charlie.into()),
 				values.clone()
 			));
 		});

--- a/integration-tests/src/tests/credentials.rs
+++ b/integration-tests/src/tests/credentials.rs
@@ -17,7 +17,6 @@
 use crate::*;
 use frame_support::{assert_ok, dispatch::GetDispatchInfo, traits::tokens::currency::VestingSchedule};
 use macros::generate_accounts;
-use pallet_funding::ParticipationMode::{Classic, OTM};
 use polimec_common::credentials::{Did, InvestorType};
 use polimec_common_test_utils::{get_fake_jwt, get_mock_jwt_with_cid, get_test_jwt};
 use polimec_runtime::PLMC;

--- a/integration-tests/src/tests/e2e.rs
+++ b/integration-tests/src/tests/e2e.rs
@@ -792,7 +792,11 @@ fn e2e_test() {
 		assert_eq!(inst.get_project_details(project_id).status, ProjectStatus::CTMigrationStarted);
 
 		for user in UserMigrations::<PolimecRuntime>::iter_key_prefix((project_id,)).collect_vec() {
-			PolimecFunding::confirm_offchain_migration(PolimecOrigin::signed(issuer.clone()), project_id, user);
+			assert_ok!(PolimecFunding::confirm_offchain_migration(
+				PolimecOrigin::signed(issuer.clone()),
+				project_id,
+				user
+			));
 		}
 		PolimecFunding::mark_project_ct_migration_as_finished(PolimecOrigin::signed(issuer.clone()), project_id)
 			.unwrap();

--- a/integration-tests/src/tests/otm_edge_cases.rs
+++ b/integration-tests/src/tests/otm_edge_cases.rs
@@ -5,15 +5,14 @@ use crate::{
 };
 use frame_support::traits::fungibles::Inspect;
 use macros::generate_accounts;
-use pallet_funding::{AcceptedFundingAsset, MultiplierOf, ParticipationMode, PriceProviderOf};
+use pallet_funding::{traits::BondingRequirementCalculation, AcceptedFundingAsset, MultiplierOf, ParticipationMode};
 use polimec_common::{credentials::InvestorType, ProvideAssetPrice, PLMC_DECIMALS, PLMC_FOREIGN_ID, USD_UNIT};
 use polimec_common_test_utils::{generate_did_from_account, get_mock_jwt_with_cid};
-use polimec_runtime::OraclePriceProvider;
-use sp_arithmetic::{FixedPointNumber, FixedU128, Perbill};
+use sp_arithmetic::{FixedPointNumber, FixedU128};
 use sp_core::bounded_vec;
 use sp_runtime::TokenError;
+
 generate_accounts!(ISSUER, BOBERT);
-use pallet_funding::traits::BondingRequirementCalculation;
 
 #[test]
 fn otm_fee_below_min_amount_reverts() {
@@ -119,7 +118,7 @@ fn after_otm_fee_user_goes_under_ed_reverts() {
 
 	polimec::set_prices(PricesBuilder::default());
 	PolimecNet::execute_with(|| {
-		let mut project_metadata = default_project_metadata(issuer.clone());
+		let project_metadata = default_project_metadata(issuer.clone());
 
 		let project_id = inst.create_community_contributing_project(
 			project_metadata.clone(),

--- a/integration-tests/src/tests/vest.rs
+++ b/integration-tests/src/tests/vest.rs
@@ -27,7 +27,7 @@ use polimec_runtime::{Balances, BlockchainOperationTreasury, ParachainStaking, R
 use sp_runtime::Perquintill;
 use xcm_emulator::helpers::get_account_id_from_seed;
 
-generate_accounts!(PEPE, CARLOS,);
+generate_accounts!(PEPE, CARLOS);
 
 #[test]
 fn base_vested_can_stake() {

--- a/nodes/parachain/Cargo.toml
+++ b/nodes/parachain/Cargo.toml
@@ -32,7 +32,6 @@ pallet-funding.workspace = true
 # Substrate
 frame-benchmarking.workspace = true
 frame-benchmarking-cli.workspace = true
-frame-support.workspace = true
 pallet-transaction-payment-rpc.workspace = true
 sc-basic-authorship.workspace = true
 sc-chain-spec.workspace = true
@@ -51,7 +50,6 @@ sc-transaction-pool.workspace = true
 sc-transaction-pool-api.workspace = true
 sc-network-sync.workspace = true
 sp-api.workspace = true
-sp-io.workspace = true
 sp-block-builder.workspace = true
 sp-blockchain.workspace = true
 sp-consensus-aura.workspace = true
@@ -89,7 +87,6 @@ runtime-benchmarks = [
 	"cumulus-primitives-core/runtime-benchmarks",
 	"frame-benchmarking-cli/runtime-benchmarks",
 	"frame-benchmarking/runtime-benchmarks",
-	"frame-support/runtime-benchmarks",
 	"pallet-funding/runtime-benchmarks",
 	"polimec-runtime/runtime-benchmarks",
 	"polkadot-cli/runtime-benchmarks",
@@ -98,7 +95,6 @@ runtime-benchmarks = [
 	"sp-runtime/runtime-benchmarks",
 ]
 try-runtime = [
-	"frame-support/try-runtime",
 	"pallet-funding/try-runtime",
 	"polimec-runtime/try-runtime",
 	"polkadot-cli/try-runtime",

--- a/pallets/dispenser/Cargo.toml
+++ b/pallets/dispenser/Cargo.toml
@@ -35,7 +35,6 @@ sp-std.workspace = true
 sp-runtime.workspace = true
 
 [dev-dependencies]
-sp-core.workspace = true
 sp-io.workspace = true
 sp-runtime.workspace = true
 pallet-balances.workspace = true
@@ -55,7 +54,6 @@ std = [
 	"polimec-common-test-utils/std",
 	"polimec-common/std",
 	"scale-info/std",
-	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",

--- a/pallets/funding/Cargo.toml
+++ b/pallets/funding/Cargo.toml
@@ -13,9 +13,6 @@ version.workspace = true
 [lints]
 workspace = true
 
-#[lints.clippy]
-#inconsistent_digit_grouping = "allow"
-
 [dependencies]
 serde = { workspace = true }
 parity-scale-codec = { workspace = true, features = [
@@ -45,9 +42,9 @@ xcm.workspace = true
 xcm-executor.workspace = true
 pallet-xcm.workspace = true
 polkadot-parachain-primitives.workspace = true
+sp-api.workspace = true
 polimec-common-test-utils = { workspace = true, optional = true }
 frame-benchmarking = { workspace = true, optional = true }
-sp-api.workspace = true
 
 # Used in the instantiator.
 itertools.workspace = true
@@ -58,10 +55,8 @@ pallet-timestamp.workspace = true
 pallet-assets.workspace = true
 pallet-linear-release.workspace = true
 polimec-common-test-utils.workspace = true
-macros.workspace = true
 xcm-builder.workspace = true
 xcm-executor.workspace = true
-env_logger = "0.10.2"
 
 [features]
 default = [ "std" ]

--- a/pallets/funding/src/instantiator/tests.rs
+++ b/pallets/funding/src/instantiator/tests.rs
@@ -23,7 +23,7 @@ fn dry_run_wap() {
 	const ANNA: AccountIdOf<TestRuntime> = 64;
 	const DAMIAN: AccountIdOf<TestRuntime> = 65;
 
-	let accounts = vec![ADAM, TOM, SOFIA, FRED, ANNA, DAMIAN];
+	let accounts = [ADAM, TOM, SOFIA, FRED, ANNA, DAMIAN];
 
 	let bounded_name = bounded_name();
 	let bounded_symbol = bounded_symbol();
@@ -55,14 +55,12 @@ fn dry_run_wap() {
 	};
 
 	// overfund with plmc
-	let plmc_fundings = accounts
-		.iter()
-		.map(|acc| UserToPLMCBalance { account: acc.clone(), plmc_amount: PLMC * 1_000_000 })
-		.collect_vec();
+	let plmc_fundings =
+		accounts.iter().map(|acc| UserToPLMCBalance { account: *acc, plmc_amount: PLMC * 1_000_000 }).collect_vec();
 	let usdt_fundings = accounts
 		.iter()
 		.map(|acc| UserToFundingAsset {
-			account: acc.clone(),
+			account: *acc,
 			asset_amount: USD_UNIT * 1_000_000,
 			asset_id: AcceptedFundingAsset::USDT.id(),
 		})
@@ -105,7 +103,7 @@ fn find_bucket_for_wap() {
 	const ANNA: AccountIdOf<TestRuntime> = 64;
 	const DAMIAN: AccountIdOf<TestRuntime> = 65;
 
-	let accounts = vec![ADAM, TOM, SOFIA, FRED, ANNA, DAMIAN];
+	let accounts = [ADAM, TOM, SOFIA, FRED, ANNA, DAMIAN];
 
 	let bounded_name = bounded_name();
 	let bounded_symbol = bounded_symbol();
@@ -137,14 +135,12 @@ fn find_bucket_for_wap() {
 	};
 
 	// overfund with plmc
-	let plmc_fundings = accounts
-		.iter()
-		.map(|acc| UserToPLMCBalance { account: acc.clone(), plmc_amount: PLMC * 1_000_000 })
-		.collect_vec();
+	let plmc_fundings =
+		accounts.iter().map(|acc| UserToPLMCBalance { account: *acc, plmc_amount: PLMC * 1_000_000 }).collect_vec();
 	let usdt_fundings = accounts
 		.iter()
 		.map(|acc| UserToFundingAsset {
-			account: acc.clone(),
+			account: *acc,
 			asset_amount: USD_UNIT * 1_000_000,
 			asset_id: AcceptedFundingAsset::USDT.id(),
 		})

--- a/pallets/funding/src/mock.rs
+++ b/pallets/funding/src/mock.rs
@@ -80,7 +80,7 @@ where
 	fn try_convert(o: RuntimeOrigin) -> Result<Location, RuntimeOrigin> {
 		o.try_with_caller(|caller| match caller.try_into() {
 			Ok(SystemRawOrigin::Signed(who)) =>
-				Ok(Junction::AccountIndex64 { network: Network::get(), index: Into::<u64>::into(who).into() }.into()),
+				Ok(Junction::AccountIndex64 { network: Network::get(), index: Into::<u64>::into(who) }.into()),
 			Ok(other) => Err(other.into()),
 			Err(other) => Err(other),
 		})

--- a/pallets/funding/src/tests/1_application.rs
+++ b/pallets/funding/src/tests/1_application.rs
@@ -825,7 +825,7 @@ mod edit_project_extrinsic {
 				project_id,
 				project_metadata.clone()
 			)));
-			let next_project_id = inst.execute(|| NextProjectId::<TestRuntime>::get());
+			let next_project_id = inst.execute(NextProjectId::<TestRuntime>::get);
 			assert_eq!(project_id, next_project_id - 1);
 			let projects_details = inst.execute(|| ProjectsDetails::<TestRuntime>::iter_keys().collect_vec());
 			let project_metadatas = inst.execute(|| ProjectsMetadata::<TestRuntime>::iter_keys().collect_vec());

--- a/pallets/funding/src/tests/3_auction.rs
+++ b/pallets/funding/src/tests/3_auction.rs
@@ -517,12 +517,7 @@ mod bid_extrinsic {
 			u8_multiplier: u8,
 		) -> DispatchResultWithPostInfo {
 			let project_policy = inst.get_project_metadata(project_id).policy_ipfs_cid.unwrap();
-			let jwt = get_mock_jwt_with_cid(
-				bidder.clone(),
-				investor_type,
-				generate_did_from_account(BIDDER_1),
-				project_policy,
-			);
+			let jwt = get_mock_jwt_with_cid(bidder, investor_type, generate_did_from_account(BIDDER_1), project_policy);
 			let amount = 1000 * CT_UNIT;
 			let mode = ParticipationMode::Classic(u8_multiplier);
 
@@ -1832,7 +1827,7 @@ mod bid_extrinsic {
 			let project_metadata = default_project_metadata(ISSUER_1);
 			let project_id =
 				inst.create_auctioning_project(project_metadata.clone(), ISSUER_1, None, default_evaluations());
-			let bids = vec![BidParams::<TestRuntime>::new(
+			let bids = [BidParams::<TestRuntime>::new(
 				BIDDER_1,
 				10_000,
 				ParticipationMode::Classic(1u8),
@@ -1906,7 +1901,7 @@ mod end_auction_extrinsic {
 			const ANNA: AccountIdOf<TestRuntime> = 64;
 			const DAMIAN: AccountIdOf<TestRuntime> = 65;
 
-			let accounts = vec![ADAM, TOM, SOFIA, FRED, ANNA, DAMIAN];
+			let accounts = [ADAM, TOM, SOFIA, FRED, ANNA, DAMIAN];
 
 			let bounded_name = bounded_name();
 			let bounded_symbol = bounded_symbol();
@@ -1947,12 +1942,12 @@ mod end_auction_extrinsic {
 			// overfund with plmc
 			let plmc_fundings = accounts
 				.iter()
-				.map(|acc| UserToPLMCBalance { account: acc.clone(), plmc_amount: PLMC * 1_000_000 })
+				.map(|acc| UserToPLMCBalance { account: *acc, plmc_amount: PLMC * 1_000_000 })
 				.collect_vec();
 			let usdt_fundings = accounts
 				.iter()
 				.map(|acc| UserToFundingAsset {
-					account: acc.clone(),
+					account: *acc,
 					asset_amount: USD_UNIT * 1_000_000,
 					asset_id: AcceptedFundingAsset::USDT.id(),
 				})
@@ -2140,7 +2135,7 @@ mod end_auction_extrinsic {
 			const ANNA: AccountIdOf<TestRuntime> = 64;
 			const DAMIAN: AccountIdOf<TestRuntime> = 65;
 
-			let accounts = vec![ADAM, TOM, SOFIA, FRED, ANNA, DAMIAN];
+			let accounts = [ADAM, TOM, SOFIA, FRED, ANNA, DAMIAN];
 			let mut project_metadata = default_project_metadata(ISSUER_1);
 			project_metadata.total_allocation_size = 100_000 * CT_UNIT;
 			project_metadata.participation_currencies =
@@ -2149,7 +2144,7 @@ mod end_auction_extrinsic {
 			// overfund with plmc
 			let plmc_fundings = accounts
 				.iter()
-				.map(|acc| UserToPLMCBalance { account: acc.clone(), plmc_amount: PLMC * 1_000_000 })
+				.map(|acc| UserToPLMCBalance { account: *acc, plmc_amount: PLMC * 1_000_000 })
 				.collect_vec();
 
 			let fundings = [AcceptedFundingAsset::USDT, AcceptedFundingAsset::USDC, AcceptedFundingAsset::DOT];
@@ -2163,7 +2158,7 @@ mod end_auction_extrinsic {
 					let asset_id = accepted_asset.id();
 					let asset_decimals = inst.execute(|| <TestRuntime as Config>::FundingCurrency::decimals(asset_id));
 					let asset_unit = 10u128.checked_pow(asset_decimals.into()).unwrap();
-					UserToFundingAsset { account: acc.clone(), asset_amount: asset_unit * 1_000_000, asset_id }
+					UserToFundingAsset { account: *acc, asset_amount: asset_unit * 1_000_000, asset_id }
 				})
 				.collect_vec();
 			inst.mint_plmc_to(plmc_fundings);

--- a/pallets/funding/src/tests/4_contribution.rs
+++ b/pallets/funding/src/tests/4_contribution.rs
@@ -483,7 +483,7 @@ mod contribute_extrinsic {
 
 			inst.mint_plmc_ed_if_required(bids.accounts());
 			inst.mint_plmc_to(bids_plmc.clone());
-			assert_eq!(inst.execute(|| Balances::free_balance(&bob)), inst.get_ed());
+			assert_eq!(inst.execute(|| Balances::free_balance(bob)), inst.get_ed());
 
 			let bids_funding_assets = inst.calculate_auction_funding_asset_charged_from_all_bids_made_or_with_bucket(
 				&bids,
@@ -495,7 +495,7 @@ mod contribute_extrinsic {
 
 			inst.bid_for_users(project_id, bids).unwrap();
 
-			assert_eq!(inst.execute(|| Balances::free_balance(&bob)), inst.get_ed());
+			assert_eq!(inst.execute(|| Balances::free_balance(bob)), inst.get_ed());
 
 			assert!(matches!(inst.go_to_next_state(project_id), ProjectStatus::CommunityRound(..)));
 
@@ -503,7 +503,7 @@ mod contribute_extrinsic {
 			inst.execute(|| {
 				PolimecFunding::settle_bid(RuntimeOrigin::signed(bob), project_id, bob, 1).unwrap();
 			});
-			let bob_plmc = inst.execute(|| Balances::free_balance(&bob));
+			let bob_plmc = inst.execute(|| Balances::free_balance(bob));
 			assert_close_enough!(bob_plmc, inst.get_ed() + usable_bond, Perquintill::from_float(0.9999));
 
 			// Calculate how much CTs can bob buy with his evaluation PLMC bond
@@ -534,7 +534,7 @@ mod contribute_extrinsic {
 
 			// Check he had no free PLMC
 			assert_close_enough!(
-				inst.execute(|| Balances::free_balance(&bob)),
+				inst.execute(|| Balances::free_balance(bob)),
 				inst.get_ed(),
 				Perquintill::from_float(0.999)
 			);
@@ -614,7 +614,7 @@ mod contribute_extrinsic {
 		) -> DispatchResultWithPostInfo {
 			let project_policy = inst.get_project_metadata(project_id).policy_ipfs_cid.unwrap();
 			let jwt = get_mock_jwt_with_cid(
-				contributor.clone(),
+				contributor,
 				investor_type,
 				generate_did_from_account(contributor),
 				project_policy,

--- a/pallets/funding/src/tests/6_settlement.rs
+++ b/pallets/funding/src/tests/6_settlement.rs
@@ -67,9 +67,7 @@ mod start_settlement_extrinsic {
 
 			assert_eq!(project_details.funding_end_block, None);
 			assert_eq!(project_details.status, ProjectStatus::FundingSuccessful);
-			inst.execute(|| {
-				assert_eq!(<TestRuntime as Config>::ContributionTokenCurrency::asset_exists(project_id), false)
-			});
+			inst.execute(|| assert!(!<TestRuntime as Config>::ContributionTokenCurrency::asset_exists(project_id)));
 
 			inst.execute(|| {
 				assert_ok!(PolimecFunding::start_settlement(RuntimeOrigin::signed(80085), project_id));
@@ -78,9 +76,7 @@ mod start_settlement_extrinsic {
 
 			assert_eq!(project_details.funding_end_block, Some(inst.current_block()));
 			assert_eq!(project_details.status, ProjectStatus::SettlementStarted(FundingOutcome::Success));
-			inst.execute(|| {
-				assert_eq!(<TestRuntime as Config>::ContributionTokenCurrency::asset_exists(project_id), true)
-			});
+			inst.execute(|| assert!(<TestRuntime as Config>::ContributionTokenCurrency::asset_exists(project_id)));
 
 			inst.assert_ct_balance(project_id, ct_treasury, treasury_allocation);
 		}
@@ -92,9 +88,7 @@ mod start_settlement_extrinsic {
 
 			assert_eq!(project_details.funding_end_block, None);
 			assert_eq!(project_details.status, ProjectStatus::FundingFailed);
-			inst.execute(|| {
-				assert_eq!(<TestRuntime as Config>::ContributionTokenCurrency::asset_exists(project_id), false)
-			});
+			inst.execute(|| assert!(!<TestRuntime as Config>::ContributionTokenCurrency::asset_exists(project_id)));
 
 			inst.execute(|| {
 				assert_ok!(PolimecFunding::start_settlement(RuntimeOrigin::signed(80085), project_id));
@@ -103,9 +97,7 @@ mod start_settlement_extrinsic {
 
 			assert_eq!(project_details.funding_end_block, Some(inst.current_block()));
 			assert_eq!(project_details.status, ProjectStatus::SettlementStarted(FundingOutcome::Failure));
-			inst.execute(|| {
-				assert_eq!(<TestRuntime as Config>::ContributionTokenCurrency::asset_exists(project_id), false)
-			});
+			inst.execute(|| assert!(!<TestRuntime as Config>::ContributionTokenCurrency::asset_exists(project_id)));
 		}
 	}
 

--- a/pallets/funding/src/tests/7_ct_migration.rs
+++ b/pallets/funding/src/tests/7_ct_migration.rs
@@ -41,7 +41,7 @@ mod pallet_migration {
 			assert_ok!(crate::Pallet::<TestRuntime>::do_start_pallet_migration(
 				&ISSUER_1,
 				project_id,
-				ParaId::from(2006u32).into(),
+				ParaId::from(2006u32),
 			));
 		});
 
@@ -100,7 +100,7 @@ mod pallet_migration {
 		let inst = MockInstantiator::new(Some(RefCell::new(new_test_ext())));
 		let (project_id, mut inst) = create_pallet_migration_project(inst);
 
-		inst.execute(|| fake_hrmp_establishment());
+		inst.execute(fake_hrmp_establishment);
 
 		let project_details = inst.get_project_details(project_id);
 		assert_eq!(
@@ -125,7 +125,7 @@ mod pallet_migration {
 	fn pallet_readiness_check() {
 		let inst = MockInstantiator::new(Some(RefCell::new(new_test_ext())));
 		let (project_id, mut inst) = create_pallet_migration_project(inst);
-		inst.execute(|| fake_hrmp_establishment());
+		inst.execute(fake_hrmp_establishment);
 
 		// At this point, we sent the pallet check xcm to the project chain, and we are awaiting a query response message.
 		// query id 0 is the CT balance of the Polimec SA

--- a/pallets/funding/src/tests/misc.rs
+++ b/pallets/funding/src/tests/misc.rs
@@ -405,7 +405,7 @@ fn project_state_transition_event() {
 		true,
 	);
 
-	let events = inst.execute(|| System::events());
+	let events = inst.execute(System::events);
 	let transition_events = events
 		.into_iter()
 		.filter_map(|event| {

--- a/pallets/funding/src/tests/mod.rs
+++ b/pallets/funding/src/tests/mod.rs
@@ -121,7 +121,8 @@ pub mod defaults {
 			CT_DECIMALS,
 		)
 		.unwrap();
-		let project_metadata = ProjectMetadataOf::<TestRuntime> {
+
+		ProjectMetadataOf::<TestRuntime> {
 			token_information: CurrencyMetadata { name: bounded_name, symbol: bounded_symbol, decimals: CT_DECIMALS },
 			mainnet_token_max_supply: 8_000_000 * CT_UNIT,
 			total_allocation_size: 100_000 * CT_UNIT,
@@ -141,8 +142,7 @@ pub mod defaults {
 			participation_currencies: vec![AcceptedFundingAsset::USDT].try_into().unwrap(),
 			funding_destination_account: ISSUER_1,
 			policy_ipfs_cid: Some(metadata_hash),
-		};
-		project_metadata
+		}
 	}
 
 	pub fn default_plmc_balances() -> Vec<UserToPLMCBalance<TestRuntime>> {

--- a/pallets/funding/src/tests/runtime_api.rs
+++ b/pallets/funding/src/tests/runtime_api.rs
@@ -310,7 +310,7 @@ fn contribution_tokens() {
 
 	inst.execute(|| {
 		let block_hash = System::block_hash(System::block_number());
-		let bob_items = TestRuntime::contribution_tokens(&TestRuntime, block_hash, bob.clone()).unwrap();
+		let bob_items = TestRuntime::contribution_tokens(&TestRuntime, block_hash, bob).unwrap();
 		assert_eq!(bob_items, expected_items);
 	});
 }
@@ -600,9 +600,9 @@ fn all_project_participations_by_did() {
 	let bids_plmc =
 		inst.calculate_auction_plmc_charged_from_all_bids_made_or_with_bucket(&bids, project_metadata.clone(), None);
 	let community_contributions_plmc =
-		inst.calculate_contributed_plmc_spent(community_contributions.clone(), project_metadata.minimum_price.clone());
+		inst.calculate_contributed_plmc_spent(community_contributions.clone(), project_metadata.minimum_price);
 	let remainder_contributions_plmc =
-		inst.calculate_contributed_plmc_spent(remainder_contributions.clone(), project_metadata.minimum_price.clone());
+		inst.calculate_contributed_plmc_spent(remainder_contributions.clone(), project_metadata.minimum_price);
 	let all_plmc = inst.generic_map_operation(
 		vec![evaluations_plmc, bids_plmc, community_contributions_plmc, remainder_contributions_plmc],
 		MergeOperation::Add,
@@ -615,14 +615,10 @@ fn all_project_participations_by_did() {
 		project_metadata.clone(),
 		None,
 	);
-	let community_contributions_usdt = inst.calculate_contributed_funding_asset_spent(
-		community_contributions.clone(),
-		project_metadata.minimum_price.clone(),
-	);
-	let remainder_contributions_usdt = inst.calculate_contributed_funding_asset_spent(
-		remainder_contributions.clone(),
-		project_metadata.minimum_price.clone(),
-	);
+	let community_contributions_usdt =
+		inst.calculate_contributed_funding_asset_spent(community_contributions.clone(), project_metadata.minimum_price);
+	let remainder_contributions_usdt =
+		inst.calculate_contributed_funding_asset_spent(remainder_contributions.clone(), project_metadata.minimum_price);
 	let all_usdt = inst.generic_map_operation(
 		vec![bids_usdt, community_contributions_usdt, remainder_contributions_usdt],
 		MergeOperation::Add,

--- a/pallets/linear-release/Cargo.toml
+++ b/pallets/linear-release/Cargo.toml
@@ -19,21 +19,16 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 parity-scale-codec = { workspace = true, features = ["derive"] }
 scale-info = { workspace = true, features = ["derive"] }
-log.workspace = true
 frame-support.workspace = true
 frame-system.workspace = true
 sp-std.workspace = true
 sp-runtime.workspace = true
 polimec-common.workspace = true
 frame-benchmarking = { workspace = true, optional = true }
-xcm-builder = { workspace = true, optional = true }
 
 [dev-dependencies]
-sp-core.workspace = true
 sp-io.workspace = true
-serde.workspace = true
 pallet-balances.workspace = true
-
 
 [features]
 default = [ "std" ]
@@ -41,17 +36,13 @@ std = [
 	"frame-benchmarking?/std",
 	"frame-support/std",
 	"frame-system/std",
-	"log/std",
 	"pallet-balances/std",
 	"parity-scale-codec/std",
 	"polimec-common/std",
 	"scale-info/std",
-	"serde/std",
-	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",
-	"xcm-builder?/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
@@ -60,7 +51,6 @@ runtime-benchmarks = [
 	"pallet-balances/runtime-benchmarks",
 	"polimec-common/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
-	"xcm-builder/runtime-benchmarks",
 ]
 try-runtime = [
 	"frame-support/try-runtime",

--- a/pallets/linear-release/src/mock.rs
+++ b/pallets/linear-release/src/mock.rs
@@ -22,7 +22,7 @@ use frame_support::{
 };
 use sp_runtime::{
 	traits::{Identity, IdentityLookup},
-	BuildStorage, Deserialize, Serialize,
+	BuildStorage,
 };
 
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -79,21 +79,7 @@ impl Config for Test {
 	const MAX_VESTING_SCHEDULES: u32 = 3;
 }
 
-#[derive(
-	Encode,
-	Decode,
-	Copy,
-	Clone,
-	PartialEq,
-	Eq,
-	RuntimeDebug,
-	MaxEncodedLen,
-	TypeInfo,
-	Ord,
-	PartialOrd,
-	Serialize,
-	Deserialize,
-)]
+#[derive(Encode, Decode, Copy, Clone, PartialEq, Eq, RuntimeDebug, MaxEncodedLen, TypeInfo, Ord, PartialOrd)]
 pub enum MockRuntimeHoldReason {
 	Reason,
 	Reason2,

--- a/pallets/on-slash-vesting/Cargo.toml
+++ b/pallets/on-slash-vesting/Cargo.toml
@@ -15,12 +15,12 @@ impl-trait-for-tuples.workspace = true
 frame-support.workspace = true
 frame-system.workspace = true
 pallet-balances.workspace = true
-log.workspace = true
 parity-scale-codec.workspace = true
 scale-info.workspace = true
 sp-runtime.workspace = true
 sp-io.workspace = true
 serde.workspace = true
+
 [lints]
 workspace = true
 
@@ -31,7 +31,6 @@ default = [ "std" ]
 std = [
 	"frame-support/std",
 	"frame-system/std",
-	"log/std",
 	"pallet-balances/std",
 	"pallet-vesting/std",
 	"parity-scale-codec/std",

--- a/pallets/oracle-ocw/src/mock.rs
+++ b/pallets/oracle-ocw/src/mock.rs
@@ -58,7 +58,7 @@ impl frame_system::Config for Test {
 }
 
 thread_local! {
-	static TIME: RefCell<u32> = RefCell::new(0);
+	static TIME: RefCell<u32> = const { RefCell::new(0) };
 }
 
 pub struct Timestamp;
@@ -171,7 +171,7 @@ pub fn new_test_ext_with_offchain_storage(
 	// let (pool, pool_state) = testing::TestTransactionPoolExt::new();
 	let (pool, pool_state) = testing::TestTransactionPoolExt::new();
 	let keystore = MemoryKeystore::new();
-	keystore.sr25519_generate_new(crate::crypto::POLIMEC_ORACLE, Some(&format!("{}", PHRASE))).unwrap();
+	keystore.sr25519_generate_new(crate::crypto::POLIMEC_ORACLE, Some(PHRASE)).unwrap();
 
 	let storage = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
 	let mut t: sp_io::TestExternalities = storage.into();
@@ -186,7 +186,7 @@ pub fn price_oracle_response(state: &mut testing::OffchainState) {
 	for (asset, response) in KRAKEN_RESPONSES.iter() {
 		state.expect_request(testing::PendingRequest {
 			method: "GET".into(),
-			uri: format!("https://api.kraken.com/0/public/OHLC?pair={}&interval=1", asset).into(),
+			uri: format!("https://api.kraken.com/0/public/OHLC?pair={}&interval=1", asset),
 			response: Some(response.to_vec()),
 			sent: true,
 			..Default::default()
@@ -196,7 +196,7 @@ pub fn price_oracle_response(state: &mut testing::OffchainState) {
 	for (asset, response) in BITFINEX_RESPONSES.iter() {
 		state.expect_request(testing::PendingRequest {
 			method: "GET".into(),
-			uri: format!("https://api-pub.bitfinex.com/v2/candles/trade%3A1m%3At{}/hist?limit=15", asset).into(),
+			uri: format!("https://api-pub.bitfinex.com/v2/candles/trade%3A1m%3At{}/hist?limit=15", asset),
 			response: Some(response.to_vec()),
 			sent: true,
 			..Default::default()
@@ -205,7 +205,7 @@ pub fn price_oracle_response(state: &mut testing::OffchainState) {
 	for (asset, response) in BITSTAMP_RESPONSES.iter() {
 		state.expect_request(testing::PendingRequest {
 			method: "GET".into(),
-			uri: format!("https://www.bitstamp.net/api/v2/ohlc/{}/?step=60&limit=15", asset).into(),
+			uri: format!("https://www.bitstamp.net/api/v2/ohlc/{}/?step=60&limit=15", asset),
 			response: Some(response.to_vec()),
 			sent: true,
 			..Default::default()
@@ -214,7 +214,7 @@ pub fn price_oracle_response(state: &mut testing::OffchainState) {
 	for (asset, response) in COINBASE_RESPONSES.iter() {
 		state.expect_request(testing::PendingRequest {
 			method: "GET".into(),
-			uri: format!("https://api.exchange.coinbase.com/products/{}/candles?granularity=60", asset).into(),
+			uri: format!("https://api.exchange.coinbase.com/products/{}/candles?granularity=60", asset),
 			response: Some(response.to_vec()),
 			sent: true,
 			..Default::default()

--- a/pallets/oracle-ocw/src/tests.rs
+++ b/pallets/oracle-ocw/src/tests.rs
@@ -53,9 +53,9 @@ fn call_offchain_worker() {
 }
 
 fn test_fetcher_against_real_api<F: FetchPrice>() {
-	for asset in vec![AssetName::DOT, AssetName::USDC, AssetName::USDT, AssetName::PLMC] {
+	for asset in [AssetName::DOT, AssetName::USDC, AssetName::USDT, AssetName::PLMC] {
 		let url = F::get_url(asset);
-		if url == "" {
+		if url.is_empty() {
 			continue;
 		}
 		let body = do_request(url);

--- a/pallets/proxy-bonding/Cargo.toml
+++ b/pallets/proxy-bonding/Cargo.toml
@@ -21,7 +21,6 @@ polimec-common.workspace = true
 parity-scale-codec.workspace = true
 scale-info.workspace = true
 serde = { workspace = true, features = ["derive"] }
-sp-core.workspace = true
 
 [dev-dependencies]
 sp-io.workspace = true
@@ -44,7 +43,6 @@ std = [
 	"polimec-common/std",
 	"scale-info/std",
 	"serde/std",
-	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
 ]

--- a/polimec-common/common/Cargo.toml
+++ b/polimec-common/common/Cargo.toml
@@ -25,7 +25,6 @@ frame-system.workspace = true
 pallet-timestamp.workspace = true
 sp-std.workspace = true
 sp-runtime.workspace = true
-itertools.workspace = true
 xcm.workspace = true
 xcm-builder.workspace = true
 
@@ -36,8 +35,6 @@ std = [
 	"frame-benchmarking?/std",
 	"frame-support/std",
 	"frame-system/std",
-	"itertools/use_alloc",
-	"itertools/use_std",
 	"jwt-compact/std",
 	"pallet-timestamp/std",
 	"parity-scale-codec/std",

--- a/runtimes/polimec/Cargo.toml
+++ b/runtimes/polimec/Cargo.toml
@@ -28,7 +28,6 @@ scale-info = { workspace= true, default-features = false, features = [
 # Uncomment this and the std feature below to see variables instead of <wasm:stripped> in the console output
 #sp-debug-derive = { workspace = true, features = ["force-debug"]}
 
-
 # Polimec specific
 pallet-dispenser.workspace = true
 pallet-funding.workspace = true
@@ -37,8 +36,8 @@ pallet-linear-release.workspace = true
 shared-configuration.workspace = true
 polimec-common.workspace = true
 pallet-parachain-staking.workspace = true
-on-slash-vesting.workspace = true
 pallet-proxy-bonding.workspace = true
+hex-literal = { workspace = true }
 
 # Substrate
 assets-common.workspace = true
@@ -111,8 +110,7 @@ parachains-common.workspace = true
 orml-oracle.workspace = true
 
 # Migration utilities
-hex-literal = { workspace = true }
-array-bytes = { workspace = true, default-features = false }
+# array-bytes = { workspace = true, default-features = false }
 
 [features]
 default = [ "std" ]
@@ -137,7 +135,6 @@ std = [
 	"frame-system/std",
 	"frame-try-runtime?/std",
 	"log/std",
-	"on-slash-vesting/std",
 	"orml-oracle/std",
 	"pallet-asset-tx-payment/std",
 	"pallet-assets/std",
@@ -208,7 +205,6 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system-benchmarking/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
-	"on-slash-vesting/runtime-benchmarks",
 	"orml-oracle/runtime-benchmarks",
 	"pallet-asset-tx-payment/runtime-benchmarks",
 	"pallet-assets/runtime-benchmarks",

--- a/runtimes/polimec/src/lib.rs
+++ b/runtimes/polimec/src/lib.rs
@@ -71,22 +71,24 @@ use sp_runtime::{
 };
 use sp_std::{cmp::Ordering, prelude::*};
 use sp_version::RuntimeVersion;
-use xcm::{IntoVersion, VersionedAssets, VersionedLocation, VersionedXcm};
 
 // XCM Imports
-use xcm::v3::{
-	Junction::{GeneralIndex, PalletInstance, Parachain},
-	Junctions::{Here, X3},
-	MultiLocation,
+use xcm::{
+	v3::{
+		Junction::{GeneralIndex, PalletInstance, Parachain},
+		Junctions::{Here, X3},
+		MultiLocation,
+	},
+	VersionedAssets, VersionedLocation, VersionedXcm,
 };
-#[cfg(not(feature = "runtime-benchmarks"))]
-use xcm_config::XcmConfig;
-
 use xcm_config::{PriceForSiblingParachainDelivery, XcmOriginToTransactDispatchOrigin};
 use xcm_fee_payment_runtime_api::{
 	dry_run::{CallDryRunEffects, Error as XcmDryRunApiError, XcmDryRunEffects},
 	fees::Error as XcmPaymentApiError,
 };
+
+#[cfg(not(feature = "runtime-benchmarks"))]
+use xcm_config::XcmConfig;
 
 // Polimec Shared Imports
 pub use pallet_parachain_staking;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.77.0"
+channel = "1.81.0"
 components = [ "rustfmt", "clippy", "rust-analyzer", "rust-src" ]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
## What?

Upgrade to Rust 1.81.0 (matching https://github.com/paritytech/srtool/commit/c59ee05a41e2fb4e3facc5241d4c7ea22bbc93a8), fix the various new (and old) compiler/clippy warnings and remove unused dependencies from the various internal crates.

## Anything Else?

A `cargo clean` is recommended. 