### PR TITLE
♻️ Replace WETH with Ethereum-native ETH

### DIFF
--- a/integration-tests/chopsticks/overrides/polimec.ts
+++ b/integration-tests/chopsticks/overrides/polimec.ts
@@ -23,20 +23,15 @@ const dot_location = {
   },
 };
 
-export const weth_location = {
+export const eth_location = {
   parents: 2,
   interior: {
-    x2: [
+    x1: [
       {
         globalConsensus: {
           ethereum: {
             chainId: 1n,
           },
-        },
-      },
-      {
-        accountKey20: {
-          key: WETH_ADDRESS,
         },
       },
     ],
@@ -81,7 +76,7 @@ export const polimec_storage = {
     // Note: We can remove Asset and Metadata from the storage override as soon we set them on-chain.
     Asset: [
       [
-        [weth_location],
+        [eth_location],
         {
           owner: Accounts.ALICE,
           issuer: Accounts.ALICE,
@@ -98,8 +93,6 @@ export const polimec_storage = {
         },
       ],
     ],
-    Metadata: [
-      [[weth_location], { symbol: 'Wrapped Ether', name: 'WETH', decimals: 18, isFrozen: false }],
-    ],
+    Metadata: [[[eth_location], { symbol: 'Ether', name: 'ETH', decimals: 18, isFrozen: false }]],
   },
 } as const;

--- a/integration-tests/chopsticks/overrides/polkadot-hub.ts
+++ b/integration-tests/chopsticks/overrides/polkadot-hub.ts
@@ -1,6 +1,6 @@
 import { INITIAL_BALANCES } from '@/constants';
 import { Accounts, Asset } from '@/types';
-import { weth_location } from './polimec';
+import { eth_location } from './polimec';
 
 export const polkadot_hub_storage = {
   System: {
@@ -35,7 +35,7 @@ export const polkadot_hub_storage = {
   ForeignAssets: {
     Account: [
       [
-        [weth_location, Accounts.POLIMEC],
+        [eth_location, Accounts.POLIMEC],
         {
           balance: INITIAL_BALANCES.WETH,
         },

--- a/integration-tests/chopsticks/src/constants.ts
+++ b/integration-tests/chopsticks/src/constants.ts
@@ -23,4 +23,4 @@ export const DERIVE_PATHS = {
 export const WETH_ADDRESS = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
 export const DEFAULT_TOPIC = FixedSizeBinary.fromArray(Array(32).fill(1));
 export const FEE_AMOUNT = 40_000_000_000n;
-export const WETH_AMOUNT = 15_000_000_000_000n;
+export const ETH_AMOUNT = 15_000_000_000_000n;

--- a/integration-tests/chopsticks/src/managers/BridgeHubManager.ts
+++ b/integration-tests/chopsticks/src/managers/BridgeHubManager.ts
@@ -46,10 +46,12 @@ export class BridgerHubManagaer extends BaseChainManager {
         return AssetSourceRelation.Sibling;
       case Asset.USDC:
         return AssetSourceRelation.Sibling;
-      case Asset.WETH:
+      case Asset.ETH:
         // TODO: Check it Placeholder
         return AssetSourceRelation.Self;
     }
+
+    return AssetSourceRelation.Self;
   }
 
   // Note: On BridgeHub, there should be no balance for any asset.

--- a/integration-tests/chopsticks/src/managers/PolimecManager.ts
+++ b/integration-tests/chopsticks/src/managers/PolimecManager.ts
@@ -47,7 +47,7 @@ export class PolimecManager extends BaseChainManager {
         return AssetSourceRelation.Sibling;
       case Asset.USDC:
         return AssetSourceRelation.Sibling;
-      case Asset.WETH:
+      case Asset.ETH:
         // Placeholder
         return AssetSourceRelation.Self;
       case Asset.PLMC:

--- a/integration-tests/chopsticks/src/managers/PolkadotHubManager.ts
+++ b/integration-tests/chopsticks/src/managers/PolkadotHubManager.ts
@@ -43,7 +43,7 @@ export class PolkadotHubManager extends BaseChainManager {
         return AssetSourceRelation.Self;
       case Asset.USDC:
         return AssetSourceRelation.Self;
-      case Asset.WETH:
+      case Asset.ETH:
         // This is not actually used, so we use Self as a placeholder
         return AssetSourceRelation.Self;
       case Asset.PLMC:

--- a/integration-tests/chopsticks/src/managers/PolkadotManager.ts
+++ b/integration-tests/chopsticks/src/managers/PolkadotManager.ts
@@ -44,10 +44,12 @@ export class PolkadotManager extends BaseChainManager {
       case Asset.USDC:
         // Placeholder
         return AssetSourceRelation.Self;
-      case Asset.WETH:
+      case Asset.ETH:
         // Placeholder
         return AssetSourceRelation.Self;
     }
+
+    return AssetSourceRelation.Self;
   }
 
   async getAssetBalanceOf(account: Accounts, asset: Asset): Promise<bigint> {

--- a/integration-tests/chopsticks/src/tests/bridge.test.ts
+++ b/integration-tests/chopsticks/src/tests/bridge.test.ts
@@ -22,12 +22,12 @@ describe('Bridge Hub -> Polimec Transfer Tests', () => {
   afterAll(async () => await chainSetup.cleanup());
 
   test(
-    'Send WETH to Polimec',
+    'Send ETH to Polimec',
     () =>
       transferTest.testTransfer({
         account: Accounts.ALICE,
-        assets: [[Asset.WETH, TRANSFER_AMOUNTS.BRIDGED, AssetSourceRelation.Self]],
+        assets: [[Asset.ETH, TRANSFER_AMOUNTS.BRIDGED, AssetSourceRelation.Self]],
       }),
-    { timeout: 25000 },
+    { timeout: 40000 },
   );
 });

--- a/integration-tests/chopsticks/src/transfers/BridgeToPolimec.ts
+++ b/integration-tests/chopsticks/src/transfers/BridgeToPolimec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'bun:test';
-import { DEFAULT_TOPIC, FEE_AMOUNT, WETH_ADDRESS, WETH_AMOUNT } from '@/constants';
+import { DEFAULT_TOPIC, ETH_AMOUNT, FEE_AMOUNT, WETH_ADDRESS } from '@/constants';
 import type { BridgerHubManagaer } from '@/managers/BridgeHubManager';
 import type { PolimecManager } from '@/managers/PolimecManager';
 import type { PolkadotHubManager } from '@/managers/PolkadotHubManager';
@@ -102,7 +102,10 @@ export class BridgeToPolimecTransfer extends BaseTransferTest {
       (event) => event.type === 'ForeignAssets' && event.value.type === 'Issued',
     );
 
-    // TODO: Check why we have 3 events instead of 2 (WETH + DOT). Curently we have 3 events (WETH + DOT + DOT)
+    console.log('Issued Events on Destination: \n');
+    console.dir(issuedEventsOnDest, { depth: null });
+
+    // TODO: Check why we have 3 events instead of 2 (ETH + DOT). Curently we have 3 events (ETH + DOT + DOT)
     expect(issuedEventsOnDest.length).toBe(3);
 
     return { sourceBlock, destBlock };
@@ -147,15 +150,11 @@ export class BridgeToPolimecTransfer extends BaseTransferTest {
           {
             id: XcmV3MultiassetAssetId.Concrete({
               parents: 2,
-              interior: XcmV3Junctions.X2([
+              interior: XcmV3Junctions.X1(
                 XcmV3Junction.GlobalConsensus(XcmV3JunctionNetworkId.Ethereum({ chain_id: 1n })),
-                XcmV3Junction.AccountKey20({
-                  network: undefined,
-                  key: FixedSizeBinary.fromHex(WETH_ADDRESS),
-                }),
-              ]),
+              ),
             }),
-            fun: XcmV3MultiassetFungibility.Fungible(WETH_AMOUNT),
+            fun: XcmV3MultiassetFungibility.Fungible(ETH_AMOUNT),
           },
         ]),
 
@@ -190,15 +189,11 @@ export class BridgeToPolimecTransfer extends BaseTransferTest {
             {
               id: XcmV3MultiassetAssetId.Concrete({
                 parents: 2,
-                interior: XcmV3Junctions.X2([
+                interior: XcmV3Junctions.X1(
                   XcmV3Junction.GlobalConsensus(XcmV3JunctionNetworkId.Ethereum({ chain_id: 1n })),
-                  XcmV3Junction.AccountKey20({
-                    network: undefined,
-                    key: FixedSizeBinary.fromHex(WETH_ADDRESS),
-                  }),
-                ]),
+                ),
               }),
-              fun: XcmV3MultiassetFungibility.Fungible(WETH_AMOUNT),
+              fun: XcmV3MultiassetFungibility.Fungible(ETH_AMOUNT),
             },
           ]),
           dest: {
@@ -250,15 +245,11 @@ export class BridgeToPolimecTransfer extends BaseTransferTest {
           {
             id: XcmV3MultiassetAssetId.Concrete({
               parents: 2,
-              interior: XcmV3Junctions.X2([
+              interior: XcmV3Junctions.X1(
                 XcmV3Junction.GlobalConsensus(XcmV3JunctionNetworkId.Ethereum({ chain_id: 1n })),
-                XcmV3Junction.AccountKey20({
-                  network: undefined,
-                  key: FixedSizeBinary.fromHex(WETH_ADDRESS),
-                }),
-              ]),
+              ),
             }),
-            fun: XcmV3MultiassetFungibility.Fungible(WETH_AMOUNT),
+            fun: XcmV3MultiassetFungibility.Fungible(ETH_AMOUNT),
           },
         ]),
 

--- a/integration-tests/chopsticks/src/transfers/PolimecToHub.ts
+++ b/integration-tests/chopsticks/src/transfers/PolimecToHub.ts
@@ -64,26 +64,6 @@ export class PolimecToHubTransfer extends BaseTransferTest {
     return { asset_balances: [{ source, destination }] };
   }
 
-  // verifyFinalBalances(
-  //   initialBalances: BalanceCheck[],
-  //   finalBalances: BalanceCheck[],
-  //   options: TransferOptions,
-  // ) {
-  //   // TODO: At the moment we exclude fees from the balance check since the PAPI team is wotking on some utilies to calculate fees.
-  //   const initialBalance =
-  //     options.assets[0][0] === Asset.DOT
-  //       ? INITIAL_BALANCES.DOT
-  //       : options.assets[0][0] === Asset.USDT
-  //         ? INITIAL_BALANCES.USDT
-  //         : INITIAL_BALANCES.USDC;
-  //   for (let i = 0; i < options.assets.length; i++) {
-  //     expect(initialBalances[i].destination).toBe(0n);
-  //     expect(initialBalances[i].source).toBe(initialBalance);
-  //     expect(finalBalances[i].source).toBeLessThan(initialBalances[i].source);
-  //     expect(finalBalances[i].destination).toBeGreaterThan(initialBalances[i].destination);
-  //   }
-  // }
-
   async verifyFinalBalances(
     assetInitialBalances: PolimecBalanceCheck[],
     assetFinalBalances: PolimecBalanceCheck[],

--- a/integration-tests/chopsticks/src/types.ts
+++ b/integration-tests/chopsticks/src/types.ts
@@ -96,7 +96,7 @@ export enum Asset {
   DOT = 10,
   USDC = 1337,
   USDT = 1984,
-  WETH = 10000,
+  ETH = 10000,
   PLMC = 3344,
 }
 
@@ -160,13 +160,12 @@ export function NativeAssetLocation(
   }
 }
 
-export function EthereumAssetLocation(contract_address: FixedSizeBinary<20>): XcmVersionedLocation {
+export function EthereumLocation(): XcmVersionedLocation {
   return XcmVersionedLocation.V4({
     parents: 2,
-    interior: XcmV3Junctions.X2([
+    interior: XcmV3Junctions.X1(
       XcmV3Junction.GlobalConsensus(XcmV3JunctionNetworkId.Ethereum({ chain_id: 1n })),
-      XcmV3Junction.AccountKey20({ network: undefined, key: contract_address }),
-    ]),
+    ),
   });
 }
 
@@ -175,8 +174,8 @@ export function AssetLocation(
   assetSourceRelation: AssetSourceRelation,
 ): XcmVersionedLocation {
   const baseLocation =
-    asset === Asset.WETH
-      ? EthereumAssetLocation(FixedSizeBinary.fromHex(WETH_ADDRESS))
+    asset === Asset.ETH
+      ? EthereumLocation()
       : asset === Asset.DOT || asset === Asset.PLMC
         ? NativeAssetLocation(assetSourceRelation, asset)
         : AssetHubAssetLocation(BigInt(asset), assetSourceRelation);

--- a/integration-tests/src/constants.rs
+++ b/integration-tests/src/constants.rs
@@ -318,7 +318,7 @@ pub mod polimec {
 			let usdc = (AcceptedFundingAsset::USDC.id(), prices.usdc);
 			let usdt = (AcceptedFundingAsset::USDT.id(), prices.usdt);
 			let plmc = (Location::here(), prices.plmc);
-			let weth = (AcceptedFundingAsset::WETH.id(), prices.weth);
+			let weth = (AcceptedFundingAsset::ETH.id(), prices.weth);
 
 			let values: BoundedVec<(Location, FixedU128), <PolimecRuntime as orml_oracle::Config>::MaxFeedValues> =
 				vec![dot, usdc, usdt, plmc, weth].try_into().expect("benchmarks can panic");
@@ -356,7 +356,7 @@ pub mod polimec {
 		let dot_asset_id = AcceptedFundingAsset::DOT.id();
 		let usdt_asset_id = AcceptedFundingAsset::USDT.id();
 		let usdc_asset_id = AcceptedFundingAsset::USDC.id();
-		let weth_asset_id = AcceptedFundingAsset::WETH.id();
+		let weth_asset_id = AcceptedFundingAsset::ETH.id();
 
 		let mut funded_accounts = vec![(
 			PolimecNet::sovereign_account_id_of((Parent, xcm::prelude::Parachain(1000)).into()),

--- a/integration-tests/src/tests/defaults.rs
+++ b/integration-tests/src/tests/defaults.rs
@@ -23,8 +23,8 @@ use pallet_funding::{
 
 use macros::generate_accounts;
 use polimec_common::{
-	assets::AcceptedFundingAsset::{DOT, USDC, USDT, WETH},
-	ProvideAssetPrice, USD_DECIMALS, USD_UNIT,
+    assets::AcceptedFundingAsset::{DOT, USDC, USDT, ETH},
+    ProvideAssetPrice, USD_DECIMALS, USD_UNIT,
 };
 use polimec_runtime::AccountId;
 use sp_runtime::traits::ConstU32;
@@ -71,7 +71,7 @@ pub fn default_project_metadata(issuer: AccountId) -> ProjectMetadataOf<polimec_
 			retail: TicketSize::new(100 * USD_UNIT, None),
 			phantom: Default::default(),
 		},
-		participation_currencies: vec![USDT, USDC, DOT, WETH].try_into().unwrap(),
+		participation_currencies: vec![USDT, USDC, DOT, ETH].try_into().unwrap(),
 		funding_destination_account: issuer,
 		policy_ipfs_cid: Some(ipfs_hash()),
 		participants_account_type: ParticipantsAccountType::Polkadot,

--- a/integration-tests/src/tests/evaluator_slash_sideffects.rs
+++ b/integration-tests/src/tests/evaluator_slash_sideffects.rs
@@ -115,10 +115,12 @@ fn evaluator_slash_reduces_vesting_schedules() {
 		assert_eq!(ProjectStatus::AuctionRound, inst.go_to_next_state(project_id));
 		assert_eq!(ProjectStatus::FundingFailed, inst.go_to_next_state(project_id));
 		assert_eq!(ProjectStatus::SettlementStarted(FundingOutcome::Failure), inst.go_to_next_state(project_id));
-		assert_eq!(inst.current_block(), BlockNumberFor::<PolimecRuntime>::from(25u32));
 
-		// All schedules start at block 5, and funding ended at block 25
-		const TIME_PASSED: u128 = 20u128;
+		const END_BLOCK: u32 = 18;
+		assert_eq!(inst.current_block(), BlockNumberFor::<PolimecRuntime>::from(END_BLOCK));
+
+		// All schedules start at block 5, and funding ended at block 18
+		const TIME_PASSED: u128 = 13u128;
 
 		let alice_account_data = Account::<PolimecRuntime>::get(&alice.clone()).data;
 		assert_eq!(
@@ -177,9 +179,9 @@ fn evaluator_slash_reduces_vesting_schedules() {
 		assert_eq!(
 			alice_schedules,
 			vec![
-				VestingInfo::new(new_lock_1, new_per_block_1, 25),
-				VestingInfo::new(new_lock_3, new_per_block_3, 25),
-				VestingInfo::new(new_lock_4, new_per_block_4, 25),
+				VestingInfo::new(new_lock_1, new_per_block_1, END_BLOCK),
+				VestingInfo::new(new_lock_3, new_per_block_3, END_BLOCK),
+				VestingInfo::new(new_lock_4, new_per_block_4, END_BLOCK),
 			]
 		);
 		assert_eq!(alice_account_data, AccountData { free, reserved, frozen, flags: Default::default() });

--- a/integration-tests/src/tests/oracle.rs
+++ b/integration-tests/src/tests/oracle.rs
@@ -21,7 +21,7 @@ use sp_runtime::{bounded_vec, BoundedVec, FixedU128};
 use std::collections::BTreeMap;
 use tests::defaults::*;
 
-use AcceptedFundingAsset::{DOT, USDC, USDT, WETH};
+use AcceptedFundingAsset::{DOT, USDC, USDT, ETH};
 
 fn values(
 	values: [f64; 5],
@@ -31,7 +31,7 @@ fn values(
 		(DOT.id(), FixedU128::from_float(dot)),
 		(USDC.id(), FixedU128::from_float(usdc)),
 		(USDT.id(), FixedU128::from_float(usdt)),
-		(WETH.id(), FixedU128::from_float(weth)),
+		(ETH.id(), FixedU128::from_float(weth)),
 		(Location::here(), FixedU128::from_float(plmc))
 	]
 }
@@ -56,7 +56,7 @@ fn members_can_feed_data() {
 			(DOT.id(), FixedU128::from_float(4.84)),
 			(USDC.id(), FixedU128::from_float(1.0)),
 			(USDT.id(), FixedU128::from_float(1.0)),
-			(WETH.id(), FixedU128::from_float(2500.0)),
+			(ETH.id(), FixedU128::from_float(2500.0)),
 			(Location::here(), FixedU128::from_float(0.4)),
 		]);
 
@@ -102,7 +102,7 @@ fn data_is_correctly_combined() {
 			(DOT.id(), FixedU128::from_float(2.0)),
 			(USDC.id(), FixedU128::from_float(1.0)),
 			(USDT.id(), FixedU128::from_float(1.1)),
-			(WETH.id(), FixedU128::from_float(2500.0)),
+			(ETH.id(), FixedU128::from_float(2500.0)),
 			(Location::here(), FixedU128::from_float(0.22222)),
 		]);
 

--- a/integration-tests/src/tests/runtime_apis.rs
+++ b/integration-tests/src/tests/runtime_apis.rs
@@ -82,20 +82,20 @@ mod fungibles_api {
 			PolimecForeignAssets::set_balance(AcceptedFundingAsset::USDT.id(), &alice_account, 100_000_u128);
 			PolimecForeignAssets::set_balance(AcceptedFundingAsset::USDC.id(), &alice_account, 100_000_u128);
 			PolimecForeignAssets::set_balance(
-				AcceptedFundingAsset::WETH.id(),
-				&alice_account,
-				100_000_000_000_000_u128,
+                AcceptedFundingAsset::ETH.id(),
+                &alice_account,
+                100_000_000_000_000_u128,
 			);
 
 			let alice_assets = PolimecRuntime::query_account_balances(alice_account).unwrap();
 
 			let expected_assets = VersionedAssets::V4(
 				vec![
-					Asset::from((Location::here(), 150_0_000_000_000_u128)),
-					Asset::from((AcceptedFundingAsset::DOT.id(), 100_0_000_000_000_u128)),
-					Asset::from((AcceptedFundingAsset::USDC.id(), 100_000_u128)),
-					Asset::from((AcceptedFundingAsset::USDT.id(), 100_000_u128)),
-					Asset::from((AcceptedFundingAsset::WETH.id(), 100_000_000_000_000_u128)),
+                    Asset::from((Location::here(), 150_0_000_000_000_u128)),
+                    Asset::from((AcceptedFundingAsset::DOT.id(), 100_0_000_000_000_u128)),
+                    Asset::from((AcceptedFundingAsset::USDC.id(), 100_000_u128)),
+                    Asset::from((AcceptedFundingAsset::USDT.id(), 100_000_u128)),
+                    Asset::from((AcceptedFundingAsset::ETH.id(), 100_000_000_000_000_u128)),
 				]
 				.into(),
 			);

--- a/nodes/parachain/src/chain_spec/common.rs
+++ b/nodes/parachain/src/chain_spec/common.rs
@@ -110,7 +110,7 @@ pub fn genesis_config(genesis_config_params: GenesisConfigParams) -> serde_json:
 	let usdt_id = AcceptedFundingAsset::USDT.id();
 	let usdc_id = AcceptedFundingAsset::USDC.id();
 	let dot_id = AcceptedFundingAsset::DOT.id();
-	let weth_id = AcceptedFundingAsset::WETH.id();
+	let eth_id = AcceptedFundingAsset::ETH.id();
 
 	serde_json::json!({
 		"balances": {
@@ -139,7 +139,7 @@ pub fn genesis_config(genesis_config_params: GenesisConfigParams) -> serde_json:
 				70000,
 			),
 			(
-				AcceptedFundingAsset::WETH.id(),
+				AcceptedFundingAsset::ETH.id(),
 				&AccountIdConversion::<AccountId>::into_account_truncating(&<Runtime as pallet_funding::Config>::PalletId::get()),
 				true,
 				70000,
@@ -149,14 +149,14 @@ pub fn genesis_config(genesis_config_params: GenesisConfigParams) -> serde_json:
 				(usdt_id.clone(), b"Local USDT", b"USDT", 6),
 				(usdc_id.clone(), b"Local USDC", b"USDC", 6),
 				(dot_id.clone(), b"Local DOT ", b"DOT ", 10),
-				(weth_id.clone(), b"Local WETH", b"WETH", 18),
+				(eth_id.clone(), b"Local ETH ", b"ETH ", 18),
 			],
 			// (id, account_id, amount)
 			"accounts": vec![
 				(usdt_id, funding_assets_owner.clone(), 1000000000000u64),
 				(usdc_id, funding_assets_owner.clone(), 1000000000000u64),
 				(dot_id, funding_assets_owner.clone(), 1000000000000u64),
-				(weth_id, funding_assets_owner.clone(), 1000000000000u64),
+				(eth_id, funding_assets_owner.clone(), 1000000000000u64),
 			],
 		},
 		"parachainStaking": {

--- a/pallets/funding/src/benchmarking.rs
+++ b/pallets/funding/src/benchmarking.rs
@@ -35,9 +35,9 @@ use frame_support::{
 use itertools::Itertools;
 use parity_scale_codec::{Decode, Encode};
 use polimec_common::{
-	assets::AcceptedFundingAsset::{DOT, USDC, USDT, WETH},
-	credentials::InvestorType,
-	ProvideAssetPrice, USD_DECIMALS, USD_UNIT,
+    assets::AcceptedFundingAsset::{DOT, USDC, USDT, ETH},
+    credentials::InvestorType,
+    ProvideAssetPrice, USD_DECIMALS, USD_UNIT,
 };
 use polimec_common_test_utils::{generate_did_from_account, get_mock_jwt_with_cid};
 use sp_arithmetic::Percent;
@@ -75,7 +75,7 @@ where
 			retail: TicketSize::new(10u128 * USD_UNIT, None),
 			phantom: Default::default(),
 		},
-		participation_currencies: vec![USDT, USDC, DOT, WETH].try_into().unwrap(),
+		participation_currencies: vec![USDT, USDC, DOT, ETH].try_into().unwrap(),
 		funding_destination_account: issuer,
 		policy_ipfs_cid: Some(metadata_hash.into()),
 		participants_account_type: ParticipantsAccountType::Polkadot,
@@ -622,7 +622,7 @@ mod benchmarks {
 		let mut inst = BenchInstantiator::<T>::new(None);
 		<T as Config>::SetPrices::set_prices();
 
-		let weth_price = PriceProviderOf::<T>::get_price(WETH.id()).unwrap();
+		let weth_price = PriceProviderOf::<T>::get_price(ETH.id()).unwrap();
 		log::info!("weth_price: {:?}", weth_price);
 
 		// We can't see events at block 0

--- a/pallets/funding/src/instantiator/calculations.rs
+++ b/pallets/funding/src/instantiator/calculations.rs
@@ -4,7 +4,7 @@ use itertools::{izip, GroupBy};
 #[allow(clippy::wildcard_imports)]
 use polimec_common::assets::AcceptedFundingAsset;
 use polimec_common::{
-	assets::AcceptedFundingAsset::{DOT, USDC, USDT, WETH},
+	assets::AcceptedFundingAsset::{DOT, USDC, USDT, ETH},
 	ProvideAssetPrice, USD_DECIMALS,
 };
 use sp_core::{blake2_256, ecdsa, hexdisplay::AsBytesRef, keccak_256, sr25519, Pair};
@@ -427,7 +427,7 @@ impl<
 		let investor_types =
 			vec![Retail, Professional, Institutional].into_iter().cycle().take(bids_count as usize).collect_vec();
 		let funding_assets =
-			vec![USDT, USDC, DOT, WETH, USDT].into_iter().cycle().take(bids_count as usize).collect_vec();
+			vec![USDT, USDC, DOT, ETH, USDT].into_iter().cycle().take(bids_count as usize).collect_vec();
 
 		// Use Perquintill for precise weight distribution
 		let weights = {

--- a/pallets/funding/src/instantiator/chain_interactions.rs
+++ b/pallets/funding/src/instantiator/chain_interactions.rs
@@ -481,7 +481,7 @@ impl<
 				AcceptedFundingAsset::DOT => total_expected_dot += bid.funding_asset_amount_locked,
 				AcceptedFundingAsset::USDT => total_expected_usdt += bid.funding_asset_amount_locked,
 				AcceptedFundingAsset::USDC => total_expected_usdc += bid.funding_asset_amount_locked,
-				AcceptedFundingAsset::WETH => total_expected_weth += bid.funding_asset_amount_locked,
+				AcceptedFundingAsset::ETH => total_expected_weth += bid.funding_asset_amount_locked,
 			}
 		}
 
@@ -498,7 +498,7 @@ impl<
 			project_metadata.funding_destination_account.clone(),
 		);
 		let total_stored_weth = self.get_free_funding_asset_balance_for(
-			AcceptedFundingAsset::WETH.id(),
+			AcceptedFundingAsset::ETH.id(),
 			project_metadata.funding_destination_account,
 		);
 

--- a/pallets/funding/src/mock.rs
+++ b/pallets/funding/src/mock.rs
@@ -367,7 +367,7 @@ thread_local! {
 		(AcceptedFundingAsset::DOT.id(), FixedU128::from_float(69f64)), // DOT
 		(AcceptedFundingAsset::USDC.id(), FixedU128::from_float(0.97f64)), // USDC
 		(AcceptedFundingAsset::USDT.id(), FixedU128::from_float(1.0f64)), // USDT
-		(AcceptedFundingAsset::WETH.id(), FixedU128::from_float(3619.451f64)), // WETH
+		(AcceptedFundingAsset::ETH.id(), FixedU128::from_float(3619.451f64)), // WETH
 		(Location::here(), FixedU128::from_float(8.4f64)), // PLMC
 	]));
 }
@@ -506,7 +506,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 					100_000_000,
 				),
 				(
-					AcceptedFundingAsset::WETH.id(),
+					AcceptedFundingAsset::ETH.id(),
 					<TestRuntime as Config>::PalletId::get().into_account_truncating(),
 					true,
 					// 0.07 USD = .000041WETH at this moment
@@ -517,7 +517,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 				(AcceptedFundingAsset::USDT.id(), "USDT".as_bytes().to_vec(), "USDT".as_bytes().to_vec(), 6),
 				(AcceptedFundingAsset::USDC.id(), "USDC".as_bytes().to_vec(), "USDC".as_bytes().to_vec(), 6),
 				(AcceptedFundingAsset::DOT.id(), "DOT".as_bytes().to_vec(), "DOT".as_bytes().to_vec(), 10),
-				(AcceptedFundingAsset::WETH.id(), "WETH".as_bytes().to_vec(), "WETH".as_bytes().to_vec(), 18),
+				(AcceptedFundingAsset::ETH.id(), "WETH".as_bytes().to_vec(), "WETH".as_bytes().to_vec(), 18),
 			],
 			accounts: vec![],
 		},

--- a/pallets/funding/src/tests/1_application.rs
+++ b/pallets/funding/src/tests/1_application.rs
@@ -173,7 +173,7 @@ mod create_project_extrinsic {
 					.map(|acc| UserToFundingAsset {
 						account: *acc,
 						asset_amount: 1_000_000__000_000_000_000_000_000,
-						asset_id: WETH.id(),
+						asset_id: ETH.id(),
 					})
 					.collect(),
 			);

--- a/pallets/funding/src/tests/3_auction.rs
+++ b/pallets/funding/src/tests/3_auction.rs
@@ -82,7 +82,7 @@ mod round_flow {
 				AcceptedFundingAsset::USDT => usdt_price,
 				AcceptedFundingAsset::USDC => usdc_price,
 				AcceptedFundingAsset::DOT => dot_price,
-				AcceptedFundingAsset::WETH => todo!(),
+				AcceptedFundingAsset::ETH => todo!(),
 			};
 
 			let mut project_metadata = default_project_metadata.clone();

--- a/pallets/funding/src/tests/mod.rs
+++ b/pallets/funding/src/tests/mod.rs
@@ -23,7 +23,7 @@ use parachains_common::DAYS;
 use polimec_common::{
 	assets::{
 		AcceptedFundingAsset,
-		AcceptedFundingAsset::{DOT, USDC, USDT, WETH},
+		AcceptedFundingAsset::{DOT, USDC, USDT, ETH},
 	},
 	ProvideAssetPrice, USD_DECIMALS, USD_UNIT,
 };
@@ -103,7 +103,7 @@ const fn default_accounts() -> [AccountId; 18] {
 
 pub mod defaults {
 	use super::*;
-	use polimec_common::assets::AcceptedFundingAsset::{DOT, USDC, USDT, WETH};
+	use polimec_common::assets::AcceptedFundingAsset::{DOT, USDC, USDT, ETH};
 
 	pub fn default_token_information() -> CurrencyMetadata<BoundedVec<u8, StringLimitOf<TestRuntime>>> {
 		CurrencyMetadata { name: bounded_name(), symbol: bounded_symbol(), decimals: CT_DECIMALS }
@@ -130,7 +130,7 @@ pub mod defaults {
 				retail: TicketSize::new(100 * USD_UNIT, None),
 				phantom: Default::default(),
 			},
-			participation_currencies: vec![USDT, USDC, DOT, WETH].try_into().unwrap(),
+			participation_currencies: vec![USDT, USDC, DOT, ETH].try_into().unwrap(),
 			funding_destination_account: issuer,
 			policy_ipfs_cid: Some(metadata_hash),
 			participants_account_type: ParticipantsAccountType::Polkadot,

--- a/pallets/funding/src/tests/runtime_api.rs
+++ b/pallets/funding/src/tests/runtime_api.rs
@@ -525,7 +525,7 @@ fn calculate_otm_fee() {
 fn get_funding_asset_min_max_amounts() {
 	ConstPriceProvider::set_price(AcceptedFundingAsset::USDT.id(), PriceOf::<TestRuntime>::from_float(1.0f64));
 	ConstPriceProvider::set_price(AcceptedFundingAsset::DOT.id(), PriceOf::<TestRuntime>::from_float(10.0f64));
-	ConstPriceProvider::set_price(AcceptedFundingAsset::WETH.id(), PriceOf::<TestRuntime>::from_float(100.0f64));
+	ConstPriceProvider::set_price(AcceptedFundingAsset::ETH.id(), PriceOf::<TestRuntime>::from_float(100.0f64));
 	ConstPriceProvider::set_price(Location::here(), PriceOf::<TestRuntime>::from_float(0.5f64));
 	const DOT_UNIT: u128 = 10u128.pow(10u32);
 	const WETH_UNIT: u128 = 10u128.pow(18u32);
@@ -601,12 +601,12 @@ fn get_funding_asset_min_max_amounts() {
 	let (min, max) = inst
 		.execute(|| {
 			TestRuntime::get_funding_asset_min_max_amounts(
-				&TestRuntime,
-				block_hash,
-				project_id,
-				generate_did_from_account(BIDDER_1),
-				AcceptedFundingAsset::WETH,
-				InvestorType::Retail,
+                &TestRuntime,
+                block_hash,
+                project_id,
+                generate_did_from_account(BIDDER_1),
+                AcceptedFundingAsset::ETH,
+                InvestorType::Retail,
 			)
 		})
 		.unwrap()

--- a/pallets/funding/src/types.rs
+++ b/pallets/funding/src/types.rs
@@ -706,7 +706,7 @@ pub mod inner {
 
 pub mod extrinsic {
 	use super::*;
-	use crate::{AccountIdOf, Balance, Config, ParticipationMode, PriceOf, ProjectDetailsOf, ProjectId, TicketSize};
+	use crate::{AccountIdOf, Balance, Config, ParticipationMode, PriceOf, ProjectId, TicketSize};
 	use frame_system::pallet_prelude::BlockNumberFor;
 	use polimec_common::credentials::{Cid, Did, InvestorType};
 	use xcm::v4::Junction;

--- a/polimec-common/common/src/assets.rs
+++ b/polimec-common/common/src/assets.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use xcm::{
 	prelude::Parachain,
-	v4::prelude::{AccountKey20, Ethereum, GeneralIndex, GlobalConsensus, Location, PalletInstance},
+	v4::prelude::{Ethereum, GeneralIndex, GlobalConsensus, Location, PalletInstance},
 };
 
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
@@ -35,7 +35,7 @@ pub enum AcceptedFundingAsset {
 	#[codec(index = 2)]
 	DOT,
 	#[codec(index = 3)]
-	WETH,
+	ETH,
 }
 impl AcceptedFundingAsset {
 	pub fn id(&self) -> Location {
@@ -43,17 +43,16 @@ impl AcceptedFundingAsset {
 			AcceptedFundingAsset::USDT => Location::new(1, [Parachain(1000), PalletInstance(50), GeneralIndex(1984)]),
 			AcceptedFundingAsset::DOT => Location::parent(),
 			AcceptedFundingAsset::USDC => Location::new(1, [Parachain(1000), PalletInstance(50), GeneralIndex(1337)]),
-			AcceptedFundingAsset::WETH => Location::new(
+			AcceptedFundingAsset::ETH => Location::new(
 				2,
 				[
 					GlobalConsensus(Ethereum { chain_id: 1 }),
-					AccountKey20 { network: None, key: hex_literal::hex!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2") },
 				],
 			),
 		}
 	}
 
 	pub fn all_ids() -> Vec<Location> {
-		vec![Self::USDT.id(), Self::DOT.id(), Self::USDC.id(), Self::WETH.id()]
+		vec![Self::USDT.id(), Self::DOT.id(), Self::USDC.id(), Self::ETH.id()]
 	}
 }

--- a/runtimes/polimec/src/benchmark_helpers.rs
+++ b/runtimes/polimec/src/benchmark_helpers.rs
@@ -14,7 +14,7 @@ impl SetPrices for SetOraclePrices {
 		let dot = (AcceptedFundingAsset::DOT.id(), FixedU128::from_rational(69, 1));
 		let usdc = (AcceptedFundingAsset::USDC.id(), FixedU128::from_rational(1, 1));
 		let usdt = (AcceptedFundingAsset::USDT.id(), FixedU128::from_rational(1, 1));
-		let weth = (AcceptedFundingAsset::WETH.id(), FixedU128::from_rational(20_000, 1));
+		let weth = (AcceptedFundingAsset::ETH.id(), FixedU128::from_rational(20_000, 1));
 		let plmc = (Location::here(), FixedU128::from_rational(840, 100));
 
 		let values: BoundedVec<(Location, FixedU128), <Runtime as orml_oracle::Config>::MaxFeedValues> =

--- a/runtimes/shared-configuration/src/currency.rs
+++ b/runtimes/shared-configuration/src/currency.rs
@@ -29,6 +29,10 @@ pub const MILLI_PLMC: Balance = 10u128.pow(7);
 /// 0.000_001 PLMC
 pub const MICRO_PLMC: Balance = 10u128.pow(4);
 
+// Required for the treasury payout benchmark, as it does a transfer under the normal ED.
+#[cfg(feature = "runtime-benchmarks")]
+pub const EXISTENTIAL_DEPOSIT: Balance = 1;
+#[cfg(not(feature = "runtime-benchmarks"))]
 pub const EXISTENTIAL_DEPOSIT: Balance = 10 * MILLI_PLMC;
 
 /// Deposit that must be provided for each occupied storage item.
@@ -55,13 +59,6 @@ parameter_types! {
 	pub const MaxReserves: u32 = 50;
 }
 
-// Required for the treasury payout benchmark, as it does a transfer under the normal ED.
-#[cfg(feature = "runtime-benchmarks")]
-parameter_types! {
-	pub const ExistentialDeposit: Balance = 1;
-}
-
-#[cfg(not(feature = "runtime-benchmarks"))]
 parameter_types! {
 	pub const ExistentialDeposit: Balance = EXISTENTIAL_DEPOSIT;
 }
@@ -89,7 +86,7 @@ impl Convert<(AssetName, FixedU128), (Location, Price)> for AssetPriceConverter 
 			AssetName::USDC => (AcceptedFundingAsset::USDC.id(), price),
 			AssetName::USDT => (AcceptedFundingAsset::USDT.id(), price),
 			AssetName::PLMC => (Location::here(), price),
-			AssetName::WETH => (AcceptedFundingAsset::WETH.id(), price),
+			AssetName::WETH => (AcceptedFundingAsset::ETH.id(), price),
 		}
 	}
 }


### PR DESCRIPTION
## What

This PR includes a series of changes to update the asset references from WETH to ETH across multiple files in the integration tests. The changes ensure consistency in naming and update the relevant asset locations, constants, and test cases.

Key changes include:

### Asset Reference Updates:
* Updated the `weth_location` to `eth_location` and modified its structure in `integration-tests/chopsticks/overrides/polimec.ts`.
* Replaced `weth_location` with `eth_location` in the `polimec_storage` export in `integration-tests/chopsticks/overrides/polimec.ts`.
* Updated the `Metadata` entry to use `eth_location` instead of `weth_location` in `integration-tests/chopsticks/overrides/polimec.ts`.

### Constant and Enum Updates:
* Changed `WETH_AMOUNT` to `ETH_AMOUNT` in `integration-tests/chopsticks/src/constants.ts`.
* Updated the `Asset` enum to replace `WETH` with `ETH` in `integration-tests/chopsticks/src/types.ts`.

### Manager and Transfer Updates:
* Replaced `WETH` with `ETH` in various manager classes (`BridgeHubManager`, `PolimecManager`, `PolkadotHubManager`, `PolkadotManager`) in `integration-tests/chopsticks/src/managers`. [[1]](diffhunk://#diff-abfaa431bf6c22a25e34583588d9f8a6f034727ae3ffea05ca72bd652d038121L47-R52) [[2]](diffhunk://#diff-9d178e7e97867ffa376f42cc2d1c7de09eaf4d5c04cdc45324e942d92a3f34b1L46-R46) [[3]](diffhunk://#diff-17504b68de01739408ba3271f1474bc42e5e8544b68aab412f359b1345b54fa2L50-R50) F4258a6L46R46)
* Updated transfer test cases to use `ETH` instead of `WETH` in `integration-tests/chopsticks/src/tests/bridge.test.ts` and `integration-tests/chopsticks/src/transfers/BridgeToPolimec.ts`. [[1]](diffhunk://#diff-a99dd291e057f52d4bab5a9a18a1d45823ec8079cbeaec6bb57dc0d4148d2a84L25-R31) [[2]](diffhunk://#diff-d3f932bd8fa0e6df0cbaf55474b048e8008b43a22b2f502d1ea624fd1d0b9b7eL2-R2)

### Additional Changes:
* Removed outdated comments and adjusted vesting schedule blocks in `integration-tests/src/tests/evaluator_slash_sideffects.rs`. [[1]](diffhunk://#diff-ad31d56f22e95148a3285609a520696ba48d2ddcc4e27c2a5f87c9d528c4f756L118-R123) [[2]](diffhunk://#diff-ad31d56f22e95148a3285609a520696ba48d2ddcc4e27c2a5f87c9d528c4f756L180-R184)
* Updated Oracle test cases to use `ETH` instead of `WETH` in `integration-tests/src/tests/oracle.rs`. [[1]](diffhunk://#diff-d351db03f78af3ca041b937cc7d105d8c35a6035def128ad67c93477b217a47aL24-R24) [[2]](diffhunk://#diff-d351db03f78af3ca041b937cc7d105d8c35a6035def128ad67c93477b217a47aL34-R34) [[3]](diffhunk://#diff-d351db03f78af3ca041b937cc7d105d8c35a6035def128ad67c93477b217a47aL59-R59) [[4]](diffhunk://#diff-d351db03f78af3ca041b937cc7d105d8c35a6035def128ad67c93477b217a47aL105-R105)
