### PR TITLE
🙅🏻‍♂️ Add end block check on participations

### DIFF
--- a/integration-tests/src/tests/otm_edge_cases.rs
+++ b/integration-tests/src/tests/otm_edge_cases.rs
@@ -77,8 +77,11 @@ fn otm_fee_below_min_amount_reverts() {
 
 		assert!(min_usdt_contribution_otm_fee < usdt_min_balance);
 
-		let ct_for_min_usdt_contribution =
-			PolimecFunding::funding_asset_to_ct_amount_classic(project_id, AcceptedFundingAsset::USDT, min_usdt_contribution);
+		let ct_for_min_usdt_contribution = PolimecFunding::funding_asset_to_ct_amount_classic(
+			project_id,
+			AcceptedFundingAsset::USDT,
+			min_usdt_contribution,
+		);
 
 		let jwt = get_mock_jwt_with_cid(
 			bobert.clone(),
@@ -152,8 +155,11 @@ fn after_otm_fee_user_goes_under_ed_reverts() {
 		let usdt_contribution = usdt_price.reciprocal().unwrap().saturating_mul_int(usd_contribution);
 		let usdt_otm_fee = usdt_price.reciprocal().unwrap().saturating_mul_int(usd_otm_fee);
 
-		let ct_for_contribution =
-			PolimecFunding::funding_asset_to_ct_amount_classic(project_id, AcceptedFundingAsset::USDT, usdt_contribution);
+		let ct_for_contribution = PolimecFunding::funding_asset_to_ct_amount_classic(
+			project_id,
+			AcceptedFundingAsset::USDT,
+			usdt_contribution,
+		);
 		let jwt = get_mock_jwt_with_cid(
 			bobert.clone(),
 			InvestorType::Retail,

--- a/pallets/funding/src/functions/2_evaluation.rs
+++ b/pallets/funding/src/functions/2_evaluation.rs
@@ -94,6 +94,10 @@ impl<T: Config> Pallet<T> {
 		ensure!(usd_amount >= T::MinUsdPerEvaluation::get(), Error::<T>::TooLow);
 		ensure!(project_details.issuer_did != did, Error::<T>::ParticipationToOwnProject);
 		ensure!(project_details.status == ProjectStatus::EvaluationRound, Error::<T>::IncorrectRound);
+		ensure!(
+			project_details.round_duration.started(now) && !project_details.round_duration.ended(now),
+			Error::<T>::IncorrectRound
+		);
 		ensure!(total_evaluations_count < T::MaxEvaluationsPerProject::get(), Error::<T>::TooManyProjectParticipations);
 		ensure!(user_evaluations_count < T::MaxEvaluationsPerUser::get(), Error::<T>::TooManyUserParticipations);
 

--- a/pallets/funding/src/functions/3_auction.rs
+++ b/pallets/funding/src/functions/3_auction.rs
@@ -90,6 +90,10 @@ impl<T: Config> Pallet<T> {
 		ensure!(did != project_details.issuer_did, Error::<T>::ParticipationToOwnProject);
 		ensure!(matches!(project_details.status, ProjectStatus::AuctionRound), Error::<T>::IncorrectRound);
 		ensure!(
+			project_details.round_duration.started(now) && !project_details.round_duration.ended(now),
+			Error::<T>::IncorrectRound
+		);
+		ensure!(
 			project_metadata.participation_currencies.contains(&funding_asset),
 			Error::<T>::FundingAssetNotAccepted
 		);

--- a/pallets/funding/src/functions/4_contribution.rs
+++ b/pallets/funding/src/functions/4_contribution.rs
@@ -24,9 +24,11 @@ impl<T: Config> Pallet<T> {
 
 		let now = <frame_system::Pallet<T>>::block_number();
 		let remainder_started = now >= remainder_start;
-		let round_end = project_details.round_duration.end().ok_or(Error::<T>::ImpossibleState)?;
 		ensure!(!did_has_winning_bid || remainder_started, Error::<T>::UserHasWinningBid);
-		ensure!(now < round_end, Error::<T>::TooLateForRound);
+		ensure!(
+			project_details.round_duration.started(now) && !project_details.round_duration.ended(now),
+			Error::<T>::IncorrectRound
+		);
 
 		let buyable_tokens = token_amount.min(project_details.remaining_contribution_tokens);
 		if buyable_tokens.is_zero() {

--- a/pallets/funding/src/runtime_api.rs
+++ b/pallets/funding/src/runtime_api.rs
@@ -1,6 +1,6 @@
+use crate::traits::BondingRequirementCalculation;
 #[allow(clippy::wildcard_imports)]
 use crate::*;
-use crate::{traits::BondingRequirementCalculation};
 use alloc::collections::BTreeMap;
 use frame_support::traits::fungibles::{Inspect, InspectEnumerable};
 use itertools::Itertools;
@@ -194,7 +194,7 @@ impl<T: Config> Pallet<T> {
 		let otm_fee_plmc_percentage = <T as pallet_proxy_bonding::Config>::FeePercentage::get();
 		let otm_fee_usd_percentage = otm_fee_plmc_percentage / otm_multiplier;
 
-		let divisor = FixedU128::from_perbill(otm_fee_usd_percentage) + FixedU128::from_rational(1,1);
+		let divisor = FixedU128::from_perbill(otm_fee_usd_percentage) + FixedU128::from_rational(1, 1);
 		let participating_funding_asset_amount =
 			divisor.reciprocal().unwrap().saturating_mul_int(total_funding_asset_amount);
 		let fee_funding_asset_amount = total_funding_asset_amount.saturating_sub(participating_funding_asset_amount);

--- a/pallets/funding/src/tests/runtime_api.rs
+++ b/pallets/funding/src/tests/runtime_api.rs
@@ -505,7 +505,7 @@ fn funding_asset_to_ct_amount_otm() {
 			AcceptedFundingAsset::DOT,
 			dot_participation_amount + dot_fee_amount,
 		)
-			.unwrap();
+		.unwrap();
 		assert_close_enough!(ct_amount, expected_ct_amount_contribution, Perquintill::from_float(0.9999));
 		assert_close_enough!(fee_amount, dot_fee_amount, Perquintill::from_float(0.9999));
 	});
@@ -540,7 +540,7 @@ fn funding_asset_to_ct_amount_otm() {
 			AcceptedFundingAsset::DOT,
 			dot_participation_amount + dot_fee_amount,
 		)
-			.unwrap();
+		.unwrap();
 		assert_close_enough!(ct_amount, expected_ct_amount_contribution, Perquintill::from_float(0.9999f64));
 		assert_close_enough!(fee_amount, dot_fee_amount, Perquintill::from_float(0.9999f64));
 	});
@@ -594,7 +594,7 @@ fn funding_asset_to_ct_amount_otm() {
 			AcceptedFundingAsset::DOT,
 			dot_participation_amount + dot_fee_amount,
 		)
-			.unwrap();
+		.unwrap();
 		assert_close_enough!(ct_amount, expected_ct_amount, Perquintill::from_float(0.9999));
 		assert_close_enough!(fee_amount, dot_fee_amount, Perquintill::from_float(0.9999));
 	});
@@ -618,7 +618,7 @@ fn funding_asset_to_ct_amount_otm() {
 			AcceptedFundingAsset::DOT,
 			dot_participation_amount + dot_fee_amount,
 		)
-			.unwrap();
+		.unwrap();
 		assert_close_enough!(ct_amount, expected_ct_amount, Perquintill::from_float(0.9999));
 		assert_close_enough!(fee_amount, dot_fee_amount, Perquintill::from_float(0.9999));
 	});


### PR DESCRIPTION
## What?
Disallow participations done after the round end, and before the project was transitioned to a new state

## Why?
This was unintended behavior

## How?
One more ensure in each function. Quite simple

## Testing?
One new failure test for evaluate/bid/contribute
