### PR TITLE
🎗️ Feeless calls

### DIFF
--- a/pallets/funding/src/functions/1_application.rs
+++ b/pallets/funding/src/functions/1_application.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::wildcard_imports)]
 #![allow(clippy::type_complexity)]
 
+use sp_runtime::offchain::http::Method::Post;
 use super::*;
 
 impl<T: Config> Pallet<T> {
@@ -59,7 +60,7 @@ impl<T: Config> Pallet<T> {
 		issuer: &AccountIdOf<T>,
 		project_metadata: ProjectMetadataOf<T>,
 		did: Did,
-	) -> DispatchResult {
+	) -> DispatchResultWithPostInfo {
 		// * Get variables *
 		let project_id = NextProjectId::<T>::get();
 		let maybe_active_project = DidWithActiveProjects::<T>::get(did.clone());
@@ -91,7 +92,10 @@ impl<T: Config> Pallet<T> {
 		// * Emit events *
 		Self::deposit_event(Event::ProjectCreated { project_id, issuer: issuer.clone(), metadata: project_metadata });
 
-		Ok(())
+		Ok(PostDispatchInfo{
+			actual_weight: None,
+			pays_fee: Pays::No,
+		})
 	}
 
 	#[transactional]
@@ -99,7 +103,7 @@ impl<T: Config> Pallet<T> {
 		issuer: AccountIdOf<T>,
 		project_id: ProjectId,
 		new_project_metadata: ProjectMetadataOf<T>,
-	) -> DispatchResult {
+	) -> DispatchResultWithPostInfo {
 		// * Get variables *
 		let project_details = ProjectsDetails::<T>::get(project_id).ok_or(Error::<T>::ProjectDetailsNotFound)?;
 
@@ -119,11 +123,13 @@ impl<T: Config> Pallet<T> {
 		// * Emit events *
 		Self::deposit_event(Event::MetadataEdited { project_id, metadata: new_project_metadata });
 
-		Ok(())
-	}
+		Ok(PostDispatchInfo{
+			actual_weight: None,
+			pays_fee: Pays::No,
+		})	}
 
 	#[transactional]
-	pub fn do_remove_project(issuer: AccountIdOf<T>, project_id: ProjectId, did: Did) -> DispatchResult {
+	pub fn do_remove_project(issuer: AccountIdOf<T>, project_id: ProjectId, did: Did) -> DispatchResultWithPostInfo {
 		// * Get variables *
 		let project_details = ProjectsDetails::<T>::get(project_id).ok_or(Error::<T>::ProjectDetailsNotFound)?;
 
@@ -140,6 +146,8 @@ impl<T: Config> Pallet<T> {
 		// * Emit events *
 		Self::deposit_event(Event::ProjectRemoved { project_id, issuer });
 
-		Ok(())
-	}
+		Ok(PostDispatchInfo{
+			actual_weight: None,
+			pays_fee: Pays::No,
+		})	}
 }

--- a/pallets/funding/src/functions/2_evaluation.rs
+++ b/pallets/funding/src/functions/2_evaluation.rs
@@ -3,7 +3,7 @@ use super::*;
 use polimec_common::ProvideAssetPrice;
 impl<T: Config> Pallet<T> {
 	#[transactional]
-	pub fn do_start_evaluation(caller: AccountIdOf<T>, project_id: ProjectId) -> DispatchResult {
+	pub fn do_start_evaluation(caller: AccountIdOf<T>, project_id: ProjectId) -> DispatchResultWithPostInfo {
 		// * Get variables *
 		let project_metadata = ProjectsMetadata::<T>::get(project_id).ok_or(Error::<T>::ProjectMetadataNotFound)?;
 		let mut project_details = ProjectsDetails::<T>::get(project_id).ok_or(Error::<T>::ProjectDetailsNotFound)?;
@@ -24,7 +24,12 @@ impl<T: Config> Pallet<T> {
 			ProjectStatus::EvaluationRound,
 			Some(T::EvaluationRoundDuration::get()),
 			false,
-		)
+		)?;
+
+		Ok(PostDispatchInfo{
+			actual_weight: None,
+			pays_fee: Pays::No,
+		})
 	}
 
 	#[transactional]
@@ -156,7 +161,7 @@ impl<T: Config> Pallet<T> {
 
 		Ok(PostDispatchInfo {
 			actual_weight: Some(WeightInfoOf::<T>::evaluate(user_evaluations_count)),
-			pays_fee: Pays::Yes,
+			pays_fee: Pays::No,
 		})
 	}
 }

--- a/pallets/funding/src/functions/3_auction.rs
+++ b/pallets/funding/src/functions/3_auction.rs
@@ -164,7 +164,7 @@ impl<T: Config> Pallet<T> {
 
 		Ok(PostDispatchInfo {
 			actual_weight: Some(WeightInfoOf::<T>::bid(existing_bids_amount, perform_bid_calls)),
-			pays_fee: Pays::Yes,
+			pays_fee: Pays::No,
 		})
 	}
 

--- a/pallets/funding/src/functions/4_contribution.rs
+++ b/pallets/funding/src/functions/4_contribution.rs
@@ -159,6 +159,6 @@ impl<T: Config> Pallet<T> {
 
 		// return correct weight function
 		let actual_weight = Some(WeightInfoOf::<T>::contribute(caller_existing_contributions.len() as u32));
-		Ok(PostDispatchInfo { actual_weight, pays_fee: Pays::Yes })
+		Ok(PostDispatchInfo { actual_weight, pays_fee: Pays::No })
 	}
 }

--- a/pallets/funding/src/functions/7_ct_migration.rs
+++ b/pallets/funding/src/functions/7_ct_migration.rs
@@ -5,7 +5,7 @@ use xcm::v4::MaxPalletNameLen;
 // Offchain migration functions
 impl<T: Config> Pallet<T> {
 	#[transactional]
-	pub fn do_start_offchain_migration(project_id: ProjectId, caller: AccountIdOf<T>) -> DispatchResult {
+	pub fn do_start_offchain_migration(project_id: ProjectId, caller: AccountIdOf<T>) -> DispatchResultWithPostInfo {
 		let mut project_details = ProjectsDetails::<T>::get(project_id).ok_or(Error::<T>::ProjectDetailsNotFound)?;
 
 		ensure!(project_details.issuer_account == caller, Error::<T>::NotIssuer);
@@ -21,8 +21,10 @@ impl<T: Config> Pallet<T> {
 			false,
 		)?;
 
-		Ok(())
-	}
+		Ok(PostDispatchInfo{
+			actual_weight: None,
+			pays_fee: Pays::No,
+		})	}
 
 	#[transactional]
 	pub fn do_confirm_offchain_migration(
@@ -50,7 +52,7 @@ impl<T: Config> Pallet<T> {
 		caller: &AccountIdOf<T>,
 		project_id: ProjectId,
 		para_id: ParaId,
-	) -> DispatchResult {
+	) -> DispatchResultWithPostInfo {
 		// * Get variables *
 		let mut project_details = ProjectsDetails::<T>::get(project_id).ok_or(Error::<T>::ProjectDetailsNotFound)?;
 
@@ -83,8 +85,10 @@ impl<T: Config> Pallet<T> {
 			false,
 		)?;
 
-		Ok(())
-	}
+		Ok(PostDispatchInfo{
+			actual_weight: None,
+			pays_fee: Pays::No,
+		})	}
 
 	/// Handle the channel open request from the relay on behalf of a parachain.
 	/// If the parachain id belongs to a funded project with the same project id, then send an acceptance message and a request for a
@@ -206,7 +210,7 @@ impl<T: Config> Pallet<T> {
 	/// After the bidirectional HRMP channels are established, check that the project chain has the Polimec receiver pallet,
 	/// and has minted the amount of CTs sold to the Polimec sovereign account.
 	#[transactional]
-	pub fn do_start_pallet_migration_readiness_check(caller: &AccountIdOf<T>, project_id: ProjectId) -> DispatchResult {
+	pub fn do_start_pallet_migration_readiness_check(caller: &AccountIdOf<T>, project_id: ProjectId) -> DispatchResultWithPostInfo {
 		// * Get variables *
 		let mut project_details = ProjectsDetails::<T>::get(project_id).ok_or(Error::<T>::ProjectDetailsNotFound)?;
 		let Some(MigrationType::Pallet(ref mut migration_info)) = project_details.migration_type else {
@@ -298,8 +302,10 @@ impl<T: Config> Pallet<T> {
 		// * Emit events *
 		Self::deposit_event(Event::<T>::MigrationReadinessCheckStarted { project_id, caller: caller.clone() });
 
-		Ok(())
-	}
+		Ok(PostDispatchInfo{
+			actual_weight: None,
+			pays_fee: Pays::No,
+		})	}
 
 	/// Handle the migration readiness check response from the project chain.
 	#[transactional]


### PR DESCRIPTION
## What?
Refund the extrinsic execution fee for calls that require a JWT

## Why?
The fee payment is used to avoid spamming and stalling the chain, but all JWT calls from regular KYCs need to either pay a fee with OTM, or lock up PLMC.

And the other ones are locked behind an institutional JWT, so even if they act malicious we could check who they are and take action.

This should provide better UX, since you can say you spend 100USDT and spend 100USDT, instead of 100.03

## How?
Instead of returning `Ok(())` return 
```
Ok(PostDispatchInfo{
   actual_weight: None,
   pays_fee: Pays::No,
})
```

## Testing?
Tests don't include fee payments for extrinsics. So only way I can see to test this is creating a network with chopsticks/zombienet and trying it out ourselves.

For now it hasn't been tested, but its a simple change so should work.
