### PR TITLE
WETH from AssetHub support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8807,6 +8807,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
  "hex-literal",
+ "lazy_static",
  "log",
  "orml-oracle",
  "pallet-asset-tx-payment",

--- a/integration-tests/src/constants.rs
+++ b/integration-tests/src/constants.rs
@@ -69,6 +69,7 @@ pub struct Prices {
 	pub usdc: FixedU128,
 	pub usdt: FixedU128,
 	pub plmc: FixedU128,
+	pub weth: FixedU128,
 }
 
 // PricesBuilder for optional fields before building Prices
@@ -78,12 +79,13 @@ pub struct PricesBuilder {
 	usdc: Option<FixedU128>,
 	usdt: Option<FixedU128>,
 	plmc: Option<FixedU128>,
+	weth: Option<FixedU128>,
 }
 
 impl PricesBuilder {
 	// Initialize a new builder with None for each field
 	pub fn new() -> Self {
-		Self { dot: None, usdc: None, usdt: None, plmc: None }
+		Self { dot: None, usdc: None, usdt: None, plmc: None, weth: None }
 	}
 
 	pub fn default() -> Prices {
@@ -92,6 +94,7 @@ impl PricesBuilder {
 			usdc: FixedU128::from_rational(1, 1),
 			usdt: FixedU128::from_rational(1, 1),
 			plmc: FixedU128::from_rational(840, 100),
+			weth: FixedU128::from_rational(3620, 1),
 		}
 	}
 
@@ -116,6 +119,11 @@ impl PricesBuilder {
 		self
 	}
 
+	pub fn weth(&mut self, price: FixedU128) -> &mut Self {
+		self.weth = Some(price);
+		self
+	}
+
 	// Build Prices using provided values or default values
 	pub fn build(self) -> Prices {
 		Prices {
@@ -123,6 +131,7 @@ impl PricesBuilder {
 			usdc: self.usdc.unwrap_or(FixedU128::from_rational(1, 1)), // Default USDC price
 			usdt: self.usdt.unwrap_or(FixedU128::from_rational(1, 1)), // Default USDT price
 			plmc: self.plmc.unwrap_or(FixedU128::from_rational(840, 100)), // Default PLMC price
+			weth: self.weth.unwrap_or(FixedU128::from_rational(3620, 1)), // Default WETH price
 		}
 	}
 }
@@ -446,9 +455,10 @@ pub mod polimec {
 			let usdc = (AcceptedFundingAsset::USDC.id(), prices.usdc);
 			let usdt = (AcceptedFundingAsset::USDT.id(), prices.usdt);
 			let plmc = (polimec_common::PLMC_FOREIGN_ID, prices.plmc);
+			let weth = (AcceptedFundingAsset::WETH.id(), prices.weth);
 
 			let values: BoundedVec<(u32, FixedU128), <PolimecRuntime as orml_oracle::Config>::MaxFeedValues> =
-				vec![dot, usdc, usdt, plmc].try_into().expect("benchmarks can panic");
+				vec![dot, usdc, usdt, plmc, weth].try_into().expect("benchmarks can panic");
 			let alice: [u8; 32] = [
 				212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130, 44, 133, 88, 133, 76, 205,
 				227, 154, 86, 132, 231, 165, 109, 162, 125,
@@ -483,6 +493,8 @@ pub mod polimec {
 		let dot_asset_id = AcceptedFundingAsset::DOT.id();
 		let usdt_asset_id = AcceptedFundingAsset::USDT.id();
 		let usdc_asset_id = AcceptedFundingAsset::USDC.id();
+		let weth_asset_id = AcceptedFundingAsset::WETH.id();
+
 		let mut funded_accounts = vec![
 			(
 				PolimecNet::sovereign_account_id_of((Parent, xcm::prelude::Parachain(penpal::PARA_ID)).into()),
@@ -515,11 +527,13 @@ pub mod polimec {
 					(dot_asset_id, alice_account.clone(), true, 100_000_000),
 					(usdt_asset_id, alice_account.clone(), true, 70_000),
 					(usdc_asset_id, alice_account.clone(), true, 70_000),
+					(weth_asset_id, alice_account.clone(), true, 0_000_041_000_000_000_000),
 				],
 				metadata: vec![
 					(dot_asset_id, "Local DOT".as_bytes().to_vec(), "DOT".as_bytes().to_vec(), 10),
 					(usdt_asset_id, "Local USDT".as_bytes().to_vec(), "USDT".as_bytes().to_vec(), 6),
 					(usdc_asset_id, "Local USDC".as_bytes().to_vec(), "USDC".as_bytes().to_vec(), 6),
+					(usdc_asset_id, "Local WETH".as_bytes().to_vec(), "WETH".as_bytes().to_vec(), 18),
 				],
 				accounts: vec![],
 			},

--- a/integration-tests/src/tests/ethereum_support.rs
+++ b/integration-tests/src/tests/ethereum_support.rs
@@ -10,7 +10,7 @@ fn test_hardcoded_signatures() {
 	let project_id = 1;
 
 	// Values generated with `https://github.com/lrazovic/ethsigner`
-	let polimec_account_ss58 = polimec_runtime::SS58Converter::convert(polimec_account.clone());
+	let _polimec_account_ss58 = polimec_runtime::SS58Converter::convert(polimec_account.clone());
 	let ethereum_account: [u8; 20] = hex!("796afe7b8933ee8cf337f17887e5c19b657f9ab8");
 	let signature: [u8; 65] = hex!("952e312ac892fefc7c69051521e78a3bc2727fbb495585bdb5fb77e662b8a3de2b1254058d824e85034710e338c2590e2f92d74ce3c60292ed25c7537d94ed621b");
 

--- a/pallets/funding/src/instantiator/chain_interactions.rs
+++ b/pallets/funding/src/instantiator/chain_interactions.rs
@@ -545,12 +545,14 @@ impl<
 		let mut total_expected_dot: Balance = Zero::zero();
 		let mut total_expected_usdt: Balance = Zero::zero();
 		let mut total_expected_usdc: Balance = Zero::zero();
+		let mut total_expected_weth: Balance = Zero::zero();
 
 		for bid in bids {
 			match bid.funding_asset {
 				AcceptedFundingAsset::DOT => total_expected_dot += bid.funding_asset_amount_locked,
 				AcceptedFundingAsset::USDT => total_expected_usdt += bid.funding_asset_amount_locked,
 				AcceptedFundingAsset::USDC => total_expected_usdc += bid.funding_asset_amount_locked,
+				AcceptedFundingAsset::WETH => total_expected_weth += bid.funding_asset_amount_locked,
 			}
 		}
 
@@ -559,6 +561,7 @@ impl<
 				AcceptedFundingAsset::DOT => total_expected_dot += contribution.funding_asset_amount,
 				AcceptedFundingAsset::USDT => total_expected_usdt += contribution.funding_asset_amount,
 				AcceptedFundingAsset::USDC => total_expected_usdc += contribution.funding_asset_amount,
+				AcceptedFundingAsset::WETH => total_expected_weth += contribution.funding_asset_amount,
 			}
 		}
 
@@ -572,12 +575,17 @@ impl<
 		);
 		let total_stored_usdc = self.get_free_funding_asset_balance_for(
 			AcceptedFundingAsset::USDC.id(),
+			project_metadata.funding_destination_account.clone(),
+		);
+		let total_stored_weth = self.get_free_funding_asset_balance_for(
+			AcceptedFundingAsset::WETH.id(),
 			project_metadata.funding_destination_account,
 		);
 
 		assert_eq!(total_expected_dot, total_stored_dot, "DOT amount is incorrect");
 		assert_eq!(total_expected_usdt, total_stored_usdt, "USDT amount is incorrect");
 		assert_eq!(total_expected_usdc, total_stored_usdc, "USDC amount is incorrect");
+		assert_eq!(total_expected_weth, total_stored_weth, "WETH amount is incorrect");
 	}
 
 	// Used to check if all evaluations are settled correctly. We cannot check amount of

--- a/pallets/funding/src/mock.rs
+++ b/pallets/funding/src/mock.rs
@@ -362,6 +362,7 @@ thread_local! {
 		(AcceptedFundingAsset::DOT.id(), FixedU128::from_float(69f64)), // DOT
 		(AcceptedFundingAsset::USDC.id(), FixedU128::from_float(0.97f64)), // USDC
 		(AcceptedFundingAsset::USDT.id(), FixedU128::from_float(1.0f64)), // USDT
+		(AcceptedFundingAsset::WETH.id(), FixedU128::from_float(3619.451f64)), // WETH
 		(PLMC_FOREIGN_ID, FixedU128::from_float(8.4f64)), // PLMC
 	]));
 }
@@ -511,11 +512,19 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 					true,
 					100_000_000,
 				),
+				(
+					AcceptedFundingAsset::WETH.id(),
+					<TestRuntime as Config>::PalletId::get().into_account_truncating(),
+					true,
+					// 0.07 USD = .000041WETH at this moment
+					0_000_041_000_000_000_000,
+				),
 			],
 			metadata: vec![
 				(AcceptedFundingAsset::USDT.id(), "USDT".as_bytes().to_vec(), "USDT".as_bytes().to_vec(), 6),
 				(AcceptedFundingAsset::USDC.id(), "USDC".as_bytes().to_vec(), "USDC".as_bytes().to_vec(), 6),
 				(AcceptedFundingAsset::DOT.id(), "DOT".as_bytes().to_vec(), "DOT".as_bytes().to_vec(), 10),
+				(AcceptedFundingAsset::WETH.id(), "WETH".as_bytes().to_vec(), "WETH".as_bytes().to_vec(), 18),
 			],
 			accounts: vec![],
 		},

--- a/pallets/funding/src/tests/3_auction.rs
+++ b/pallets/funding/src/tests/3_auction.rs
@@ -147,6 +147,7 @@ mod round_flow {
 					AcceptedFundingAsset::USDT => usdt_price,
 					AcceptedFundingAsset::USDC => usdc_price,
 					AcceptedFundingAsset::DOT => dot_price,
+					AcceptedFundingAsset::WETH => todo!(),
 				};
 
 				let mut project_metadata = default_project_metadata.clone();
@@ -2269,8 +2270,12 @@ mod end_auction_extrinsic {
 			let accounts = [ADAM, TOM, SOFIA, FRED, ANNA, DAMIAN];
 			let mut project_metadata = default_project_metadata(ISSUER_1);
 			project_metadata.total_allocation_size = 100_000 * CT_UNIT;
-			project_metadata.participation_currencies =
-				bounded_vec![AcceptedFundingAsset::USDT, AcceptedFundingAsset::USDC, AcceptedFundingAsset::DOT,];
+			project_metadata.participation_currencies = bounded_vec![
+				AcceptedFundingAsset::USDT,
+				AcceptedFundingAsset::USDC,
+				AcceptedFundingAsset::DOT,
+				AcceptedFundingAsset::WETH
+			];
 
 			// overfund with plmc
 			let plmc_fundings = accounts
@@ -2278,11 +2283,16 @@ mod end_auction_extrinsic {
 				.map(|acc| UserToPLMCBalance { account: *acc, plmc_amount: PLMC * 1_000_000 })
 				.collect_vec();
 
-			let fundings = [AcceptedFundingAsset::USDT, AcceptedFundingAsset::USDC, AcceptedFundingAsset::DOT];
+			let fundings = [
+				AcceptedFundingAsset::USDT,
+				AcceptedFundingAsset::USDC,
+				AcceptedFundingAsset::DOT,
+				AcceptedFundingAsset::WETH,
+			];
 			assert_eq!(fundings.len(), AcceptedFundingAsset::VARIANT_COUNT);
 			let mut fundings = fundings.into_iter().cycle();
 
-			let usdt_fundings = accounts
+			let funding_asset_mints = accounts
 				.iter()
 				.map(|acc| {
 					let accepted_asset = fundings.next().unwrap();
@@ -2293,7 +2303,7 @@ mod end_auction_extrinsic {
 				})
 				.collect_vec();
 			inst.mint_plmc_to(plmc_fundings);
-			inst.mint_funding_asset_to(usdt_fundings);
+			inst.mint_funding_asset_to(funding_asset_mints);
 
 			let project_id = inst.create_auctioning_project(project_metadata, ISSUER_1, None, default_evaluations());
 
@@ -2301,9 +2311,9 @@ mod end_auction_extrinsic {
 				(ADAM, 10_000 * CT_UNIT, ParticipationMode::Classic(1), AcceptedFundingAsset::USDT).into(),
 				(TOM, 20_000 * CT_UNIT, ParticipationMode::Classic(1), AcceptedFundingAsset::USDC).into(),
 				(SOFIA, 20_000 * CT_UNIT, ParticipationMode::Classic(1), AcceptedFundingAsset::DOT).into(),
-				(FRED, 10_000 * CT_UNIT, ParticipationMode::Classic(1), AcceptedFundingAsset::USDT).into(),
-				(ANNA, 5_000 * CT_UNIT, ParticipationMode::Classic(1), AcceptedFundingAsset::USDC).into(),
-				(DAMIAN, 5_000 * CT_UNIT, ParticipationMode::Classic(1), AcceptedFundingAsset::DOT).into(),
+				(FRED, 10_000 * CT_UNIT, ParticipationMode::Classic(1), AcceptedFundingAsset::WETH).into(),
+				(ANNA, 5_000 * CT_UNIT, ParticipationMode::Classic(1), AcceptedFundingAsset::USDT).into(),
+				(DAMIAN, 5_000 * CT_UNIT, ParticipationMode::Classic(1), AcceptedFundingAsset::USDC).into(),
 			];
 
 			inst.bid_for_users(project_id, bids).unwrap();

--- a/pallets/funding/src/tests/4_contribution.rs
+++ b/pallets/funding/src/tests/4_contribution.rs
@@ -210,6 +210,7 @@ mod round_flow {
 					AcceptedFundingAsset::USDT => usdt_price,
 					AcceptedFundingAsset::USDC => usdc_price,
 					AcceptedFundingAsset::DOT => dot_price,
+					AcceptedFundingAsset::WETH => todo!(),
 				};
 
 				let mut project_metadata = default_project_metadata.clone();

--- a/pallets/funding/src/tests/misc.rs
+++ b/pallets/funding/src/tests/misc.rs
@@ -4,7 +4,6 @@ use super::*;
 mod helper_functions {
 	use super::*;
 	use polimec_common::USD_DECIMALS;
-	use sp_core::{ecdsa, hexdisplay::AsBytesRef, keccak_256, sr25519, Pair};
 
 	#[test]
 	fn test_usd_price_decimal_aware() {

--- a/pallets/funding/src/types.rs
+++ b/pallets/funding/src/types.rs
@@ -652,6 +652,8 @@ pub mod inner {
 		USDC,
 		#[codec(index = 2)]
 		DOT,
+		#[codec(index = 3)]
+		WETH,
 	}
 	impl AcceptedFundingAsset {
 		pub const fn id(&self) -> u32 {
@@ -659,6 +661,7 @@ pub mod inner {
 				AcceptedFundingAsset::USDT => 1984,
 				AcceptedFundingAsset::DOT => 10,
 				AcceptedFundingAsset::USDC => 1337,
+				AcceptedFundingAsset::WETH => 10_000,
 			}
 		}
 	}

--- a/pallets/oracle-ocw/src/mock.rs
+++ b/pallets/oracle-ocw/src/mock.rs
@@ -105,6 +105,7 @@ impl Convert<(AssetName, FixedU128), (OracleKey, OracleValue)> for AssetPriceCon
 			AssetName::USDC => (1337, price),
 			AssetName::USDT => (1984, price),
 			AssetName::PLMC => (3344, price),
+			AssetName::WETH => (10_000, price),
 		}
 	}
 }

--- a/pallets/oracle-ocw/src/types.rs
+++ b/pallets/oracle-ocw/src/types.rs
@@ -30,6 +30,7 @@ pub enum AssetName {
 	USDC,
 	DOT,
 	PLMC,
+	WETH,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -131,6 +132,7 @@ impl FetchPrice for KrakenFetcher {
 			AssetName::DOT => "https://api.kraken.com/0/public/OHLC?pair=DOTUSD&interval=1",
 			AssetName::USDC => "https://api.kraken.com/0/public/OHLC?pair=USDCUSD&interval=1",
 			AssetName::PLMC => "",
+			AssetName::WETH => "",
 		}
 	}
 }
@@ -224,6 +226,7 @@ impl FetchPrice for BitStampFetcher {
 			AssetName::DOT => "https://www.bitstamp.net/api/v2/ohlc/dotusd/?step=60&limit=15",
 			AssetName::USDC => "https://www.bitstamp.net/api/v2/ohlc/usdcusd/?step=60&limit=15",
 			AssetName::PLMC => "",
+			AssetName::WETH => "",
 		}
 	}
 }

--- a/runtimes/polimec/Cargo.toml
+++ b/runtimes/polimec/Cargo.toml
@@ -25,6 +25,8 @@ scale-info = { workspace= true, default-features = false, features = [
 	"derive",
 ] }
 
+lazy_static = "1.5.0"
+
 # Uncomment this and the std feature below to see variables instead of <wasm:stripped> in the console output
 #sp-debug-derive = { workspace = true, features = ["force-debug"]}
 

--- a/runtimes/polimec/src/lib.rs
+++ b/runtimes/polimec/src/lib.rs
@@ -837,7 +837,7 @@ parameter_types! {
 	pub const ExpiresIn: Moment = 1000 * 60; // 1 mins
 	pub const MaxHasDispatchedSize: u32 = 20;
 	pub RootOperatorAccountId: AccountId = AccountId::from([0xffu8; 32]);
-	pub const MaxFeedValues: u32 = 4; // max 4 values allowd to feed in one call (USDT, USDC, DOT, PLMC).
+	pub const MaxFeedValues: u32 = AcceptedFundingAsset::VARIANT_COUNT as u32 + 1; // Funding asset prices + PLMC
 }
 
 impl orml_oracle::Config for Runtime {
@@ -1708,9 +1708,9 @@ impl_runtime_apis! {
 		fn query_acceptable_payment_assets(xcm_version: xcm::Version) -> Result<Vec<VersionedAssetId>, XcmPaymentApiError> {
 			let acceptable_assets = vec![
 				xcm_config::HereLocation::get().into(),
-				xcm_config::DotLocation::get().into(),
-				xcm_config::UsdtLocation::get().into(),
-				xcm_config::UsdcLocation::get().into()
+				xcm_config::DOTLocation::get().into(),
+				xcm_config::USDTLocation::get().into(),
+				xcm_config::USDCLocation::get().into()
 			];
 
 			PolkadotXcm::query_acceptable_payment_assets(xcm_version, acceptable_assets)

--- a/runtimes/shared-configuration/src/currency.rs
+++ b/runtimes/shared-configuration/src/currency.rs
@@ -90,6 +90,7 @@ impl Convert<(AssetName, FixedU128), (AssetId, Price)> for AssetPriceConverter {
 			AssetName::USDC => (AcceptedFundingAsset::USDC.id(), price),
 			AssetName::USDT => (AcceptedFundingAsset::USDT.id(), price),
 			AssetName::PLMC => (PLMC_FOREIGN_ID, price),
+			AssetName::WETH => (AcceptedFundingAsset::WETH.id(), price),
 		}
 	}
 }


### PR DESCRIPTION
## What?
Add WETH from AssetHub as an `AcceptedFundingAsset`

## How?
- Add new enum variant
- Add asset multilocation to xcm filter

## Testing?
- `wap_from_different_funding_assets` modified to add WETH

## Anything Else?
We are missing the following PRs before we can release this feature:
- Integration test with chopsticks
- Price fetcher with the oracle