### PR TITLE
🚮 Remove WAP

### DIFF
--- a/integration-tests/src/tests/e2e.rs
+++ b/integration-tests/src/tests/e2e.rs
@@ -158,24 +158,20 @@ fn pre_wap_bids() -> Vec<(u32, [u8; 32], ParticipationMode, InvestorType, u64, f
 	]
 }
 
-fn wap() -> f64 {
-	10.30346708
-}
-
 #[allow(unused)]
 fn post_wap_bids() -> Vec<(u32, [u8; 32], ParticipationMode, InvestorType, u64, f64, AcceptedFundingAsset, f64, f64)> {
 	// (bid_id, User, Participation mode, Investor type, CTs specified in extrinsic, CT Price, Participation Currency, Final participation currency ticket, PLMC bonded as a consequence)
 	vec![
-		(21, SAM, OTM, Professional, 2_000, 10.303467, USDT, 20_916.0382, 22_620.1253),
-		(22, SAM, OTM, Professional, 2_200, 10.303467, DOT, 4_947.8800, 24_882.1378),
-		(16, DAVE, OTM, Professional, 1_000, 10.303467, USDT, 10_458.0191, 11_310.0627),
-		(17, GERALT, Classic(15), Institutional, 500, 10.303467, USDT, 5_151.7335, 1_885.0104),
-		(18, GEORGE, Classic(20), Institutional, 1_900, 10.303467, USDT, 19_576.5875, 5_372.2798),
-		(19, GINO, Classic(25), Institutional, 600, 10.303467, USDT, 6_182.0802, 1_357.2075),
-		(20, STEVE, OTM, Professional, 1_000, 10.303467, USDT, 10_458.0191, 11_310.0627),
-		(0, BROCK, OTM, Professional, 700, 10.000000, USDC, 7_101.4493, 7_683.8639),
-		(1, BEN, OTM, Professional, 4_000, 10.000000, USDT, 40_600.0000, 43_907.7936),
-		(2, BILL, Classic(3), Professional, 3_000, 10.000000, USDC, 29_985.0075, 54_884.7420),
+		(21, SAM, OTM, Professional, 2_000, 12.0, USDT, 24000.0, 26344.6762),
+		(22, SAM, OTM, Professional, 2_200, 12.0, DOT, 5677.419355, 28979.1438),
+		(16, DAVE, OTM, Professional, 1_000, 11.0, USDT, 11000.0, 12074.6432),
+		(17, GERALT, Classic(15), Institutional, 500, 11.0, USDT, 5500.0, 2012.4405),
+		(18, GEORGE, Classic(20), Institutional, 1_900, 11.0, USDT, 20900.0, 5735.4555),
+		(19, GINO, Classic(25), Institutional, 600, 11.0, USDT, 6600.0, 1448.9572),
+		(20, STEVE, OTM, Professional, 1_000, 11.0, USDT, 11000.0, 12074.6432),
+		(0, BROCK, OTM, Professional, 700, 10.000000, USDC, 6996.501749, 7_683.8639),
+		(1, BEN, OTM, Professional, 4_000, 10.000000, USDT, 40_000.0, 43_907.7936),
+		(2, BILL, Classic(3), Professional, 3_000, 10.000000, USDC, 29985.0075, 54_884.7420),
 		(3, BRAD, Classic(6), Professional, 700, 10.000000, USDT, 7_000.0000, 6_403.2199),
 		(4, BROCK, Classic(9), Professional, 3_400, 10.000000, USDT, 34_000.0000, 20_734.2359),
 		(5, BLAIR, Classic(8), Professional, 1_000, 10.000000, USDT, 10_000.0000, 6_860.5928),
@@ -187,7 +183,7 @@ fn post_wap_bids() -> Vec<(u32, [u8; 32], ParticipationMode, InvestorType, u64, 
 		(11, BELLA, Classic(1), Professional, 800, 10.000000, USDT, 8_000.0000, 43_907.7936),
 		(12, BRUCE, Classic(4), Institutional, 3_000, 10.000000, USDT, 30_000.0000, 41_163.5565),
 		(13, BRENT, Classic(1), Institutional, 8_000, 10.000000, USDT, 80_000.0000, 439_077.9363),
-		(14, DOUG, OTM, Institutional, 100, 10.000000, USDT, 1_015.0000, 5_488.4742),
+		(14, DOUG, OTM, Institutional, 100, 10.000000, USDT, 1000.0, 5_488.4742),
 		(15, DAVE, OTM, Professional, 0, 10.000000, USDT, 0.00, 0.00),
 	]
 }
@@ -198,7 +194,7 @@ fn cts_minted() -> f64 {
 }
 
 fn usd_raised() -> f64 {
-	502_791.8972
+	513_400.0000
 }
 
 #[allow(unused)]
@@ -209,7 +205,7 @@ fn ct_fees() -> (f64, f64, f64) {
 
 fn issuer_payouts() -> (f64, f64, f64) {
 	// (USDT, USDC, DOT)
-	(430_124.27, 36_981.51, 7_670.46)
+	(437_000.00, 36_981.51, 8_473.12)
 }
 
 fn evaluator_reward_pots() -> (f64, f64, f64, f64) {
@@ -245,9 +241,9 @@ fn final_payouts() -> Vec<([u8; 32], f64, f64)> {
 		(DAVE, 1059.661749, 0.00),
 		(MASON, 35.37757672, 0.00),
 		(MIKE, 82.74302164, 0.00),
-		(GERALT, 500.0, 1_885.01),
-		(GEORGE, 1_900.0, 5_372.28),
-		(GINO, 600.0, 1_357.21),
+		(GERALT, 500.0, 2_012.44),
+		(GEORGE, 1_900.0, 5_735.46),
+		(GINO, 600.0, 1_448.96),
 		(STEVE, 1017.159307, 0.0),
 		(SAM, 4267.09505, 0.0),
 	]
@@ -255,7 +251,7 @@ fn final_payouts() -> Vec<([u8; 32], f64, f64)> {
 
 fn otm_fee_recipient_balances() -> (f64, f64, f64) {
 	// USDT, USDC, DOT
-	(1233.208025, 104.9475262, 73.12137929)
+	(1305.0, 104.9475262, 85.16129032)
 }
 
 fn otm_treasury_sub_account_plmc_held() -> f64 {
@@ -462,18 +458,6 @@ fn e2e_test() {
 
 		let project_details = inst.get_project_details(project_id);
 		let project_metadata = inst.get_project_metadata(project_id);
-		let stored_wap = project_details.weighted_average_price.unwrap();
-		let expected_wap = PriceProviderOf::<PolimecRuntime>::calculate_decimals_aware_price(
-			PriceOf::<PolimecRuntime>::from_float(wap()),
-			USD_DECIMALS,
-			CT_DECIMALS,
-		)
-		.unwrap();
-		assert_close_enough!(
-			stored_wap.saturating_mul_int(PLMC),
-			expected_wap.saturating_mul_int(PLMC),
-			Perquintill::from_float(0.9999)
-		);
 
 		let actual_cts_minted = polimec_runtime::ContributionTokens::total_issuance(project_id);
 		let expected_cts_minted = FixedU128::from_float(cts_minted()).saturating_mul_int(CT_UNIT);
@@ -544,6 +528,8 @@ fn e2e_test() {
 		);
 
 		for (user, ct_rewarded, plmc_bonded) in final_payouts() {
+			let names = names();
+
 			let user: PolimecAccountId = user.into();
 			let ct_rewarded = FixedU128::from_float(ct_rewarded).saturating_mul_int(CT_UNIT);
 			let plmc_bonded = FixedU128::from_float(plmc_bonded).saturating_mul_int(PLMC);

--- a/pallets/funding/src/functions/1_application.rs
+++ b/pallets/funding/src/functions/1_application.rs
@@ -33,7 +33,6 @@ impl<T: Config> Pallet<T> {
 			issuer_account: issuer.clone(),
 			issuer_did: did.clone(),
 			is_frozen: false,
-			weighted_average_price: None,
 			fundraising_target_usd: fundraising_target,
 			status: ProjectStatus::Application,
 			round_duration: BlockNumberPair::new(None, None),

--- a/pallets/funding/src/functions/5_funding_end.rs
+++ b/pallets/funding/src/functions/5_funding_end.rs
@@ -26,8 +26,6 @@ impl<T: Config> Pallet<T> {
 		ProjectsInAuctionRound::<T>::put(WeakBoundedVec::force_from(project_ids, None));
 
 		let auction_allocation_size = project_metadata.total_allocation_size;
-		let weighted_average_price = bucket.calculate_wap(auction_allocation_size);
-		project_details.weighted_average_price = Some(weighted_average_price);
 
 		let bucket_price_higher_than_initial = bucket.current_price > bucket.initial_price;
 		let sold_percent =
@@ -39,7 +37,7 @@ impl<T: Config> Pallet<T> {
 
 		DidWithActiveProjects::<T>::set(issuer_did, None);
 
-		let usd_raised = Self::calculate_usd_sold_from_bucket(bucket.clone(), project_metadata.total_allocation_size);
+		let usd_raised = bucket.calculate_usd_raised(auction_allocation_size);
 		project_details.funding_amount_reached_usd = usd_raised;
 		project_details.remaining_contribution_tokens =
 			if bucket.current_price == bucket.initial_price { bucket.amount_left } else { Zero::zero() };

--- a/pallets/funding/src/instantiator/chain_interactions.rs
+++ b/pallets/funding/src/instantiator/chain_interactions.rs
@@ -284,7 +284,6 @@ impl<
 			issuer_account: self.get_issuer(project_id),
 			issuer_did,
 			is_frozen: false,
-			weighted_average_price: None,
 			status: ProjectStatus::Application,
 			round_duration: BlockNumberPair::new(None, None),
 			fundraising_target_usd: expected_metadata
@@ -334,7 +333,6 @@ impl<
 		let project_metadata = self.get_project_metadata(project_id);
 		let project_details = self.get_project_details(project_id);
 		let project_bids = self.execute(|| Bids::<T>::iter_prefix_values(project_id).collect::<Vec<_>>());
-		assert!(project_details.weighted_average_price.is_some(), "Weighted average price should exist");
 
 		for filter in bid_expectations {
 			let _found_bid = project_bids.iter().find(|bid| filter.matches_bid(bid)).unwrap();

--- a/pallets/funding/src/instantiator/tests.rs
+++ b/pallets/funding/src/instantiator/tests.rs
@@ -1,170 +1,11 @@
 use crate::{
-	instantiator::{UserToFundingAsset, UserToPLMCBalance},
-	mock::{new_test_ext, TestRuntime, PLMC},
-	tests::{
-		defaults::{bounded_name, bounded_symbol, default_project_metadata, ipfs_hash},
-		CT_DECIMALS, CT_UNIT,
-	},
+	mock::{new_test_ext, TestRuntime},
+	tests::{defaults::default_project_metadata, CT_DECIMALS, CT_UNIT},
 	*,
 };
 use core::cell::RefCell;
-use itertools::Itertools;
 use polimec_common::{assets::AcceptedFundingAsset, ProvideAssetPrice, USD_DECIMALS, USD_UNIT};
 use sp_arithmetic::Perquintill;
-
-#[test]
-fn dry_run_wap() {
-	let mut inst = tests::MockInstantiator::new(Some(RefCell::new(new_test_ext())));
-
-	const ADAM: AccountIdOf<TestRuntime> = 60;
-	const TOM: AccountIdOf<TestRuntime> = 61;
-	const SOFIA: AccountIdOf<TestRuntime> = 62;
-	const FRED: AccountIdOf<TestRuntime> = 63;
-	const ANNA: AccountIdOf<TestRuntime> = 64;
-	const DAMIAN: AccountIdOf<TestRuntime> = 65;
-
-	let accounts = [ADAM, TOM, SOFIA, FRED, ANNA, DAMIAN];
-
-	let bounded_name = bounded_name();
-	let bounded_symbol = bounded_symbol();
-	let metadata_hash = ipfs_hash();
-	let normalized_price = PriceOf::<TestRuntime>::from_float(10.0);
-	let decimal_aware_price =
-		PriceProviderOf::<TestRuntime>::calculate_decimals_aware_price(normalized_price, USD_DECIMALS, CT_DECIMALS)
-			.unwrap();
-	let project_metadata = ProjectMetadata {
-		token_information: CurrencyMetadata { name: bounded_name, symbol: bounded_symbol, decimals: CT_DECIMALS },
-		mainnet_token_max_supply: 8_000_000 * CT_UNIT,
-		total_allocation_size: 100_000 * CT_UNIT,
-		minimum_price: decimal_aware_price,
-		bidding_ticket_sizes: BiddingTicketSizes {
-			professional: TicketSize::new(5000 * USD_UNIT, None),
-			institutional: TicketSize::new(5000 * USD_UNIT, None),
-			retail: TicketSize::new(100 * USD_UNIT, None),
-			phantom: Default::default(),
-		},
-		participation_currencies: vec![AcceptedFundingAsset::USDT].try_into().unwrap(),
-		funding_destination_account: 0,
-		policy_ipfs_cid: Some(metadata_hash),
-		participants_account_type: ParticipantsAccountType::Polkadot,
-	};
-
-	// overfund with plmc
-	let plmc_fundings =
-		accounts.iter().map(|acc| UserToPLMCBalance { account: *acc, plmc_amount: PLMC * 1_000_000 }).collect_vec();
-	let usdt_fundings = accounts
-		.iter()
-		.map(|acc| UserToFundingAsset {
-			account: *acc,
-			asset_amount: USD_UNIT * 1_000_000,
-			asset_id: AcceptedFundingAsset::USDT.id(),
-		})
-		.collect_vec();
-	inst.mint_plmc_to(plmc_fundings);
-	inst.mint_funding_asset_to(usdt_fundings);
-
-	let evaluations = inst.generate_successful_evaluations(project_metadata.clone(), 5);
-	let project_id = inst.create_auctioning_project(project_metadata.clone(), 0, None, evaluations);
-
-	let bids = vec![
-		(ADAM, 10_000 * CT_UNIT).into(),
-		(TOM, 20_000 * CT_UNIT).into(),
-		(SOFIA, 20_000 * CT_UNIT).into(),
-		(FRED, 10_000 * CT_UNIT).into(),
-		(ANNA, 5_000 * CT_UNIT).into(),
-		(DAMIAN, 5_000 * CT_UNIT).into(),
-	];
-
-	inst.bid_for_users(project_id, bids).unwrap();
-
-	let next_state = inst.go_to_next_state(project_id);
-	assert!(matches!(next_state, ProjectStatus::FundingSuccessful));
-
-	let project_details = inst.get_project_details(project_id);
-	let wap = project_details.weighted_average_price.unwrap();
-	let bucket = inst.execute(|| Buckets::<TestRuntime>::get(project_id).unwrap());
-	let dry_run_price = bucket.calculate_wap(project_metadata.total_allocation_size);
-
-	assert_eq!(dry_run_price, wap);
-}
-
-#[test]
-fn find_bucket_for_wap() {
-	let mut inst = tests::MockInstantiator::new(Some(RefCell::new(new_test_ext())));
-
-	const ADAM: AccountIdOf<TestRuntime> = 60;
-	const TOM: AccountIdOf<TestRuntime> = 61;
-	const SOFIA: AccountIdOf<TestRuntime> = 62;
-	const FRED: AccountIdOf<TestRuntime> = 63;
-	const ANNA: AccountIdOf<TestRuntime> = 64;
-	const DAMIAN: AccountIdOf<TestRuntime> = 65;
-
-	let accounts = [ADAM, TOM, SOFIA, FRED, ANNA, DAMIAN];
-
-	let bounded_name = bounded_name();
-	let bounded_symbol = bounded_symbol();
-	let metadata_hash = ipfs_hash();
-	let normalized_price = PriceOf::<TestRuntime>::from_float(10.0);
-	let decimal_aware_price =
-		PriceProviderOf::<TestRuntime>::calculate_decimals_aware_price(normalized_price, USD_DECIMALS, CT_DECIMALS)
-			.unwrap();
-	let project_metadata = ProjectMetadata {
-		token_information: CurrencyMetadata { name: bounded_name, symbol: bounded_symbol, decimals: CT_DECIMALS },
-		mainnet_token_max_supply: 8_000_000 * CT_UNIT,
-		total_allocation_size: 50_000 * CT_UNIT,
-		minimum_price: decimal_aware_price,
-		bidding_ticket_sizes: BiddingTicketSizes {
-			professional: TicketSize::new(5000 * USD_UNIT, None),
-			institutional: TicketSize::new(5000 * USD_UNIT, None),
-			retail: TicketSize::new(100 * USD_UNIT, None),
-			phantom: Default::default(),
-		},
-		participation_currencies: vec![AcceptedFundingAsset::USDT].try_into().unwrap(),
-		funding_destination_account: 0,
-		policy_ipfs_cid: Some(metadata_hash),
-		participants_account_type: ParticipantsAccountType::Polkadot,
-	};
-
-	// overfund with plmc
-	let plmc_fundings =
-		accounts.iter().map(|acc| UserToPLMCBalance { account: *acc, plmc_amount: PLMC * 1_000_000 }).collect_vec();
-	let usdt_fundings = accounts
-		.iter()
-		.map(|acc| UserToFundingAsset {
-			account: *acc,
-			asset_amount: USD_UNIT * 1_000_000,
-			asset_id: AcceptedFundingAsset::USDT.id(),
-		})
-		.collect_vec();
-	inst.mint_plmc_to(plmc_fundings);
-	inst.mint_funding_asset_to(usdt_fundings);
-
-	let evaluations = inst.generate_successful_evaluations(project_metadata.clone(), 5);
-	let project_id = inst.create_auctioning_project(project_metadata.clone(), 0, None, evaluations);
-
-	let bids = vec![
-		(ADAM, 10_000 * CT_UNIT).into(),
-		(TOM, 20_000 * CT_UNIT).into(),
-		(SOFIA, 20_000 * CT_UNIT).into(),
-		(FRED, 10_000 * CT_UNIT).into(),
-		(ANNA, 5_000 * CT_UNIT).into(),
-		(DAMIAN, 5_000 * CT_UNIT).into(),
-	];
-
-	inst.bid_for_users(project_id, bids).unwrap();
-
-	assert!(matches!(inst.go_to_next_state(project_id), ProjectStatus::FundingSuccessful));
-
-	let project_details = inst.get_project_details(project_id);
-	let wap = project_details.weighted_average_price.unwrap();
-	let bucket_stored = inst.execute(|| Buckets::<TestRuntime>::get(project_id).unwrap());
-
-	let bucket_found = inst.find_bucket_for_wap(project_metadata.clone(), wap);
-	assert_eq!(bucket_found, bucket_stored);
-
-	let wap_found = bucket_found.calculate_wap(project_metadata.total_allocation_size);
-	assert_eq!(wap_found, wap);
-}
 
 #[test]
 fn generate_bids_from_bucket() {
@@ -173,16 +14,18 @@ fn generate_bids_from_bucket() {
 	// Has a min price of 10.0
 	let project_metadata = default_project_metadata(0);
 	let desired_real_wap = FixedU128::from_float(20.0f64);
-	let desired_price_aware_wap =
+	let desired_bucket_price_aware =
 		PriceProviderOf::<TestRuntime>::calculate_decimals_aware_price(desired_real_wap, USD_DECIMALS, CT_DECIMALS)
 			.unwrap();
-	let necessary_bucket = inst.find_bucket_for_wap(project_metadata.clone(), desired_price_aware_wap);
+	let mut necessary_bucket = Pallet::<TestRuntime>::create_bucket_from_metadata(&project_metadata).unwrap();
+	necessary_bucket.current_price = desired_bucket_price_aware;
+	necessary_bucket.amount_left = necessary_bucket.delta_amount;
+
 	let bids = inst.generate_bids_from_bucket(project_metadata.clone(), necessary_bucket, AcceptedFundingAsset::USDT);
 	let evaluations = inst.generate_successful_evaluations(project_metadata.clone(), 5);
 	let project_id = inst.create_finished_project(project_metadata.clone(), 0, None, evaluations, bids);
-	let project_details = inst.get_project_details(project_id);
-	let wap = project_details.weighted_average_price.unwrap();
-	assert_eq!(wap, desired_price_aware_wap);
+	let current_bucket = inst.execute(|| Buckets::<TestRuntime>::get(project_id).unwrap());
+	assert_eq!(current_bucket.current_price, desired_bucket_price_aware);
 }
 
 #[test]

--- a/pallets/funding/src/lib.rs
+++ b/pallets/funding/src/lib.rs
@@ -134,7 +134,7 @@ pub type AssetIdOf<T> =
 pub type VestingInfoOf<T> = VestingInfo<BlockNumberFor<T>>;
 
 pub type ProjectMetadataOf<T> = ProjectMetadata<BoundedVec<u8, StringLimitOf<T>>, PriceOf<T>, AccountIdOf<T>, Cid>;
-pub type ProjectDetailsOf<T> = ProjectDetails<AccountIdOf<T>, Did, BlockNumberFor<T>, PriceOf<T>, EvaluationRoundInfo>;
+pub type ProjectDetailsOf<T> = ProjectDetails<AccountIdOf<T>, Did, BlockNumberFor<T>, EvaluationRoundInfo>;
 pub type EvaluationInfoOf<T> = EvaluationInfo<u32, Did, ProjectId, AccountIdOf<T>, BlockNumberFor<T>>;
 pub type BidInfoOf<T> = BidInfo<ProjectId, Did, PriceOf<T>, AccountIdOf<T>, BlockNumberFor<T>>;
 
@@ -501,7 +501,6 @@ pub mod pallet {
 			id: u32,
 			status: BidStatus,
 			final_ct_amount: Balance,
-			final_ct_usd_price: PriceOf<T>,
 		},
 		/// A contribution was settled. On Funding Success the PLMC has been unbonded/locked with a vesting schedule and the funding assets have been transferred to the issuer.
 		/// If Funding Failed, the PLMC has been unbonded and the funds have been returned to the contributor.

--- a/pallets/funding/src/tests/2_evaluation.rs
+++ b/pallets/funding/src/tests/2_evaluation.rs
@@ -286,7 +286,6 @@ mod start_evaluation_extrinsic {
 				issuer_account: ISSUER_1,
 				issuer_did,
 				is_frozen: true,
-				weighted_average_price: None,
 				status: ProjectStatus::EvaluationRound,
 				round_duration: BlockNumberPair::new(
 					Some(1),

--- a/pallets/funding/src/tests/misc.rs
+++ b/pallets/funding/src/tests/misc.rs
@@ -1,5 +1,4 @@
 use super::*;
-use polimec_common::assets::AcceptedFundingAsset;
 
 // check that functions created to facilitate testing return the expected results
 mod helper_functions {
@@ -131,142 +130,6 @@ mod helper_functions {
 			assert_close_enough!(expected, calculated, Perquintill::from_float(0.999));
 		}
 	}
-
-	#[test]
-	fn calculate_auction_plmc_returned() {
-		const CT_AMOUNT_1: u128 = 5000 * CT_UNIT;
-		const CT_AMOUNT_2: u128 = 40_000 * CT_UNIT;
-		const CT_AMOUNT_3: u128 = 10_000 * CT_UNIT;
-		const CT_AMOUNT_4: u128 = 6000 * CT_UNIT;
-		const CT_AMOUNT_5: u128 = 2000 * CT_UNIT;
-
-		let bid_1 = BidParams::from((
-			BIDDER_1,
-			Retail,
-			CT_AMOUNT_1,
-			ParticipationMode::Classic(1u8),
-			AcceptedFundingAsset::USDT,
-		));
-		let bid_2 = BidParams::from((
-			BIDDER_2,
-			Retail,
-			CT_AMOUNT_2,
-			ParticipationMode::Classic(1u8),
-			AcceptedFundingAsset::USDT,
-		));
-		let bid_3 = BidParams::from((
-			BIDDER_1,
-			Retail,
-			CT_AMOUNT_3,
-			ParticipationMode::Classic(1u8),
-			AcceptedFundingAsset::USDT,
-		));
-		let bid_4 = BidParams::from((
-			BIDDER_3,
-			Retail,
-			CT_AMOUNT_4,
-			ParticipationMode::Classic(1u8),
-			AcceptedFundingAsset::USDT,
-		));
-		let bid_5 = BidParams::from((
-			BIDDER_4,
-			Retail,
-			CT_AMOUNT_5,
-			ParticipationMode::Classic(1u8),
-			AcceptedFundingAsset::USDT,
-		));
-
-		// post bucketing, the bids look like this:
-		// (BIDDER_1, 5k) - (BIDDER_2, 40k) - (BIDDER_1, 5k) - (BIDDER_1, 5k) - (BIDDER_3 - 5k) - (BIDDER_3 - 1k) - (BIDDER_4 - 2k)
-		// | -------------------- 1USD ----------------------|---- 1.1 USD ---|---- 1.2 USD ----|----------- 1.3 USD -------------|
-		// post wap ~ 1.0557252:
-		// (Accepted, 5k) - (Partially, 32k) - (Rejected, 5k) - (Accepted, 5k) - (Accepted - 5k) - (Accepted - 1k) - (Accepted - 2k)
-
-		const ORIGINAL_PLMC_CHARGED_BIDDER_1: f64 = 18_452.3809523790;
-		const ORIGINAL_PLMC_CHARGED_BIDDER_2: f64 = 47_619.0476190470;
-		const ORIGINAL_PLMC_CHARGED_BIDDER_3: f64 = 86_90.4761904760;
-		const ORIGINAL_PLMC_CHARGED_BIDDER_4: f64 = 30_95.2380952380;
-
-		const FINAL_PLMC_CHARGED_BIDDER_1: f64 = 12_236.4594692840;
-		const FINAL_PLMC_CHARGED_BIDDER_2: f64 = 38_095.2380952380;
-		const FINAL_PLMC_CHARGED_BIDDER_3: f64 = 75_40.8942202840;
-		const FINAL_PLMC_CHARGED_BIDDER_4: f64 = 2_513.6314067610;
-
-		let bids = vec![bid_1, bid_2, bid_3, bid_4, bid_5];
-
-		let mut inst = MockInstantiator::new(Some(RefCell::new(new_test_ext())));
-		let project_metadata = ProjectMetadata {
-			token_information: default_token_information(),
-			mainnet_token_max_supply: 8_000_000 * CT_UNIT,
-			total_allocation_size: 50_000 * CT_UNIT,
-			minimum_price: PriceProviderOf::<TestRuntime>::calculate_decimals_aware_price(
-				PriceOf::<TestRuntime>::from_float(10.0),
-				USD_DECIMALS,
-				CT_DECIMALS,
-			)
-			.unwrap(),
-			bidding_ticket_sizes: BiddingTicketSizes {
-				professional: TicketSize::new(5000 * USD_UNIT, None),
-				institutional: TicketSize::new(5000 * USD_UNIT, None),
-				retail: TicketSize::new(100 * USD_UNIT, None),
-				phantom: Default::default(),
-			},
-			participation_currencies: vec![AcceptedFundingAsset::USDT].try_into().unwrap(),
-			funding_destination_account: ISSUER_1,
-			policy_ipfs_cid: Some(ipfs_hash()),
-			participants_account_type: ParticipantsAccountType::Polkadot,
-		};
-
-		let successful_evaluations = inst.generate_successful_evaluations(project_metadata.clone(), 5);
-
-		let project_id = inst.create_finished_project(
-			project_metadata.clone(),
-			ISSUER_1,
-			None,
-			successful_evaluations,
-			bids.clone(),
-		);
-
-		let wap = inst.get_project_details(project_id).weighted_average_price.unwrap();
-
-		let expected_returns = vec![
-			ORIGINAL_PLMC_CHARGED_BIDDER_1 - FINAL_PLMC_CHARGED_BIDDER_1,
-			ORIGINAL_PLMC_CHARGED_BIDDER_2 - FINAL_PLMC_CHARGED_BIDDER_2,
-			ORIGINAL_PLMC_CHARGED_BIDDER_3 - FINAL_PLMC_CHARGED_BIDDER_3,
-			ORIGINAL_PLMC_CHARGED_BIDDER_4 - FINAL_PLMC_CHARGED_BIDDER_4,
-		];
-
-		let mut returned_plmc_mappings =
-			inst.calculate_auction_plmc_returned_from_all_bids_made(&bids, project_metadata.clone(), wap);
-		returned_plmc_mappings.sort_by(|b1, b2| b1.account.cmp(&b2.account));
-
-		let returned_plmc_balances = returned_plmc_mappings.into_iter().map(|map| map.plmc_amount).collect_vec();
-
-		for (expected_return, returned_balance) in zip(expected_returns, returned_plmc_balances) {
-			let expected_value = FixedU128::from_float(expected_return).checked_mul_int(PLMC).unwrap();
-
-			assert_close_enough!(expected_value, returned_balance, Perquintill::from_float(0.99));
-		}
-	}
-
-	#[test]
-	fn bucket_wap_calculation() {
-		let initial_price = FixedU128::from_float(10.0);
-		let mut bucket = Bucket::new(100u128, initial_price, FixedU128::from_float(1.0), 10u128);
-		let wap = bucket.calculate_wap(100u128);
-		assert!(wap == initial_price);
-
-		// Initial token amount: 100
-		// Simulate total bidding amount of 128
-		bucket.update(100u128);
-		bucket.update(10u128);
-		bucket.update(10u128);
-		bucket.update(8u128);
-		let wap = bucket.calculate_wap(100u128);
-		let expected = FixedU128::from_float(10.628);
-		let diff = if wap > expected { wap - expected } else { expected - wap };
-		assert!(diff <= FixedU128::from_float(0.001));
-	}
 }
 
 // logic of small functions that extrinsics use to process data or interact with storage
@@ -316,24 +179,25 @@ mod inner_functions {
 		bucket.update(10_000 * CT_UNIT);
 
 		// We bought 10k CTs at a price of 10USD, meaning we should get 100k USD
-		let usd_sold =
-			Pallet::<TestRuntime>::calculate_usd_sold_from_bucket(bucket, project_metadata.total_allocation_size);
+		let usd_sold = bucket.calculate_usd_raised(project_metadata.total_allocation_size);
 		assert_eq!(usd_sold, 100_000 * USD_UNIT);
 
 		// This bucket has 2 buckets sold out on top of the first one
 		let mut bucket = Pallet::<TestRuntime>::create_bucket_from_metadata(&project_metadata).unwrap();
+
+		let usd_raised_first_bucket = bucket.current_price.saturating_mul_int(400_000 * CT_UNIT);
 		bucket.update(project_metadata.total_allocation_size);
+
+		let usd_raised_second_bucket = bucket.current_price.saturating_mul_int(50_000 * CT_UNIT);
 		bucket.update(50_000 * CT_UNIT);
+
+		let usd_raised_third_bucket = bucket.current_price.saturating_mul_int(50_000 * CT_UNIT);
 		bucket.update(50_000 * CT_UNIT);
-		let wap = bucket.calculate_wap(project_metadata.total_allocation_size);
-		let usd_raised_first_bucket = project_metadata.minimum_price.saturating_mul_int(400_000 * CT_UNIT);
-		let usd_raised_second_bucket = wap.saturating_mul_int(50_000 * CT_UNIT);
-		let usd_raised_third_bucket = wap.saturating_mul_int(50_000 * CT_UNIT);
+
 		let total_expected_rasied = usd_raised_first_bucket + usd_raised_second_bucket + usd_raised_third_bucket;
 
 		// We bought 10k CTs at a price of 10USD, meaning we should get 100k USD
-		let usd_sold =
-			Pallet::<TestRuntime>::calculate_usd_sold_from_bucket(bucket, project_metadata.total_allocation_size);
+		let usd_sold = bucket.calculate_usd_raised(project_metadata.total_allocation_size);
 		assert_eq!(usd_sold, total_expected_rasied);
 	}
 }

--- a/pallets/funding/src/tests/runtime_api.rs
+++ b/pallets/funding/src/tests/runtime_api.rs
@@ -226,69 +226,9 @@ fn contribution_tokens() {
 fn funding_asset_to_ct_amount_classic() {
 	let mut inst = MockInstantiator::new(Some(RefCell::new(new_test_ext())));
 
-	// We want to use a funding asset that is not equal to 1 USD
-	// Sanity check
-	assert_eq!(
-		PriceProviderOf::<TestRuntime>::get_price(AcceptedFundingAsset::DOT.id()).unwrap(),
-		PriceOf::<TestRuntime>::from_float(69.0f64)
-	);
-
-	let dot_amount: u128 = 1350_0_000_000_000;
-	// USD Ticket = 93_150 USD
-
-	// Easy case, wap is already calculated, we want to know how many tokens at wap we can buy with `x` USDT
-	let project_metadata_1 = default_project_metadata(ISSUER_1);
-	let evaluations = inst.generate_successful_evaluations(project_metadata_1.clone(), 5);
-	let project_id_1 =
-		inst.create_finished_project(project_metadata_1.clone(), ISSUER_1, None, evaluations.clone(), vec![]);
-	let wap = project_metadata_1.minimum_price;
-	assert_eq!(inst.get_project_details(project_id_1).weighted_average_price.unwrap(), wap);
-
-	// Price of ct is min price = 10 USD/CT
-	let expected_ct_amount_contribution = 9_315 * CT_UNIT;
-	inst.execute(|| {
-		let block_hash = System::block_hash(System::block_number());
-		let ct_amount = TestRuntime::funding_asset_to_ct_amount_classic(
-			&TestRuntime,
-			block_hash,
-			project_id_1,
-			AcceptedFundingAsset::DOT,
-			dot_amount,
-		)
-		.unwrap();
-		assert_eq!(ct_amount, expected_ct_amount_contribution);
-	});
-
-	// Medium case, contribution at a wap that is not the minimum price.
-	let project_metadata_2 = default_project_metadata(ISSUER_2);
-	let new_price = PriceOf::<TestRuntime>::from_float(16.3f64);
-	let decimal_aware_price =
-		PriceProviderOf::<TestRuntime>::calculate_decimals_aware_price(new_price, USD_DECIMALS, CT_DECIMALS).unwrap();
-
-	let bids = inst.generate_bids_that_take_price_to(project_metadata_2.clone(), decimal_aware_price);
-	let project_id_2 =
-		inst.create_finished_project(project_metadata_2.clone(), ISSUER_2, None, evaluations.clone(), bids);
-	// Sanity check
-	let project_details = inst.get_project_details(project_id_2);
-	assert_eq!(project_details.weighted_average_price.unwrap(), decimal_aware_price);
-
-	// 5'714.72... rounded down
-	let expected_ct_amount_contribution = 5_714_720_000_000_000_000;
-	inst.execute(|| {
-		let block_hash = System::block_hash(System::block_number());
-		let ct_amount = TestRuntime::funding_asset_to_ct_amount_classic(
-			&TestRuntime,
-			block_hash,
-			project_id_2,
-			AcceptedFundingAsset::DOT,
-			dot_amount,
-		)
-		.unwrap();
-		assert_close_enough!(ct_amount, expected_ct_amount_contribution, Perquintill::from_float(0.999f64));
-	});
-
 	// Medium case, a bid goes over part of a bucket (bucket after the first one)
 	let project_metadata_3 = default_project_metadata(ISSUER_3);
+	let evaluations = inst.generate_successful_evaluations(project_metadata_3.clone(), 5);
 	let project_id_3 = inst.create_auctioning_project(project_metadata_3.clone(), ISSUER_3, None, evaluations.clone());
 	let mut bucket = inst.execute(|| Buckets::<TestRuntime>::get(project_id_3)).unwrap();
 
@@ -297,15 +237,7 @@ fn funding_asset_to_ct_amount_classic() {
 	bucket.current_price = bucket.initial_price + bucket.delta_price * FixedU128::from_float(6.0f64);
 	bucket.amount_left = bucket.delta_amount;
 	let bids = inst.generate_bids_from_bucket(project_metadata_3.clone(), bucket, AcceptedFundingAsset::USDT);
-	let necessary_plmc =
-		inst.calculate_auction_plmc_charged_from_all_bids_made_or_with_bucket(&bids, project_metadata_3.clone(), None);
-	let necessary_usdt = inst.calculate_auction_funding_asset_charged_from_all_bids_made_or_with_bucket(
-		&bids,
-		project_metadata_3.clone(),
-		None,
-	);
-	inst.mint_plmc_to(necessary_plmc);
-	inst.mint_funding_asset_to(necessary_usdt);
+	inst.mint_necessary_tokens_for_bids(project_id_3, bids.clone());
 	inst.bid_for_users(project_id_3, bids).unwrap();
 
 	// Sanity check
@@ -366,65 +298,9 @@ fn funding_asset_to_ct_amount_otm() {
 		PriceOf::<TestRuntime>::from_float(69.0f64)
 	);
 
-	let dot_participation_amount: u128 = 1350_0_000_000_000;
-	// USD Ticket = 93_150 USD
-	let dot_fee_amount = FixedU128::from_float(0.015f64).saturating_mul_int(dot_participation_amount);
-
-	// Easy case, wap is already calculated, we want to know how many tokens at wap we can buy with `x` USDT
-	let project_metadata_1 = default_project_metadata(ISSUER_1);
-	let evaluations = inst.generate_successful_evaluations(project_metadata_1.clone(), 5);
-	let project_id_1 =
-		inst.create_finished_project(project_metadata_1.clone(), ISSUER_1, None, evaluations.clone(), vec![]);
-	let wap = project_metadata_1.minimum_price;
-	assert_eq!(inst.get_project_details(project_id_1).weighted_average_price.unwrap(), wap);
-
-	// Price of ct is min price = 10 USD/CT
-	let expected_ct_amount_contribution = 9_315 * CT_UNIT;
-	inst.execute(|| {
-		let block_hash = System::block_hash(System::block_number());
-		let (ct_amount, fee_amount) = TestRuntime::funding_asset_to_ct_amount_otm(
-			&TestRuntime,
-			block_hash,
-			project_id_1,
-			AcceptedFundingAsset::DOT,
-			dot_participation_amount + dot_fee_amount,
-		)
-		.unwrap();
-		assert_close_enough!(ct_amount, expected_ct_amount_contribution, Perquintill::from_float(0.9999));
-		assert_close_enough!(fee_amount, dot_fee_amount, Perquintill::from_float(0.9999));
-	});
-
-	// Medium case, contribution at a wap that is not the minimum price.
-	let project_metadata_2 = default_project_metadata(ISSUER_2);
-	let new_price = PriceOf::<TestRuntime>::from_float(16.3f64);
-	let decimal_aware_price =
-		PriceProviderOf::<TestRuntime>::calculate_decimals_aware_price(new_price, USD_DECIMALS, CT_DECIMALS).unwrap();
-
-	let bids = inst.generate_bids_that_take_price_to(project_metadata_2.clone(), decimal_aware_price);
-	let project_id_2 =
-		inst.create_finished_project(project_metadata_2.clone(), ISSUER_2, None, evaluations.clone(), bids);
-	// Sanity check
-	let project_details = inst.get_project_details(project_id_2);
-	assert_eq!(project_details.weighted_average_price.unwrap(), decimal_aware_price);
-
-	// 5'714.72... rounded down
-	let expected_ct_amount_contribution = 5_714_720_000_000_000_000;
-	inst.execute(|| {
-		let block_hash = System::block_hash(System::block_number());
-		let (ct_amount, fee_amount) = TestRuntime::funding_asset_to_ct_amount_otm(
-			&TestRuntime,
-			block_hash,
-			project_id_2,
-			AcceptedFundingAsset::DOT,
-			dot_participation_amount + dot_fee_amount,
-		)
-		.unwrap();
-		assert_close_enough!(ct_amount, expected_ct_amount_contribution, Perquintill::from_float(0.9999f64));
-		assert_close_enough!(fee_amount, dot_fee_amount, Perquintill::from_float(0.9999f64));
-	});
-
 	// Medium case, a bid goes over part of a bucket (bucket after the first one)
 	let project_metadata_3 = default_project_metadata(ISSUER_3);
+	let evaluations = inst.generate_successful_evaluations(project_metadata_3.clone(), 5);
 	let project_id_3 = inst.create_auctioning_project(project_metadata_3.clone(), ISSUER_3, None, evaluations.clone());
 	let mut bucket = inst.execute(|| Buckets::<TestRuntime>::get(project_id_3)).unwrap();
 
@@ -433,15 +309,7 @@ fn funding_asset_to_ct_amount_otm() {
 	bucket.current_price = bucket.initial_price + bucket.delta_price * FixedU128::from_float(6.0f64);
 	bucket.amount_left = bucket.delta_amount;
 	let bids = inst.generate_bids_from_bucket(project_metadata_3.clone(), bucket, AcceptedFundingAsset::USDT);
-	let necessary_plmc =
-		inst.calculate_auction_plmc_charged_from_all_bids_made_or_with_bucket(&bids, project_metadata_3.clone(), None);
-	let necessary_usdt = inst.calculate_auction_funding_asset_charged_from_all_bids_made_or_with_bucket(
-		&bids,
-		project_metadata_3.clone(),
-		None,
-	);
-	inst.mint_plmc_to(necessary_plmc);
-	inst.mint_funding_asset_to(necessary_usdt);
+	inst.mint_necessary_tokens_for_bids(project_id_3, bids.clone());
 	inst.bid_for_users(project_id_3, bids).unwrap();
 
 	// Sanity check

--- a/pallets/funding/src/types.rs
+++ b/pallets/funding/src/types.rs
@@ -287,13 +287,11 @@ pub mod storage {
 	}
 
 	#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
-	pub struct ProjectDetails<AccountId, Did, BlockNumber, Price: FixedPointNumber, EvaluationRoundInfo> {
+	pub struct ProjectDetails<AccountId, Did, BlockNumber, EvaluationRoundInfo> {
 		pub issuer_account: AccountId,
 		pub issuer_did: Did,
 		/// Whether the project is frozen, so no `metadata` changes are allowed.
 		pub is_frozen: bool,
-		/// The price in USD per token decided after the Auction Round
-		pub weighted_average_price: Option<Price>,
 		/// The current status of the project
 		pub status: ProjectStatus,
 		/// When the different project phases start and end
@@ -441,31 +439,42 @@ pub mod storage {
 			self.current_price = self.current_price.saturating_add(self.delta_price);
 		}
 
-		pub fn calculate_wap(self, mut total_amount: Balance) -> Price {
-			// First bucket is not empty so wap is the same as the initial price
-			if self.current_price == self.initial_price {
-				return self.current_price;
+		pub fn calculate_usd_raised(self, allocation_size: Balance) -> Balance {
+			let mut usd_raised = Balance::zero();
+			let mut cts_left = allocation_size;
+			let mut calculation_bucket = self.clone();
+
+			// If current bucket is the first bucket, then its not oversubscribed and we just return the price * tokens bought
+			if calculation_bucket.current_price == calculation_bucket.initial_price {
+				let amount_bought = allocation_size.saturating_sub(calculation_bucket.amount_left);
+				return calculation_bucket.current_price.saturating_mul_int(amount_bought);
 			}
-			let mut amount: Balance = self.delta_amount.saturating_sub(self.amount_left);
-			let mut price: Price = self.current_price;
-			let mut bucket_sizes: Vec<(Balance, Price)> = Vec::new();
-			while price > self.initial_price && total_amount > Balance::zero() {
-				total_amount.saturating_reduce(amount);
-				bucket_sizes.push((price.saturating_mul_int(amount), price));
-				price = price.saturating_sub(self.delta_price);
-				amount = self.delta_amount;
+			// If the current bucket is at a higher price, then auction is oversubscribed
+			// We first calculate the amount bought by checking the amount remaining in the bucket.
+			// Then we go down in buckets assuming the full amount was bought in each lower bucket.
+			else {
+				let amount_bought = calculation_bucket.delta_amount.saturating_sub(calculation_bucket.amount_left);
+				cts_left.saturating_reduce(amount_bought);
+				usd_raised =
+					usd_raised.saturating_add(calculation_bucket.current_price.saturating_mul_int(amount_bought));
+				calculation_bucket.current_price.saturating_reduce(calculation_bucket.delta_price);
 			}
 
-			if total_amount > Balance::zero() {
-				bucket_sizes.push((self.initial_price.saturating_mul_int(total_amount), self.initial_price));
+			while cts_left > 0 {
+				let amount = if calculation_bucket.current_price == calculation_bucket.initial_price {
+					cts_left
+				} else {
+					cts_left.min(calculation_bucket.delta_amount)
+				};
+
+				usd_raised = usd_raised.saturating_add(calculation_bucket.current_price.saturating_mul_int(amount));
+				cts_left = cts_left.saturating_sub(amount);
+
+				calculation_bucket.current_price =
+					calculation_bucket.current_price.saturating_sub(calculation_bucket.delta_price);
 			}
 
-			let sum = bucket_sizes.iter().map(|x| x.0).fold(Balance::zero(), |acc, x| acc.saturating_add(x));
-
-			bucket_sizes
-				.into_iter()
-				.map(|x| <Price as FixedPointNumber>::saturating_from_rational(x.0, sum).saturating_mul(x.1))
-				.fold(Price::zero(), |acc: Price, p: Price| acc.saturating_add(p))
+			usd_raised
 		}
 	}
 
@@ -839,8 +848,7 @@ pub mod extrinsic {
 		pub receiving_account: Junction,
 	}
 
-	pub struct BidRefund<T: Config> {
-		pub final_ct_usd_price: PriceOf<T>,
+	pub struct BidRefund {
 		pub final_ct_amount: Balance,
 		pub refunded_plmc: Balance,
 		pub refunded_funding_asset_amount: Balance,


### PR DESCRIPTION
## What?
- Remove the WAP
- Accepted bids don't get any refund since there's no difference between price paid and final price.
- Only Partially accepted bids get some refund
- Rejected bids still get full refund

## Why?
- No contribution round to profit from the WAP, so only thing we're doing is making the system more confusing and giving less funds to the issuer.

## How?
- Remove all references to the WAP
- Don't give refunds based on the price difference

## Testing?
- Delete WAP related tests
- Amend the other tests
