### PR TITLE
🔧 Set round end block to None on evaluation fail

### DIFF
--- a/pallets/funding/src/functions/2_evaluation.rs
+++ b/pallets/funding/src/functions/2_evaluation.rs
@@ -60,7 +60,7 @@ impl<T: Config> Pallet<T> {
 				project_details,
 				ProjectStatus::EvaluationRound,
 				ProjectStatus::FundingFailed,
-				Some(One::one()),
+				None,
 				false,
 			)
 		}


### PR DESCRIPTION
## Why?
- All rounds that don't have an end depending on time, should have a None end. This includes `FundingSuccessful`, `FundingFailed`, all Settlement states, and all Migration states.

## Testing?
- No new tests needed since its something affecting the UI
