### PR TITLE
🐛 Update the integration tests

### DIFF
--- a/integration-tests/chopsticks/README.md
+++ b/integration-tests/chopsticks/README.md
@@ -1,4 +1,10 @@
-# chopsticks
+# XCM Integration Tests: Polkadot API x Chopsticks 
+
+## Prerequisites
+
+- [Bun](https://bun.sh/docs/installation)
+
+## Usage
 
 To install dependencies:
 
@@ -6,32 +12,37 @@ To install dependencies:
 bun install
 ```
 
+To generate the Chains descriptors:
+
 ```bash
 bun papi
 ```
 
 > [!NOTE]
-> Sometimes you need to regenerate the Polimec descriptors. To do that, run:
+> If you need to regenerate the Polimec descriptors (e.g. you changed something on the Runtime). You can run:
 >
 > ```bash
+> bun papi
 > bun papi add polimec --wasm ../../target/release/wbuild/polimec-runtime/polimec_runtime.compact.compressed.wasm
 > ```
 
-To start the chains:
+> [!NOTE]
+> If you need to regenerate the descriptors. You can delete the `.papi` folder and run:
+> ```bash
+> bun papi add polimec --wasm ../../target/release/wbuild/polimec-runtime/polimec_runtime.compact.compressed.wasm
+> bun papi add bridge -w wss://sys.ibp.network/bridgehub-polkadot
+> bun papi add pah -w wss://sys.ibp.network/statemint
+> bun papi add polkadot -w wss://rpc.ibp.network/polkadot
+> ```
 
-```bash
-bun run dev
-```
-
-To run the tests:
+To run all the tests:
 
 ```bash
 bun run test
 ```
 
+To run a specific test case, e.g Polkadot to Polimec:
 
-> [!IMPORTANT]
-> TODO: Add:
-> - [ ] Polimec SA on AH: Add ETH balance to it in the Chopstick ovveride
-> - [ ] Polimec to Asset Hub: ETH transfer. This is a "normal" transfer_asset call.
-> - [ ] Polimec to Ethereum: ETH transfer. This is a bit more complex, example extrinsic: https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fhydration.ibp.network#/extrinsics/decode/0x6b0d04010100a10f040801000007464a69c7e002020907040300c02aaa39b223fe8d0a0e5c4f27ead9083c756cc200130000e8890423c78a0204010002040816040d01000001010088ca48e3e1d0f1c50bd6b504e1312d21f5bd45ed147e3c30c77eb5e4d63bdc6310010102020907040300c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2000201090704081300010300c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20004000d010204000103001501c1413e4178c38567ada8945a80351f7b849600
+```bash
+bun run test polkadot
+```

--- a/integration-tests/chopsticks/bun.lock
+++ b/integration-tests/chopsticks/bun.lock
@@ -5,12 +5,12 @@
       "name": "chopsticks",
       "dependencies": {
         "@polkadot-api/descriptors": "file:.papi/descriptors",
-        "polkadot-api": "^1.9.0",
+        "polkadot-api": "^1.9.3",
       },
       "devDependencies": {
-        "@acala-network/chopsticks": "1.0.2",
+        "@acala-network/chopsticks": "1.0.3",
         "@biomejs/biome": "1.9.4",
-        "@polkadot-labs/hdkd": "0.0.11",
+        "@polkadot-labs/hdkd": "0.0.12",
         "@types/bun": "latest",
       },
       "peerDependencies": {
@@ -19,13 +19,13 @@
     },
   },
   "packages": {
-    "@acala-network/chopsticks": ["@acala-network/chopsticks@1.0.2", "", { "dependencies": { "@acala-network/chopsticks-core": "1.0.2", "@acala-network/chopsticks-db": "1.0.2", "@pnpm/npm-conf": "^2.3.1", "@polkadot/api": "^15.0", "@polkadot/api-augment": "^15.0", "@polkadot/rpc-provider": "^15.0", "@polkadot/types": "^15.0", "@polkadot/util": "^13.2", "@polkadot/util-crypto": "^13.2", "axios": "^1.7.9", "comlink": "^4.4.2", "dotenv": "^16.4.7", "global-agent": "^3.0.0", "js-yaml": "^4.1.0", "jsondiffpatch": "^0.5.0", "lodash": "^4.17.21", "ws": "^8.18.0", "yargs": "^17.7.2", "zod": "^3.24.1" }, "bin": "./chopsticks.cjs" }, "sha512-3CqyGAv2/G0yMiZrX+zZgBvyIFpxAtgm2gJGj/OZK2oVXcQBVXxUkQW5FQEoN9eftVIfMfzC+YlZN4t/TxkhoA=="],
+    "@acala-network/chopsticks": ["@acala-network/chopsticks@1.0.3", "", { "dependencies": { "@acala-network/chopsticks-core": "1.0.3", "@acala-network/chopsticks-db": "1.0.3", "@pnpm/npm-conf": "^3.0.0", "@polkadot/api": "^15.7.1", "@polkadot/api-augment": "^15.7.1", "@polkadot/rpc-provider": "^15.7.1", "@polkadot/types": "^15.7.1", "@polkadot/util": "^13.4.3", "@polkadot/util-crypto": "^13.4.3", "axios": "^1.8.1", "comlink": "^4.4.2", "dotenv": "^16.4.7", "global-agent": "^3.0.0", "js-yaml": "^4.1.0", "jsondiffpatch": "^0.5.0", "lodash": "^4.17.21", "ws": "^8.18.1", "yargs": "^17.7.2", "zod": "^3.24.2" }, "bin": "./chopsticks.cjs" }, "sha512-M/1fty7iv/+aTI1oYkp2jPOi3LsgoFuAV2WiISHwa39SzBOlG2Gd9ZMUOp3gwcexr47RUP+Ciqw3ZmH4tLT1Aw=="],
 
-    "@acala-network/chopsticks-core": ["@acala-network/chopsticks-core@1.0.2", "", { "dependencies": { "@acala-network/chopsticks-executor": "1.0.2", "@polkadot/rpc-provider": "^15.0", "@polkadot/types": "^15.0", "@polkadot/types-codec": "^15.0", "@polkadot/types-known": "^15.0", "@polkadot/util": "^13.2", "@polkadot/util-crypto": "^13.2", "comlink": "^4.4.2", "eventemitter3": "^5.0.1", "lodash": "^4.17.21", "lru-cache": "^11.0.2", "pino": "^9.5.0", "pino-pretty": "^13.0.0", "rxjs": "^7.8.1", "zod": "^3.24.1" } }, "sha512-j45pTfgamgI7YjJHI943GFoj15kjciIP0nAVfX1CVMXwNA5YewLY8t8SCoyKhnPvS9OskdVtC54jWjjJRttC+w=="],
+    "@acala-network/chopsticks-core": ["@acala-network/chopsticks-core@1.0.3", "", { "dependencies": { "@acala-network/chopsticks-executor": "1.0.3", "@polkadot/rpc-provider": "^15.7.1", "@polkadot/types": "^15.7.1", "@polkadot/types-codec": "^15.7.1", "@polkadot/types-known": "^15.7.1", "@polkadot/util": "^13.4.3", "@polkadot/util-crypto": "^13.4.3", "comlink": "^4.4.2", "eventemitter3": "^5.0.1", "lodash": "^4.17.21", "lru-cache": "^11.0.2", "pino": "^9.6.0", "pino-pretty": "^13.0.0", "rxjs": "^7.8.2", "zod": "^3.24.2" } }, "sha512-dM10KzftZQ/jC4nuChXbKv/zxhqqxHBW1pJksXcJfwudLNrrzYuiPshM1QwF43kq78eD1uWGc1aHDfBopPVlgQ=="],
 
-    "@acala-network/chopsticks-db": ["@acala-network/chopsticks-db@1.0.2", "", { "dependencies": { "@acala-network/chopsticks-core": "1.0.2", "@polkadot/util": "^13.2", "idb": "^8.0.1", "sqlite3": "^5.1.7", "typeorm": "^0.3.20" } }, "sha512-ky94awHwhK6uHsPLRqryIhhriBWK9RQDXHplybU+icdMq9C9aAYMmejQsF2T7lAC8LwFoe3mI0tDYRMDK0zhJA=="],
+    "@acala-network/chopsticks-db": ["@acala-network/chopsticks-db@1.0.3", "", { "dependencies": { "@acala-network/chopsticks-core": "1.0.3", "@polkadot/util": "^13.4.3", "idb": "^8.0.2", "sqlite3": "^5.1.7", "typeorm": "^0.3.20" } }, "sha512-H5KSx8/jBTb8e7LB3a2M2Cbz8gxkFcWMI+Do0YEWhctKzLUTiaRvzJrmQfA+ukn9jy5duEVDPTWjCYQb4lSFmg=="],
 
-    "@acala-network/chopsticks-executor": ["@acala-network/chopsticks-executor@1.0.2", "", { "dependencies": { "@polkadot/util": "^13.2", "@polkadot/wasm-util": "^7.4" } }, "sha512-I0fie9j9pcnQMO89Ix5ZoLwWRcsUj7L2ba1b4UeJB0JwVibcJcCwSmAMefmcceDZPEkwvWya1ukv0gy/AY93Lw=="],
+    "@acala-network/chopsticks-executor": ["@acala-network/chopsticks-executor@1.0.3", "", { "dependencies": { "@polkadot/util": "^13.4.3", "@polkadot/wasm-util": "^7.4.1" } }, "sha512-iWOJicWwL3NpI7krqJuEAVrJZArE19OIdHLY7FHB0ibu/ebrlHkr2neo9GkYEtWIvGT24vtH1OIKqsbJxdXpEA=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.26.2", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.25.9", "js-tokens": "^4.0.0", "picocolors": "^1.0.0" } }, "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ=="],
 
@@ -51,55 +51,55 @@
 
     "@commander-js/extra-typings": ["@commander-js/extra-typings@13.1.0", "", { "peerDependencies": { "commander": "~13.1.0" } }, "sha512-q5P52BYb1hwVWE6dtID7VvuJWrlfbCv4klj7BjUUOqMz4jbSZD4C9fJ9lRjL2jnBGTg+gDDlaXN51rkWcLk4fg=="],
 
-    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.24.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA=="],
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ=="],
 
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.24.2", "", { "os": "android", "cpu": "arm" }, "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q=="],
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.0", "", { "os": "android", "cpu": "arm" }, "sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g=="],
 
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.24.2", "", { "os": "android", "cpu": "arm64" }, "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg=="],
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.0", "", { "os": "android", "cpu": "arm64" }, "sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g=="],
 
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.24.2", "", { "os": "android", "cpu": "x64" }, "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw=="],
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.0", "", { "os": "android", "cpu": "x64" }, "sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg=="],
 
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.24.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA=="],
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw=="],
 
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.24.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA=="],
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg=="],
 
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.24.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg=="],
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w=="],
 
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.24.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q=="],
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A=="],
 
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.24.2", "", { "os": "linux", "cpu": "arm" }, "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA=="],
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.0", "", { "os": "linux", "cpu": "arm" }, "sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg=="],
 
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.24.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg=="],
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg=="],
 
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.24.2", "", { "os": "linux", "cpu": "ia32" }, "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw=="],
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg=="],
 
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.24.2", "", { "os": "linux", "cpu": "none" }, "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ=="],
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.0", "", { "os": "linux", "cpu": "none" }, "sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw=="],
 
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.24.2", "", { "os": "linux", "cpu": "none" }, "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw=="],
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.0", "", { "os": "linux", "cpu": "none" }, "sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ=="],
 
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.24.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw=="],
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw=="],
 
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.24.2", "", { "os": "linux", "cpu": "none" }, "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q=="],
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.0", "", { "os": "linux", "cpu": "none" }, "sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA=="],
 
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.24.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw=="],
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA=="],
 
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.24.2", "", { "os": "linux", "cpu": "x64" }, "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q=="],
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.0", "", { "os": "linux", "cpu": "x64" }, "sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw=="],
 
-    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.24.2", "", { "os": "none", "cpu": "arm64" }, "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw=="],
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.0", "", { "os": "none", "cpu": "arm64" }, "sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw=="],
 
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.24.2", "", { "os": "none", "cpu": "x64" }, "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw=="],
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.0", "", { "os": "none", "cpu": "x64" }, "sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA=="],
 
-    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.24.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A=="],
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw=="],
 
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.24.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA=="],
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg=="],
 
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.24.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig=="],
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg=="],
 
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.24.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ=="],
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw=="],
 
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.24.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA=="],
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA=="],
 
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.24.2", "", { "os": "win32", "cpu": "x64" }, "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg=="],
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.0", "", { "os": "win32", "cpu": "x64" }, "sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ=="],
 
     "@gar/promisify": ["@gar/promisify@1.1.3", "", {}, "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="],
 
@@ -129,9 +129,9 @@
 
     "@pnpm/network.ca-file": ["@pnpm/network.ca-file@1.0.2", "", { "dependencies": { "graceful-fs": "4.2.10" } }, "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA=="],
 
-    "@pnpm/npm-conf": ["@pnpm/npm-conf@2.3.1", "", { "dependencies": { "@pnpm/config.env-replace": "^1.1.0", "@pnpm/network.ca-file": "^1.0.1", "config-chain": "^1.1.11" } }, "sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw=="],
+    "@pnpm/npm-conf": ["@pnpm/npm-conf@3.0.0", "", { "dependencies": { "@pnpm/config.env-replace": "^1.1.0", "@pnpm/network.ca-file": "^1.0.1", "config-chain": "^1.1.11" } }, "sha512-LdFkv/+4ONkQ9ZyE8ihC2L2RcPjvNcOTQq6pvvvZp8KeDYATCJeJX7gpHZF3Bx1XvUSU35dyF9Q9dS+JShtOFA=="],
 
-    "@polkadot-api/cli": ["@polkadot-api/cli@0.11.0", "", { "dependencies": { "@commander-js/extra-typings": "^13.1.0", "@polkadot-api/codegen": "0.13.0", "@polkadot-api/ink-contracts": "0.2.5", "@polkadot-api/json-rpc-provider": "0.0.4", "@polkadot-api/known-chains": "0.7.0", "@polkadot-api/metadata-compatibility": "0.1.15", "@polkadot-api/observable-client": "0.8.0", "@polkadot-api/polkadot-sdk-compat": "2.3.1", "@polkadot-api/sm-provider": "0.1.7", "@polkadot-api/smoldot": "0.3.8", "@polkadot-api/substrate-bindings": "0.11.0", "@polkadot-api/substrate-client": "0.3.0", "@polkadot-api/utils": "0.1.2", "@polkadot-api/wasm-executor": "^0.1.2", "@polkadot-api/ws-provider": "0.3.6", "@types/node": "^22.13.1", "commander": "^13.1.0", "execa": "^9.5.2", "fs.promises.exists": "^1.1.4", "ora": "^8.2.0", "read-pkg": "^9.0.1", "rxjs": "^7.8.1", "tsc-prog": "^2.3.0", "tsup": "^8.3.6", "typescript": "^5.7.3", "write-package": "^7.1.0" }, "bin": { "papi": "dist/main.js", "polkadot-api": "dist/main.js" } }, "sha512-ygOwpjoE54rZ6zE3n6gXFzWoFz9XegQIXKyBc4tV6fjxALiuNAtg/p1x60rXl1iEh0+jrBd+xpxvj2rUbSmejA=="],
+    "@polkadot-api/cli": ["@polkadot-api/cli@0.11.1", "", { "dependencies": { "@commander-js/extra-typings": "^13.1.0", "@polkadot-api/codegen": "0.13.0", "@polkadot-api/ink-contracts": "0.2.5", "@polkadot-api/json-rpc-provider": "0.0.4", "@polkadot-api/known-chains": "0.7.1", "@polkadot-api/metadata-compatibility": "0.1.15", "@polkadot-api/observable-client": "0.8.1", "@polkadot-api/polkadot-sdk-compat": "2.3.2", "@polkadot-api/sm-provider": "0.1.7", "@polkadot-api/smoldot": "0.3.8", "@polkadot-api/substrate-bindings": "0.11.0", "@polkadot-api/substrate-client": "0.3.0", "@polkadot-api/utils": "0.1.2", "@polkadot-api/wasm-executor": "^0.1.2", "@polkadot-api/ws-provider": "0.4.0", "@types/node": "^22.13.5", "commander": "^13.1.0", "execa": "^9.5.2", "fs.promises.exists": "^1.1.4", "ora": "^8.2.0", "read-pkg": "^9.0.1", "rxjs": "^7.8.2", "tsc-prog": "^2.3.0", "tsup": "^8.4.0", "typescript": "^5.7.3", "write-package": "^7.1.0" }, "bin": { "papi": "dist/main.js", "polkadot-api": "dist/main.js" } }, "sha512-3AvNhTxREygzfbN5UrAHMLhNyQJLn5WnVHZnR+aj6A13Da/Q6I2Oh8u/8HFjGzHHVz8xYRA0/lAR2MUFFr5TdA=="],
 
     "@polkadot-api/codegen": ["@polkadot-api/codegen@0.13.0", "", { "dependencies": { "@polkadot-api/ink-contracts": "0.2.5", "@polkadot-api/metadata-builders": "0.10.1", "@polkadot-api/metadata-compatibility": "0.1.15", "@polkadot-api/substrate-bindings": "0.11.0", "@polkadot-api/utils": "0.1.2" } }, "sha512-VU0juJz7TWohFa/tUqOSUdauGlGBJT562+POFerz1/DdXeJ4P1U7BKGM+s57PJlN8D6cHfIv1uoPvuuwnfazgg=="],
 
@@ -143,7 +143,7 @@
 
     "@polkadot-api/json-rpc-provider-proxy": ["@polkadot-api/json-rpc-provider-proxy@0.2.4", "", {}, "sha512-nuGoY9QpBAiRU7xmXN3nugFvPcnSu3IxTLm1OWcNTGlZ1LW5bvdQHz3JLk56+Jlyb3GJ971hqdg2DJsMXkKCOg=="],
 
-    "@polkadot-api/known-chains": ["@polkadot-api/known-chains@0.7.0", "", {}, "sha512-hKkxFG8bR4gy5K1GK4HrTLLpJVLu2IJDQHY9Ezz9RbL8QFffwg4BIGDI6JXdKBFnCDnHE8oN6xhd6aUiLIppQw=="],
+    "@polkadot-api/known-chains": ["@polkadot-api/known-chains@0.7.1", "", {}, "sha512-65hwgOrS0dFi4J6LQy043fZoBv29ctvAO91gQjSyhQdTionpoNVEizUWZwJj2qx3U4+sSovQXP+s71QBpv8NZA=="],
 
     "@polkadot-api/logs-provider": ["@polkadot-api/logs-provider@0.0.6", "", { "dependencies": { "@polkadot-api/json-rpc-provider": "0.0.4" } }, "sha512-4WgHlvy+xee1ADaaVf6+MlK/+jGMtsMgAzvbQOJZnP4PfQuagoTqaeayk8HYKxXGphogLlPbD06tANxcb+nvAg=="],
 
@@ -151,11 +151,11 @@
 
     "@polkadot-api/metadata-compatibility": ["@polkadot-api/metadata-compatibility@0.1.15", "", { "dependencies": { "@polkadot-api/metadata-builders": "0.10.1", "@polkadot-api/substrate-bindings": "0.11.0" } }, "sha512-voOXicr3S/l/5bkNb8hCmTWpfXLOg6iGYulguMJgCI+xGBooJBx7twtVogaNJTzXfrIZtEbxrD+tUsKScIN6iw=="],
 
-    "@polkadot-api/observable-client": ["@polkadot-api/observable-client@0.8.0", "", { "dependencies": { "@polkadot-api/metadata-builders": "0.10.1", "@polkadot-api/substrate-bindings": "0.11.0", "@polkadot-api/utils": "0.1.2" }, "peerDependencies": { "@polkadot-api/substrate-client": "0.3.0", "rxjs": ">=7.8.0" } }, "sha512-n7k79RPyVL/sc22+AzIEioZM4vQO9mp+spkW7s+7M0WLvxpAJ6OR0YNt5/MYPggZGKUTIgH4iWPsLNYNtAJ4MA=="],
+    "@polkadot-api/observable-client": ["@polkadot-api/observable-client@0.8.1", "", { "dependencies": { "@polkadot-api/metadata-builders": "0.10.1", "@polkadot-api/substrate-bindings": "0.11.0", "@polkadot-api/utils": "0.1.2" }, "peerDependencies": { "@polkadot-api/substrate-client": "0.3.0", "rxjs": ">=7.8.0" } }, "sha512-FlmLkd3GDdYUgd725nHABgz9TV/mIGHgI4Af9VhuaL+U1yKC9AX7dmobD8TUVHxv+1qyNyXY8/Mmkmh22fGkOg=="],
 
     "@polkadot-api/pjs-signer": ["@polkadot-api/pjs-signer@0.6.4", "", { "dependencies": { "@polkadot-api/metadata-builders": "0.10.1", "@polkadot-api/polkadot-signer": "0.1.6", "@polkadot-api/signers-common": "0.1.5", "@polkadot-api/substrate-bindings": "0.11.0", "@polkadot-api/utils": "0.1.2" } }, "sha512-dXln8Par3I5dIX1xw59a8ovpsBj346ZKxsW9/uF9Cm9IQB2QffG3N0jctBUGHYZ+8dHRPug117o/xZCzqOAibw=="],
 
-    "@polkadot-api/polkadot-sdk-compat": ["@polkadot-api/polkadot-sdk-compat@2.3.1", "", { "dependencies": { "@polkadot-api/json-rpc-provider": "0.0.4" } }, "sha512-rb8IWmPRhKWD9NG4zh2n4q0HlEAvq+Cv1CbD+8YxH0XAqIIiFA+ch5JeDCIxQYngkn/43B0Gs7Gtzh18yv2yoA=="],
+    "@polkadot-api/polkadot-sdk-compat": ["@polkadot-api/polkadot-sdk-compat@2.3.2", "", { "dependencies": { "@polkadot-api/json-rpc-provider": "0.0.4" } }, "sha512-rLCveP3a6Xd0r218yRqVY34lJ8bXVmE12cArbU4JFp9p8e8Jbb6xdqOdu7bQtjlZUsahhcmfIHYQSXKziST7PA=="],
 
     "@polkadot-api/polkadot-signer": ["@polkadot-api/polkadot-signer@0.1.6", "", {}, "sha512-X7ghAa4r7doETtjAPTb50IpfGtrBmy3BJM5WCfNKa1saK04VFY9w+vDn+hwEcM4p0PcDHt66Ts74hzvHq54d9A=="],
 
@@ -175,45 +175,45 @@
 
     "@polkadot-api/wasm-executor": ["@polkadot-api/wasm-executor@0.1.2", "", {}, "sha512-a5wGenltB3EFPdf72u8ewi6HsUg2qubUAf3ekJprZf24lTK3+w8a/GUF/y6r08LJF35MALZ32SAtLqtVTIOGnQ=="],
 
-    "@polkadot-api/ws-provider": ["@polkadot-api/ws-provider@0.3.6", "", { "dependencies": { "@polkadot-api/json-rpc-provider": "0.0.4", "@polkadot-api/json-rpc-provider-proxy": "0.2.4", "ws": "^8.18.0" } }, "sha512-D2+rvcDc9smt24qUKqFoCuKKNhyBVDQEtnsqHiUN/Ym8UGP+Acegac3b9VOig70EpCcRBoYeXY2gEog2ybx1Kg=="],
+    "@polkadot-api/ws-provider": ["@polkadot-api/ws-provider@0.4.0", "", { "dependencies": { "@polkadot-api/json-rpc-provider": "0.0.4", "@polkadot-api/json-rpc-provider-proxy": "0.2.4", "ws": "^8.18.1" } }, "sha512-ZurjUHHAlQ1Ux8HiZz7mtkg1qjq6LmqxcHljcZxne0U7foCZrXdWHsohwlV8kUQUir5kXuDsNvdZN/MFCUMaVw=="],
 
-    "@polkadot-labs/hdkd": ["@polkadot-labs/hdkd@0.0.11", "", { "dependencies": { "@polkadot-labs/hdkd-helpers": "0.0.11" } }, "sha512-1s375PlIup6cV7EYZ1+Y1eLGLQlYnv7Gdvo20aA5PzXH2VskKHSOOgXH1t1umJIAG8J0pGXlCDG0kNc7nm8+ww=="],
+    "@polkadot-labs/hdkd": ["@polkadot-labs/hdkd@0.0.12", "", { "dependencies": { "@polkadot-labs/hdkd-helpers": "0.0.12" } }, "sha512-t+TB93E5Jo8a0bSsCg5vBpSUZJ+xY4fmP/rIF0lMGLEAkSxE0FXtwXeEzPjKeZmHs2jPo/hTEttBfwbMComqnQ=="],
 
-    "@polkadot-labs/hdkd-helpers": ["@polkadot-labs/hdkd-helpers@0.0.11", "", { "dependencies": { "@noble/curves": "^1.8.1", "@noble/hashes": "^1.7.1", "@scure/base": "^1.2.4", "micro-sr25519": "^0.1.0", "scale-ts": "^1.6.1" } }, "sha512-qPlWqC3NNV/2NYc5GEy+Ovi4UBAgkMGvMfyiYuj2BQN4lW59Q1T9coNx0Yp6XzsnJ1ddaF9PWaUtxj3LdM0IDw=="],
+    "@polkadot-labs/hdkd-helpers": ["@polkadot-labs/hdkd-helpers@0.0.12", "", { "dependencies": { "@noble/curves": "^1.8.1", "@noble/hashes": "^1.7.1", "@scure/base": "^1.2.4", "micro-sr25519": "^0.1.0", "scale-ts": "^1.6.1" } }, "sha512-29NMeW+EqNkaCszrOeNRWFEJK7uhGJ57v7KvSvBZ7wX88BoDQEq/lg9h5KN+Sn9rRJuxd6LOudqj/kWNx8+QEg=="],
 
-    "@polkadot/api": ["@polkadot/api@15.4.1", "", { "dependencies": { "@polkadot/api-augment": "15.4.1", "@polkadot/api-base": "15.4.1", "@polkadot/api-derive": "15.4.1", "@polkadot/keyring": "^13.3.1", "@polkadot/rpc-augment": "15.4.1", "@polkadot/rpc-core": "15.4.1", "@polkadot/rpc-provider": "15.4.1", "@polkadot/types": "15.4.1", "@polkadot/types-augment": "15.4.1", "@polkadot/types-codec": "15.4.1", "@polkadot/types-create": "15.4.1", "@polkadot/types-known": "15.4.1", "@polkadot/util": "^13.3.1", "@polkadot/util-crypto": "^13.3.1", "eventemitter3": "^5.0.1", "rxjs": "^7.8.1", "tslib": "^2.8.1" } }, "sha512-o+5WmEt38rs+Enk2XTE5Mn3Vne+gbolvca7nl+hB/VOr5cK+ZAwhMfEt/ZFXzdAQOA9ePO91FLRsS48mimZ8PA=="],
+    "@polkadot/api": ["@polkadot/api@15.7.1", "", { "dependencies": { "@polkadot/api-augment": "15.7.1", "@polkadot/api-base": "15.7.1", "@polkadot/api-derive": "15.7.1", "@polkadot/keyring": "^13.4.3", "@polkadot/rpc-augment": "15.7.1", "@polkadot/rpc-core": "15.7.1", "@polkadot/rpc-provider": "15.7.1", "@polkadot/types": "15.7.1", "@polkadot/types-augment": "15.7.1", "@polkadot/types-codec": "15.7.1", "@polkadot/types-create": "15.7.1", "@polkadot/types-known": "15.7.1", "@polkadot/util": "^13.4.3", "@polkadot/util-crypto": "^13.4.3", "eventemitter3": "^5.0.1", "rxjs": "^7.8.1", "tslib": "^2.8.1" } }, "sha512-jV4TWjxcC30FKEn16KBMI2+IPoLvOg1I6rCSKrKEmzAUql58/pd3Lm9tglLdL1Thhajee3iwJtU8DkFayYneUA=="],
 
-    "@polkadot/api-augment": ["@polkadot/api-augment@15.4.1", "", { "dependencies": { "@polkadot/api-base": "15.4.1", "@polkadot/rpc-augment": "15.4.1", "@polkadot/types": "15.4.1", "@polkadot/types-augment": "15.4.1", "@polkadot/types-codec": "15.4.1", "@polkadot/util": "^13.3.1", "tslib": "^2.8.1" } }, "sha512-mq/m5eC5hzxzsYfbYoLxdqRgH3/hf60DYoVN1f8P7m798cHXE/8DjCSwgtb5QDiWfp+CifaI5O/PcgL8YNj6jw=="],
+    "@polkadot/api-augment": ["@polkadot/api-augment@15.7.1", "", { "dependencies": { "@polkadot/api-base": "15.7.1", "@polkadot/rpc-augment": "15.7.1", "@polkadot/types": "15.7.1", "@polkadot/types-augment": "15.7.1", "@polkadot/types-codec": "15.7.1", "@polkadot/util": "^13.4.3", "tslib": "^2.8.1" } }, "sha512-xL/ydO6iqa7/+8z7e3rJbPpsjuv5OJ8j9FhWjhfYpnWLBkkPIOscemAWIcXTDRhQoPKVTKyQPb2495G+yGFBCQ=="],
 
-    "@polkadot/api-base": ["@polkadot/api-base@15.4.1", "", { "dependencies": { "@polkadot/rpc-core": "15.4.1", "@polkadot/types": "15.4.1", "@polkadot/util": "^13.3.1", "rxjs": "^7.8.1", "tslib": "^2.8.1" } }, "sha512-7a0wsLPpnEDLXhPmaLds03XchCnj7oP7MbdoULVKzIjYDq0MjYasigAz0Vs/QR6O5qodZWmgS2gA+VG+Ga5OMA=="],
+    "@polkadot/api-base": ["@polkadot/api-base@15.7.1", "", { "dependencies": { "@polkadot/rpc-core": "15.7.1", "@polkadot/types": "15.7.1", "@polkadot/util": "^13.4.3", "rxjs": "^7.8.1", "tslib": "^2.8.1" } }, "sha512-5i2RFziPnYj1shhoHlatEyB5vLDPbB9zK0pvJWN5V6lQsYJoiPQ6UpNiQ8JD98qcYRVuKTjlhx03mRQ3FLFgDg=="],
 
-    "@polkadot/api-derive": ["@polkadot/api-derive@15.4.1", "", { "dependencies": { "@polkadot/api": "15.4.1", "@polkadot/api-augment": "15.4.1", "@polkadot/api-base": "15.4.1", "@polkadot/rpc-core": "15.4.1", "@polkadot/types": "15.4.1", "@polkadot/types-codec": "15.4.1", "@polkadot/util": "^13.3.1", "@polkadot/util-crypto": "^13.3.1", "rxjs": "^7.8.1", "tslib": "^2.8.1" } }, "sha512-0EFrp0kNNpDWqtuSKbNe8+V1iEz1cXAiL+G7UM0oWae/U2xpbi0zdCMeC7hstUoJS//py1vPnDo0nkVfrdhT/A=="],
+    "@polkadot/api-derive": ["@polkadot/api-derive@15.7.1", "", { "dependencies": { "@polkadot/api": "15.7.1", "@polkadot/api-augment": "15.7.1", "@polkadot/api-base": "15.7.1", "@polkadot/rpc-core": "15.7.1", "@polkadot/types": "15.7.1", "@polkadot/types-codec": "15.7.1", "@polkadot/util": "^13.4.3", "@polkadot/util-crypto": "^13.4.3", "rxjs": "^7.8.1", "tslib": "^2.8.1" } }, "sha512-EY0ymkLFJ48PqDRh5Sm06iVhWZe5YdZEErFu6Qseq9U891PQ+g3UJo2kGXrH2JowXRUf/x8SzH/NU85JycTriA=="],
 
-    "@polkadot/keyring": ["@polkadot/keyring@13.3.1", "", { "dependencies": { "@polkadot/util": "13.3.1", "@polkadot/util-crypto": "13.3.1", "tslib": "^2.8.0" } }, "sha512-PT3uG9MqciPyoEz/f23RRMSlht77fo1hZaA1Vbcs1Rz7h7qFC0+7jFI9Ak30EJh9V0I2YugfzqAe3NjjyDxlvw=="],
+    "@polkadot/keyring": ["@polkadot/keyring@13.4.3", "", { "dependencies": { "@polkadot/util": "13.4.3", "@polkadot/util-crypto": "13.4.3", "tslib": "^2.8.0" } }, "sha512-2ePNcvBTznDN2luKbZM5fdxgAnj7V8m276qSTgrHlqKVvg9FsQpRCR6CAU+AjhnHzpe7uiZO+UH+jlXWefI3AA=="],
 
-    "@polkadot/networks": ["@polkadot/networks@13.3.1", "", { "dependencies": { "@polkadot/util": "13.3.1", "@substrate/ss58-registry": "^1.51.0", "tslib": "^2.8.0" } }, "sha512-g/0OmCMUrbbW4RQ/xajTYd2SMJvFKY4kmMvpxtNN57hWQpY7c5oDXSz57jGH2uwvcBWeDfaNokcS+9hJL1RBcA=="],
+    "@polkadot/networks": ["@polkadot/networks@13.4.3", "", { "dependencies": { "@polkadot/util": "13.4.3", "@substrate/ss58-registry": "^1.51.0", "tslib": "^2.8.0" } }, "sha512-Z+YZkltBt//CtkVH8ZYJ1z66qYxdI0yPamzkzZAqw6gj3gjgSxKtxB4baA/rcAw05QTvN2R3dLkkmKr2mnHovQ=="],
 
-    "@polkadot/rpc-augment": ["@polkadot/rpc-augment@15.4.1", "", { "dependencies": { "@polkadot/rpc-core": "15.4.1", "@polkadot/types": "15.4.1", "@polkadot/types-codec": "15.4.1", "@polkadot/util": "^13.3.1", "tslib": "^2.8.1" } }, "sha512-DiNSSK+UFkAnF0UtVWr6HSCDio74LWjVjLsh9csAKfqy8bXzTVshl8VjZR2G9nuW9YxoJjQREN8wEcM9F+kL3Q=="],
+    "@polkadot/rpc-augment": ["@polkadot/rpc-augment@15.7.1", "", { "dependencies": { "@polkadot/rpc-core": "15.7.1", "@polkadot/types": "15.7.1", "@polkadot/types-codec": "15.7.1", "@polkadot/util": "^13.4.3", "tslib": "^2.8.1" } }, "sha512-6kkD9nLgbC40ZSOYFipU0/CaCyiHr/JCNJNzdLzE1bM4Z/7N4TpywMqlCls/dFFLw1sS9SsgR7SWsLCriGQHKQ=="],
 
-    "@polkadot/rpc-core": ["@polkadot/rpc-core@15.4.1", "", { "dependencies": { "@polkadot/rpc-augment": "15.4.1", "@polkadot/rpc-provider": "15.4.1", "@polkadot/types": "15.4.1", "@polkadot/util": "^13.3.1", "rxjs": "^7.8.1", "tslib": "^2.8.1" } }, "sha512-llAtGpKQgtmsy5+320T0Dr8Lxse77eN0NVbpWr7cQo8R5If8YM9cAMNETMtrY1S9596aaLX/GrThp5Zvt6Z5Aw=="],
+    "@polkadot/rpc-core": ["@polkadot/rpc-core@15.7.1", "", { "dependencies": { "@polkadot/rpc-augment": "15.7.1", "@polkadot/rpc-provider": "15.7.1", "@polkadot/types": "15.7.1", "@polkadot/util": "^13.4.3", "rxjs": "^7.8.1", "tslib": "^2.8.1" } }, "sha512-/sIHhUvLf29ZiLWPCyhMMaXs5vfKLIrfB/OPOGYy2dR8yKEnBuKbN6Ae54N+mLHGKksi2jNXWhX3Kuu4CbXoeQ=="],
 
-    "@polkadot/rpc-provider": ["@polkadot/rpc-provider@15.4.1", "", { "dependencies": { "@polkadot/keyring": "^13.3.1", "@polkadot/types": "15.4.1", "@polkadot/types-support": "15.4.1", "@polkadot/util": "^13.3.1", "@polkadot/util-crypto": "^13.3.1", "@polkadot/x-fetch": "^13.3.1", "@polkadot/x-global": "^13.3.1", "@polkadot/x-ws": "^13.3.1", "eventemitter3": "^5.0.1", "mock-socket": "^9.3.1", "nock": "^13.5.5", "tslib": "^2.8.1" }, "optionalDependencies": { "@substrate/connect": "0.8.11" } }, "sha512-GOtU8fBczbpEa3U4nQxBvwCtYyP1fYbi6vWBnA/YiwQY6RWqMBY2Tfo9fw0MfYqZVpYvbUoaER4akTrtVvCoVA=="],
+    "@polkadot/rpc-provider": ["@polkadot/rpc-provider@15.7.1", "", { "dependencies": { "@polkadot/keyring": "^13.4.3", "@polkadot/types": "15.7.1", "@polkadot/types-support": "15.7.1", "@polkadot/util": "^13.4.3", "@polkadot/util-crypto": "^13.4.3", "@polkadot/x-fetch": "^13.4.3", "@polkadot/x-global": "^13.4.3", "@polkadot/x-ws": "^13.4.3", "eventemitter3": "^5.0.1", "mock-socket": "^9.3.1", "nock": "^13.5.5", "tslib": "^2.8.1" }, "optionalDependencies": { "@substrate/connect": "0.8.11" } }, "sha512-DLRjOdsJ16RjFR5aTKOvlLhcmFeo3WGC/lJDYZ9J+oTeY4dFJLEF/ERKRWsv9YnYNsOSMkCHq23F7NvCYAjXAg=="],
 
-    "@polkadot/types": ["@polkadot/types@15.4.1", "", { "dependencies": { "@polkadot/keyring": "^13.3.1", "@polkadot/types-augment": "15.4.1", "@polkadot/types-codec": "15.4.1", "@polkadot/types-create": "15.4.1", "@polkadot/util": "^13.3.1", "@polkadot/util-crypto": "^13.3.1", "rxjs": "^7.8.1", "tslib": "^2.8.1" } }, "sha512-5Oh6iwdtXg9/CN55c2IzNx90/ALK1DlP/OswN9vERp6rqZttAEGTQgSiYFHP0+7WhDB8H6v8jVutHadqv7lhMg=="],
+    "@polkadot/types": ["@polkadot/types@15.7.1", "", { "dependencies": { "@polkadot/keyring": "^13.4.3", "@polkadot/types-augment": "15.7.1", "@polkadot/types-codec": "15.7.1", "@polkadot/types-create": "15.7.1", "@polkadot/util": "^13.4.3", "@polkadot/util-crypto": "^13.4.3", "rxjs": "^7.8.1", "tslib": "^2.8.1" } }, "sha512-E4qksl/D+sMpEIH2WDwjC6hDRBu7IBW+tK99QTxZ28F087Xkpjc8W38lzr/bZhodoJQ+lsLQkPh+XpbcaIbelA=="],
 
-    "@polkadot/types-augment": ["@polkadot/types-augment@15.4.1", "", { "dependencies": { "@polkadot/types": "15.4.1", "@polkadot/types-codec": "15.4.1", "@polkadot/util": "^13.3.1", "tslib": "^2.8.1" } }, "sha512-40X4UVEHmJhNV+gYS79RY38rv3shFEGd9H8xTas91IgZtT12mRw1kH5vjLHk+nYTVAAR1ml3D3IStILAwzikgQ=="],
+    "@polkadot/types-augment": ["@polkadot/types-augment@15.7.1", "", { "dependencies": { "@polkadot/types": "15.7.1", "@polkadot/types-codec": "15.7.1", "@polkadot/util": "^13.4.3", "tslib": "^2.8.1" } }, "sha512-rLQ8nvsLp4XyiTGQigens4JDP5PPFyzlYMdAGMqYsH+K/6TdqStgXciFeUGe2jeir49aCgBgXqQV+/5kNSK2Wg=="],
 
-    "@polkadot/types-codec": ["@polkadot/types-codec@15.4.1", "", { "dependencies": { "@polkadot/util": "^13.3.1", "@polkadot/x-bigint": "^13.3.1", "tslib": "^2.8.1" } }, "sha512-LksB8JBdu8ysYWsRbE1U+cv8svUpSddalR6mg0pP0H/ngj58PWrRUWJBRw2LDw65B4Dw1AIJ0QrbigmCjCyz+A=="],
+    "@polkadot/types-codec": ["@polkadot/types-codec@15.7.1", "", { "dependencies": { "@polkadot/util": "^13.4.3", "@polkadot/x-bigint": "^13.4.3", "tslib": "^2.8.1" } }, "sha512-QxYNDo1SH6VqF5Atcciu1r7MbKQIr8jDIZ0jYtOkrzsw3BvynlI59+3icTRrrK4Uk79D8PD0QWo4r+krJ0VMmQ=="],
 
-    "@polkadot/types-create": ["@polkadot/types-create@15.4.1", "", { "dependencies": { "@polkadot/types-codec": "15.4.1", "@polkadot/util": "^13.3.1", "tslib": "^2.8.1" } }, "sha512-NP1YGsLdGii0FNAKeKHNxpvLZCusEugs+g21vHHmdtFLC08ngU7pNJGERteo6vDNr5JDejzVbB+i94Y9RzKC0Q=="],
+    "@polkadot/types-create": ["@polkadot/types-create@15.7.1", "", { "dependencies": { "@polkadot/types-codec": "15.7.1", "@polkadot/util": "^13.4.3", "tslib": "^2.8.1" } }, "sha512-baEU+H+GnHOnNAL5hu09lr2m1bK2HiGvrOZq8txLsNpy67uxI04YzzSkckxWdORyix6Yo55rWW0QfaDlSoiP7g=="],
 
-    "@polkadot/types-known": ["@polkadot/types-known@15.4.1", "", { "dependencies": { "@polkadot/networks": "^13.3.1", "@polkadot/types": "15.4.1", "@polkadot/types-codec": "15.4.1", "@polkadot/types-create": "15.4.1", "@polkadot/util": "^13.3.1", "tslib": "^2.8.1" } }, "sha512-LF9estF7y7sXHQ7tA9QoVzAmtkglJdcqMbj70H70V+CBZjiyAgd84PvBtQ6mcIywJ54iCyBBLbhlqcbH/zgUdw=="],
+    "@polkadot/types-known": ["@polkadot/types-known@15.7.1", "", { "dependencies": { "@polkadot/networks": "^13.4.3", "@polkadot/types": "15.7.1", "@polkadot/types-codec": "15.7.1", "@polkadot/types-create": "15.7.1", "@polkadot/util": "^13.4.3", "tslib": "^2.8.1" } }, "sha512-G56TRuaxd7rA1eTFMJyoyYkqFmGZsFwrnviIK9HsSuE2uzaV6vrOfit6eIIg+YQGIyWoshRJCDiLizjzwZhdGQ=="],
 
-    "@polkadot/types-support": ["@polkadot/types-support@15.4.1", "", { "dependencies": { "@polkadot/util": "^13.3.1", "tslib": "^2.8.1" } }, "sha512-BeMi+780cP0jb4HTwovjcNt/Yf/lgKkXGlfu/gZhLb6eu7Sz3VzAxI8z2WdMWE/NiXMEHeC0YpwOowhRS2tEVA=="],
+    "@polkadot/types-support": ["@polkadot/types-support@15.7.1", "", { "dependencies": { "@polkadot/util": "^13.4.3", "tslib": "^2.8.1" } }, "sha512-uM/DyU48PU+ok4yFeSIhTtdKY46zAYY0cuaK0iBbW4/oIRBdSJQ6U3CnU9iMVNCN5kKJdIR3K7V2uoZGl6GXvw=="],
 
-    "@polkadot/util": ["@polkadot/util@13.3.1", "", { "dependencies": { "@polkadot/x-bigint": "13.3.1", "@polkadot/x-global": "13.3.1", "@polkadot/x-textdecoder": "13.3.1", "@polkadot/x-textencoder": "13.3.1", "@types/bn.js": "^5.1.6", "bn.js": "^5.2.1", "tslib": "^2.8.0" } }, "sha512-5crLP/rUZOJzuo/W8t73J8PxpibJ5vrxY57rR6V+mIpCZd1ORiw0wxeHcV5F9Adpn7yJyuGBwxPbueNR5Rr1Zw=="],
+    "@polkadot/util": ["@polkadot/util@13.4.3", "", { "dependencies": { "@polkadot/x-bigint": "13.4.3", "@polkadot/x-global": "13.4.3", "@polkadot/x-textdecoder": "13.4.3", "@polkadot/x-textencoder": "13.4.3", "@types/bn.js": "^5.1.6", "bn.js": "^5.2.1", "tslib": "^2.8.0" } }, "sha512-6v2zvg8l7W22XvjYf7qv9tPQdYl2E6aXY94M4TZKsXZxmlS5BoG+A9Aq0+Gw8zBUjupjEmUkA6Y//msO8Zisug=="],
 
-    "@polkadot/util-crypto": ["@polkadot/util-crypto@13.3.1", "", { "dependencies": { "@noble/curves": "^1.3.0", "@noble/hashes": "^1.3.3", "@polkadot/networks": "13.3.1", "@polkadot/util": "13.3.1", "@polkadot/wasm-crypto": "^7.4.1", "@polkadot/wasm-util": "^7.4.1", "@polkadot/x-bigint": "13.3.1", "@polkadot/x-randomvalues": "13.3.1", "@scure/base": "^1.1.7", "tslib": "^2.8.0" } }, "sha512-FU6yf3IY++DKlf0eqO9/obe2y1zuZ5rbqRs75fyOME/5VXio1fA3GIpW7aFphyneFRd78G8QLh8kn0oIwBGMNg=="],
+    "@polkadot/util-crypto": ["@polkadot/util-crypto@13.4.3", "", { "dependencies": { "@noble/curves": "^1.3.0", "@noble/hashes": "^1.3.3", "@polkadot/networks": "13.4.3", "@polkadot/util": "13.4.3", "@polkadot/wasm-crypto": "^7.4.1", "@polkadot/wasm-util": "^7.4.1", "@polkadot/x-bigint": "13.4.3", "@polkadot/x-randomvalues": "13.4.3", "@scure/base": "^1.1.7", "tslib": "^2.8.0" } }, "sha512-Ml0mjhKVetMrRCIosmVNMa6lbFPa3fSAeOggf34NsDIIQOKt9FL644iGz1ZSMOnBwN9qk2qHYmcFMTDXX2yKVQ=="],
 
     "@polkadot/wasm-bridge": ["@polkadot/wasm-bridge@7.4.1", "", { "dependencies": { "@polkadot/wasm-util": "7.4.1", "tslib": "^2.7.0" }, "peerDependencies": { "@polkadot/util": "*", "@polkadot/x-randomvalues": "*" } }, "sha512-tdkJaV453tezBxhF39r4oeG0A39sPKGDJmN81LYLf+Fihb7astzwju+u75BRmDrHZjZIv00un3razJEWCxze6g=="],
 
@@ -227,57 +227,57 @@
 
     "@polkadot/wasm-util": ["@polkadot/wasm-util@7.4.1", "", { "dependencies": { "tslib": "^2.7.0" }, "peerDependencies": { "@polkadot/util": "*" } }, "sha512-RAcxNFf3zzpkr+LX/ItAsvj+QyM56TomJ0xjUMo4wKkHjwsxkz4dWJtx5knIgQz/OthqSDMR59VNEycQeNuXzA=="],
 
-    "@polkadot/x-bigint": ["@polkadot/x-bigint@13.3.1", "", { "dependencies": { "@polkadot/x-global": "13.3.1", "tslib": "^2.8.0" } }, "sha512-ewc708a7LUdrT92v9DsSAIbcJQBn3aR9/LavF/iyMOq5lZJyPXDSjAnskfMs818R3RLCrKVKfs+aKkxt2eqo8g=="],
+    "@polkadot/x-bigint": ["@polkadot/x-bigint@13.4.3", "", { "dependencies": { "@polkadot/x-global": "13.4.3", "tslib": "^2.8.0" } }, "sha512-8NbjF5Q+5lflhvDFve58wULjCVcvXa932LKFtI5zL2gx5VDhMgyfkNcYRjHB18Ecl21963JuGzvGVTZNkh/i6g=="],
 
-    "@polkadot/x-fetch": ["@polkadot/x-fetch@13.3.1", "", { "dependencies": { "@polkadot/x-global": "13.3.1", "node-fetch": "^3.3.2", "tslib": "^2.8.0" } }, "sha512-J+HM42j0KGqdC/eo7vmsdLPz74MR7+0My4km6TG9HGjKqqztwygtenpopPod2SbRnL4nHiEG0wZzpVOW6HN2gw=="],
+    "@polkadot/x-fetch": ["@polkadot/x-fetch@13.4.3", "", { "dependencies": { "@polkadot/x-global": "13.4.3", "node-fetch": "^3.3.2", "tslib": "^2.8.0" } }, "sha512-EwhcwROqWa7mvNTbLVNH71Hbyp5PW5j9lV2UpII5MZzRO95eYwV4oP/xgtTxC+60nC8lrvzAw0JxEHrmNzmtlg=="],
 
-    "@polkadot/x-global": ["@polkadot/x-global@13.3.1", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-861TeIw49a3JvkwlUWrddfG+JaUqtFZDsemYxxZIjjcRJLrKOsoKNqHbiHi2OPrwlX8PwAA/wc5I9Q4XRQ7KEg=="],
+    "@polkadot/x-global": ["@polkadot/x-global@13.4.3", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-6c98kxZdoGRct3ua9Dz6/qz8wb3XFRUkaY+4+RzIgehKMPhu19pGWTrzmbJSyY9FtIpThuWKuDaBEvd5KgSxjA=="],
 
-    "@polkadot/x-randomvalues": ["@polkadot/x-randomvalues@13.3.1", "", { "dependencies": { "@polkadot/x-global": "13.3.1", "tslib": "^2.8.0" }, "peerDependencies": { "@polkadot/util": "13.3.1", "@polkadot/wasm-util": "*" } }, "sha512-GIb0au3vIX2U/DRH0PRckM+1I4EIbU8PLX1roGJgN1MAYKWiylJTKPVoBMafMM87o8qauOevJ46uYB/qlfbiWg=="],
+    "@polkadot/x-randomvalues": ["@polkadot/x-randomvalues@13.4.3", "", { "dependencies": { "@polkadot/x-global": "13.4.3", "tslib": "^2.8.0" }, "peerDependencies": { "@polkadot/util": "13.4.3", "@polkadot/wasm-util": "*" } }, "sha512-pskXP/S2jROZ6aASExsUFlNp7GbJvQikKogvyvMMCzNIbUYLxpLuquLRa3MOORx2c0SNsENg90cx/zHT+IjPRQ=="],
 
-    "@polkadot/x-textdecoder": ["@polkadot/x-textdecoder@13.3.1", "", { "dependencies": { "@polkadot/x-global": "13.3.1", "tslib": "^2.8.0" } }, "sha512-g2R9O1p0ZsNDhZ3uEBZh6fQaVLlo3yFr0YNqt15v7e9lBI4APvTJ202EINlo2jB5lz/R438/BdjEA3AL+0zUtQ=="],
+    "@polkadot/x-textdecoder": ["@polkadot/x-textdecoder@13.4.3", "", { "dependencies": { "@polkadot/x-global": "13.4.3", "tslib": "^2.8.0" } }, "sha512-k7Wg6csAPxfNtpBt3k5yUuPHYmRl/nl7H2OMr40upMjbZXbQ1RJW9Z3GBkLmQczG7NwwfAXHwQE9FYOMUtbuRQ=="],
 
-    "@polkadot/x-textencoder": ["@polkadot/x-textencoder@13.3.1", "", { "dependencies": { "@polkadot/x-global": "13.3.1", "tslib": "^2.8.0" } }, "sha512-DnHLUdoKDYxekfxopuUuPB+j5Mu7Jemejcduu5gz3/89GP/sYPAu0CAVbq9B+hK1yGjBBj31eA4wkAV1oktYmg=="],
+    "@polkadot/x-textencoder": ["@polkadot/x-textencoder@13.4.3", "", { "dependencies": { "@polkadot/x-global": "13.4.3", "tslib": "^2.8.0" } }, "sha512-byl2LbN1rnEXKmnsCzEDaIjSIHAr+1ciSe2yj3M0K+oWEEcaFZEovJaf/uoyzkcjn+/l8rDv3nget6mPuQ/DSw=="],
 
-    "@polkadot/x-ws": ["@polkadot/x-ws@13.3.1", "", { "dependencies": { "@polkadot/x-global": "13.3.1", "tslib": "^2.8.0", "ws": "^8.18.0" } }, "sha512-ytqkC7FwVs4BlzNFAmPMFp+xD1KIdMMP/mvCSOrnxjlsyM5DVGop4x4c2ZgDUBmrFqmIiVkWDfMIZeOxui2OLQ=="],
+    "@polkadot/x-ws": ["@polkadot/x-ws@13.4.3", "", { "dependencies": { "@polkadot/x-global": "13.4.3", "tslib": "^2.8.0", "ws": "^8.18.0" } }, "sha512-GS0I6MYLD/xNAAjODZi/pbG7Ba0e/5sbvDIrT01iKH3SPGN+PZoyAsc04t2IOXA6QmPa1OBHnaU3N4K8gGmJ+w=="],
 
-    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.31.0", "", { "os": "android", "cpu": "arm" }, "sha512-9NrR4033uCbUBRgvLcBrJofa2KY9DzxL2UKZ1/4xA/mnTNyhZCWBuD8X3tPm1n4KxcgaraOYgrFKSgwjASfmlA=="],
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.34.9", "", { "os": "android", "cpu": "arm" }, "sha512-qZdlImWXur0CFakn2BJ2znJOdqYZKiedEPEVNTBrpfPjc/YuTGcaYZcdmNFTkUj3DU0ZM/AElcM8Ybww3xVLzA=="],
 
-    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.31.0", "", { "os": "android", "cpu": "arm64" }, "sha512-iBbODqT86YBFHajxxF8ebj2hwKm1k8PTBQSojSt3d1FFt1gN+xf4CowE47iN0vOSdnd+5ierMHBbu/rHc7nq5g=="],
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.34.9", "", { "os": "android", "cpu": "arm64" }, "sha512-4KW7P53h6HtJf5Y608T1ISKvNIYLWRKMvfnG0c44M6In4DQVU58HZFEVhWINDZKp7FZps98G3gxwC1sb0wXUUg=="],
 
-    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.31.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-WHIZfXgVBX30SWuTMhlHPXTyN20AXrLH4TEeH/D0Bolvx9PjgZnn4H677PlSGvU6MKNsjCQJYczkpvBbrBnG6g=="],
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.34.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0CY3/K54slrzLDjOA7TOjN1NuLKERBgk9nY5V34mhmuu673YNb+7ghaDUs6N0ujXR7fz5XaS5Aa6d2TNxZd0OQ=="],
 
-    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.31.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-hrWL7uQacTEF8gdrQAqcDy9xllQ0w0zuL1wk1HV8wKGSGbKPVjVUv/DEwT2+Asabf8Dh/As+IvfdU+H8hhzrQQ=="],
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.34.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-eOojSEAi/acnsJVYRxnMkPFqcxSMFfrw7r2iD9Q32SGkb/Q9FpUY1UlAu1DH9T7j++gZ0lHjnm4OyH2vCI7l7Q=="],
 
-    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.31.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-S2oCsZ4hJviG1QjPY1h6sVJLBI6ekBeAEssYKad1soRFv3SocsQCzX6cwnk6fID6UQQACTjeIMB+hyYrFacRew=="],
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.34.9", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-2lzjQPJbN5UnHm7bHIUKFMulGTQwdvOkouJDpPysJS+QFBGDJqcfh+CxxtG23Ik/9tEvnebQiylYoazFMAgrYw=="],
 
-    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.31.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-pCANqpynRS4Jirn4IKZH4tnm2+2CqCNLKD7gAdEjzdLGbH1iO0zouHz4mxqg0uEMpO030ejJ0aA6e1PJo2xrPA=="],
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.34.9", "", { "os": "freebsd", "cpu": "x64" }, "sha512-SLl0hi2Ah2H7xQYd6Qaiu01kFPzQ+hqvdYSoOtHYg/zCIFs6t8sV95kaoqjzjFwuYQLtOI0RZre/Ke0nPaQV+g=="],
 
-    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.31.0", "", { "os": "linux", "cpu": "arm" }, "sha512-0O8ViX+QcBd3ZmGlcFTnYXZKGbFu09EhgD27tgTdGnkcYXLat4KIsBBQeKLR2xZDCXdIBAlWLkiXE1+rJpCxFw=="],
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.34.9", "", { "os": "linux", "cpu": "arm" }, "sha512-88I+D3TeKItrw+Y/2ud4Tw0+3CxQ2kLgu3QvrogZ0OfkmX/DEppehus7L3TS2Q4lpB+hYyxhkQiYPJ6Mf5/dPg=="],
 
-    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.31.0", "", { "os": "linux", "cpu": "arm" }, "sha512-w5IzG0wTVv7B0/SwDnMYmbr2uERQp999q8FMkKG1I+j8hpPX2BYFjWe69xbhbP6J9h2gId/7ogesl9hwblFwwg=="],
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.34.9", "", { "os": "linux", "cpu": "arm" }, "sha512-3qyfWljSFHi9zH0KgtEPG4cBXHDFhwD8kwg6xLfHQ0IWuH9crp005GfoUUh/6w9/FWGBwEHg3lxK1iHRN1MFlA=="],
 
-    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.31.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-JyFFshbN5xwy6fulZ8B/8qOqENRmDdEkcIMF0Zz+RsfamEW+Zabl5jAb0IozP/8UKnJ7g2FtZZPEUIAlUSX8cA=="],
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.34.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-6TZjPHjKZUQKmVKMUowF3ewHxctrRR09eYyvT5eFv8w/fXarEra83A2mHTVJLA5xU91aCNOUnM+DWFMSbQ0Nxw=="],
 
-    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.31.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-kpQXQ0UPFeMPmPYksiBL9WS/BDiQEjRGMfklVIsA0Sng347H8W2iexch+IEwaR7OVSKtr2ZFxggt11zVIlZ25g=="],
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.34.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-LD2fytxZJZ6xzOKnMbIpgzFOuIKlxVOpiMAXawsAZ2mHBPEYOnLRK5TTEsID6z4eM23DuO88X0Tq1mErHMVq0A=="],
 
-    "@rollup/rollup-linux-loongarch64-gnu": ["@rollup/rollup-linux-loongarch64-gnu@4.31.0", "", { "os": "linux", "cpu": "none" }, "sha512-pMlxLjt60iQTzt9iBb3jZphFIl55a70wexvo8p+vVFK+7ifTRookdoXX3bOsRdmfD+OKnMozKO6XM4zR0sHRrQ=="],
+    "@rollup/rollup-linux-loongarch64-gnu": ["@rollup/rollup-linux-loongarch64-gnu@4.34.9", "", { "os": "linux", "cpu": "none" }, "sha512-dRAgTfDsn0TE0HI6cmo13hemKpVHOEyeciGtvlBTkpx/F65kTvShtY/EVyZEIfxFkV5JJTuQ9tP5HGBS0hfxIg=="],
 
-    "@rollup/rollup-linux-powerpc64le-gnu": ["@rollup/rollup-linux-powerpc64le-gnu@4.31.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-D7TXT7I/uKEuWiRkEFbed1UUYZwcJDU4vZQdPTcepK7ecPhzKOYk4Er2YR4uHKme4qDeIh6N3XrLfpuM7vzRWQ=="],
+    "@rollup/rollup-linux-powerpc64le-gnu": ["@rollup/rollup-linux-powerpc64le-gnu@4.34.9", "", { "os": "linux", "cpu": "ppc64" }, "sha512-PHcNOAEhkoMSQtMf+rJofwisZqaU8iQ8EaSps58f5HYll9EAY5BSErCZ8qBDMVbq88h4UxaNPlbrKqfWP8RfJA=="],
 
-    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.31.0", "", { "os": "linux", "cpu": "none" }, "sha512-wal2Tc8O5lMBtoePLBYRKj2CImUCJ4UNGJlLwspx7QApYny7K1cUYlzQ/4IGQBLmm+y0RS7dwc3TDO/pmcneTw=="],
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.34.9", "", { "os": "linux", "cpu": "none" }, "sha512-Z2i0Uy5G96KBYKjeQFKbbsB54xFOL5/y1P5wNBsbXB8yE+At3oh0DVMjQVzCJRJSfReiB2tX8T6HUFZ2k8iaKg=="],
 
-    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.31.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-O1o5EUI0+RRMkK9wiTVpk2tyzXdXefHtRTIjBbmFREmNMy7pFeYXCFGbhKFwISA3UOExlo5GGUuuj3oMKdK6JQ=="],
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.34.9", "", { "os": "linux", "cpu": "s390x" }, "sha512-U+5SwTMoeYXoDzJX5dhDTxRltSrIax8KWwfaaYcynuJw8mT33W7oOgz0a+AaXtGuvhzTr2tVKh5UO8GVANTxyQ=="],
 
-    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.31.0", "", { "os": "linux", "cpu": "x64" }, "sha512-zSoHl356vKnNxwOWnLd60ixHNPRBglxpv2g7q0Cd3Pmr561gf0HiAcUBRL3S1vPqRC17Zo2CX/9cPkqTIiai1g=="],
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.34.9", "", { "os": "linux", "cpu": "x64" }, "sha512-FwBHNSOjUTQLP4MG7y6rR6qbGw4MFeQnIBrMe161QGaQoBQLqSUEKlHIiVgF3g/mb3lxlxzJOpIBhaP+C+KP2A=="],
 
-    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.31.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ypB/HMtcSGhKUQNiFwqgdclWNRrAYDH8iMYH4etw/ZlGwiTVxBz2tDrGRrPlfZu6QjXwtd+C3Zib5pFqID97ZA=="],
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.34.9", "", { "os": "linux", "cpu": "x64" }, "sha512-cYRpV4650z2I3/s6+5/LONkjIz8MBeqrk+vPXV10ORBnshpn8S32bPqQ2Utv39jCiDcO2eJTuSlPXpnvmaIgRA=="],
 
-    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.31.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-JuhN2xdI/m8Hr+aVO3vspO7OQfUFO6bKLIRTAy0U15vmWjnZDLrEgCZ2s6+scAYaQVpYSh9tZtRijApw9IXyMw=="],
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.34.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-z4mQK9dAN6byRA/vsSgQiPeuO63wdiDxZ9yg9iyX2QTzKuQM7T4xlBoeUP/J8uiFkqxkcWndWi+W7bXdPbt27Q=="],
 
-    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.31.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-U1xZZXYkvdf5MIWmftU8wrM5PPXzyaY1nGCI4KI4BFfoZxHamsIe+BtnPLIvvPykvQWlVbqUXdLa4aJUuilwLQ=="],
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.34.9", "", { "os": "win32", "cpu": "ia32" }, "sha512-KB48mPtaoHy1AwDNkAJfHXvHp24H0ryZog28spEs0V48l3H1fr4i37tiyHsgKZJnCmvxsbATdZGBpbmxTE3a9w=="],
 
-    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.31.0", "", { "os": "win32", "cpu": "x64" }, "sha512-ul8rnCsUumNln5YWwz0ted2ZHFhzhRRnkpBZ+YRuHoRAlUji9KChpOUOndY7uykrPEPXVbHLlsdo6v5yXo/TXw=="],
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.34.9", "", { "os": "win32", "cpu": "x64" }, "sha512-AyleYRPU7+rgkMWbEh71fQlrzRfeP6SyMnRf9XX4fCdDPAJumdSBqYEcWPMzVQ4ScAl7E4oFfK0GUVn77xSwbw=="],
 
     "@rx-state/core": ["@rx-state/core@0.1.4", "", { "peerDependencies": { "rxjs": ">=7" } }, "sha512-Z+3hjU2xh1HisLxt+W5hlYX/eGSDaXXP+ns82gq/PLZpkXLu0uwcNUh9RLY3Clq4zT+hSsA3vcpIGt6+UAb8rQ=="],
 
@@ -339,7 +339,7 @@
 
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
-    "axios": ["axios@1.7.9", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.0", "proxy-from-env": "^1.1.0" } }, "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw=="],
+    "axios": ["axios@1.8.1", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.0", "proxy-from-env": "^1.1.0" } }, "sha512-NN+fvwH/kV01dYUQ3PTOZns4LWtWhOFCAhQ/pHb88WQ1hNe5V/dvFwc4VJcDL11LT9xSX0QtsR8sWUuyOuOq7g=="],
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
@@ -455,7 +455,7 @@
 
     "es6-error": ["es6-error@4.1.1", "", {}, "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="],
 
-    "esbuild": ["esbuild@0.24.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.24.2", "@esbuild/android-arm": "0.24.2", "@esbuild/android-arm64": "0.24.2", "@esbuild/android-x64": "0.24.2", "@esbuild/darwin-arm64": "0.24.2", "@esbuild/darwin-x64": "0.24.2", "@esbuild/freebsd-arm64": "0.24.2", "@esbuild/freebsd-x64": "0.24.2", "@esbuild/linux-arm": "0.24.2", "@esbuild/linux-arm64": "0.24.2", "@esbuild/linux-ia32": "0.24.2", "@esbuild/linux-loong64": "0.24.2", "@esbuild/linux-mips64el": "0.24.2", "@esbuild/linux-ppc64": "0.24.2", "@esbuild/linux-riscv64": "0.24.2", "@esbuild/linux-s390x": "0.24.2", "@esbuild/linux-x64": "0.24.2", "@esbuild/netbsd-arm64": "0.24.2", "@esbuild/netbsd-x64": "0.24.2", "@esbuild/openbsd-arm64": "0.24.2", "@esbuild/openbsd-x64": "0.24.2", "@esbuild/sunos-x64": "0.24.2", "@esbuild/win32-arm64": "0.24.2", "@esbuild/win32-ia32": "0.24.2", "@esbuild/win32-x64": "0.24.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA=="],
+    "esbuild": ["esbuild@0.25.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.0", "@esbuild/android-arm": "0.25.0", "@esbuild/android-arm64": "0.25.0", "@esbuild/android-x64": "0.25.0", "@esbuild/darwin-arm64": "0.25.0", "@esbuild/darwin-x64": "0.25.0", "@esbuild/freebsd-arm64": "0.25.0", "@esbuild/freebsd-x64": "0.25.0", "@esbuild/linux-arm": "0.25.0", "@esbuild/linux-arm64": "0.25.0", "@esbuild/linux-ia32": "0.25.0", "@esbuild/linux-loong64": "0.25.0", "@esbuild/linux-mips64el": "0.25.0", "@esbuild/linux-ppc64": "0.25.0", "@esbuild/linux-riscv64": "0.25.0", "@esbuild/linux-s390x": "0.25.0", "@esbuild/linux-x64": "0.25.0", "@esbuild/netbsd-arm64": "0.25.0", "@esbuild/netbsd-x64": "0.25.0", "@esbuild/openbsd-arm64": "0.25.0", "@esbuild/openbsd-x64": "0.25.0", "@esbuild/sunos-x64": "0.25.0", "@esbuild/win32-arm64": "0.25.0", "@esbuild/win32-ia32": "0.25.0", "@esbuild/win32-x64": "0.25.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -543,7 +543,7 @@
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
-    "idb": ["idb@8.0.1", "", {}, "sha512-EkBCzUZSdhJV8PxMSbeEV//xguVKZu9hZZulM+2gHXI0t2hGVU3eYE6/XnH77DS6FM2FY8wl17aDcu9vXpvLWQ=="],
+    "idb": ["idb@8.0.2", "", {}, "sha512-CX70rYhx7GDDQzwwQMDwF6kDRQi5vVs6khHUumDrMecBylKkwvZ8HWvKV08AGb7VbpoGCWUQ4aHzNDgoUiOIUg=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
@@ -715,7 +715,7 @@
 
     "pirates": ["pirates@4.0.6", "", {}, "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg=="],
 
-    "polkadot-api": ["polkadot-api@1.9.0", "", { "dependencies": { "@polkadot-api/cli": "0.11.0", "@polkadot-api/ink-contracts": "0.2.5", "@polkadot-api/json-rpc-provider": "0.0.4", "@polkadot-api/known-chains": "0.7.0", "@polkadot-api/logs-provider": "0.0.6", "@polkadot-api/metadata-builders": "0.10.1", "@polkadot-api/metadata-compatibility": "0.1.15", "@polkadot-api/observable-client": "0.8.0", "@polkadot-api/pjs-signer": "0.6.4", "@polkadot-api/polkadot-sdk-compat": "2.3.1", "@polkadot-api/polkadot-signer": "0.1.6", "@polkadot-api/signer": "0.1.14", "@polkadot-api/sm-provider": "0.1.7", "@polkadot-api/smoldot": "0.3.8", "@polkadot-api/substrate-bindings": "0.11.0", "@polkadot-api/substrate-client": "0.3.0", "@polkadot-api/utils": "0.1.2", "@polkadot-api/ws-provider": "0.3.6", "@rx-state/core": "^0.1.4" }, "peerDependencies": { "rxjs": ">=7.8.0" }, "bin": { "papi": "bin/cli.mjs", "polkadot-api": "bin/cli.mjs" } }, "sha512-k454jsoJfDdr69ua9aYQ9EA9DpZ8nqarwLEmJiG1DFm9zy7uhkrJUk3QnDInkPtgQMNU0JC+MyGoTlFUMXMxlA=="],
+    "polkadot-api": ["polkadot-api@1.9.3", "", { "dependencies": { "@polkadot-api/cli": "0.11.1", "@polkadot-api/ink-contracts": "0.2.5", "@polkadot-api/json-rpc-provider": "0.0.4", "@polkadot-api/known-chains": "0.7.1", "@polkadot-api/logs-provider": "0.0.6", "@polkadot-api/metadata-builders": "0.10.1", "@polkadot-api/metadata-compatibility": "0.1.15", "@polkadot-api/observable-client": "0.8.1", "@polkadot-api/pjs-signer": "0.6.4", "@polkadot-api/polkadot-sdk-compat": "2.3.2", "@polkadot-api/polkadot-signer": "0.1.6", "@polkadot-api/signer": "0.1.14", "@polkadot-api/sm-provider": "0.1.7", "@polkadot-api/smoldot": "0.3.8", "@polkadot-api/substrate-bindings": "0.11.0", "@polkadot-api/substrate-client": "0.3.0", "@polkadot-api/utils": "0.1.2", "@polkadot-api/ws-provider": "0.4.0", "@rx-state/core": "^0.1.4" }, "peerDependencies": { "rxjs": ">=7.8.0" }, "bin": { "papi": "bin/cli.mjs", "polkadot-api": "bin/cli.mjs" } }, "sha512-D2mUFaTSbMD/JgaE50RuWP4gOPU/TsNkwscODyWGLHajynKgC0r0RfGJ3084Y8je2KjxF5SS9CjnosIrgF710Q=="],
 
     "postcss-load-config": ["postcss-load-config@6.0.1", "", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "postcss", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
 
@@ -765,9 +765,9 @@
 
     "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
 
-    "rollup": ["rollup@4.31.0", "", { "dependencies": { "@types/estree": "1.0.6" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.31.0", "@rollup/rollup-android-arm64": "4.31.0", "@rollup/rollup-darwin-arm64": "4.31.0", "@rollup/rollup-darwin-x64": "4.31.0", "@rollup/rollup-freebsd-arm64": "4.31.0", "@rollup/rollup-freebsd-x64": "4.31.0", "@rollup/rollup-linux-arm-gnueabihf": "4.31.0", "@rollup/rollup-linux-arm-musleabihf": "4.31.0", "@rollup/rollup-linux-arm64-gnu": "4.31.0", "@rollup/rollup-linux-arm64-musl": "4.31.0", "@rollup/rollup-linux-loongarch64-gnu": "4.31.0", "@rollup/rollup-linux-powerpc64le-gnu": "4.31.0", "@rollup/rollup-linux-riscv64-gnu": "4.31.0", "@rollup/rollup-linux-s390x-gnu": "4.31.0", "@rollup/rollup-linux-x64-gnu": "4.31.0", "@rollup/rollup-linux-x64-musl": "4.31.0", "@rollup/rollup-win32-arm64-msvc": "4.31.0", "@rollup/rollup-win32-ia32-msvc": "4.31.0", "@rollup/rollup-win32-x64-msvc": "4.31.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-9cCE8P4rZLx9+PjoyqHLs31V9a9Vpvfo4qNcs6JCiGWYhw2gijSetFbH6SSy1whnkgcefnUwr8sad7tgqsGvnw=="],
+    "rollup": ["rollup@4.34.9", "", { "dependencies": { "@types/estree": "1.0.6" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.34.9", "@rollup/rollup-android-arm64": "4.34.9", "@rollup/rollup-darwin-arm64": "4.34.9", "@rollup/rollup-darwin-x64": "4.34.9", "@rollup/rollup-freebsd-arm64": "4.34.9", "@rollup/rollup-freebsd-x64": "4.34.9", "@rollup/rollup-linux-arm-gnueabihf": "4.34.9", "@rollup/rollup-linux-arm-musleabihf": "4.34.9", "@rollup/rollup-linux-arm64-gnu": "4.34.9", "@rollup/rollup-linux-arm64-musl": "4.34.9", "@rollup/rollup-linux-loongarch64-gnu": "4.34.9", "@rollup/rollup-linux-powerpc64le-gnu": "4.34.9", "@rollup/rollup-linux-riscv64-gnu": "4.34.9", "@rollup/rollup-linux-s390x-gnu": "4.34.9", "@rollup/rollup-linux-x64-gnu": "4.34.9", "@rollup/rollup-linux-x64-musl": "4.34.9", "@rollup/rollup-win32-arm64-msvc": "4.34.9", "@rollup/rollup-win32-ia32-msvc": "4.34.9", "@rollup/rollup-win32-x64-msvc": "4.34.9", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-nF5XYqWWp9hx/LrpC8sZvvvmq0TeTjQgaZHYmAgwysT9nh8sWnZhBnM8ZyVbbJFIQBLwHDNoMqsBZBbUo4U8sQ=="],
 
-    "rxjs": ["rxjs@7.8.1", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg=="],
+    "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
@@ -863,7 +863,7 @@
 
     "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
-    "tinyglobby": ["tinyglobby@0.2.10", "", { "dependencies": { "fdir": "^6.4.2", "picomatch": "^4.0.2" } }, "sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew=="],
+    "tinyglobby": ["tinyglobby@0.2.12", "", { "dependencies": { "fdir": "^6.4.3", "picomatch": "^4.0.2" } }, "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww=="],
 
     "tr46": ["tr46@1.0.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA=="],
 
@@ -875,7 +875,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "tsup": ["tsup@8.3.6", "", { "dependencies": { "bundle-require": "^5.0.0", "cac": "^6.7.14", "chokidar": "^4.0.1", "consola": "^3.2.3", "debug": "^4.3.7", "esbuild": "^0.24.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.24.0", "source-map": "0.8.0-beta.0", "sucrase": "^3.35.0", "tinyexec": "^0.3.1", "tinyglobby": "^0.2.9", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core", "postcss", "typescript"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-XkVtlDV/58S9Ye0JxUUTcrQk4S+EqlOHKzg6Roa62rdjL1nGWNUstG0xgI4vanHdfIpjP448J8vlN0oK6XOJ5g=="],
+    "tsup": ["tsup@8.4.0", "", { "dependencies": { "bundle-require": "^5.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "consola": "^3.4.0", "debug": "^4.4.0", "esbuild": "^0.25.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.34.8", "source-map": "0.8.0-beta.0", "sucrase": "^3.35.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.11", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core", "postcss", "typescript"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-b+eZbPCjz10fRryaAA7C8xlIHnf8VnsaRqydheLIqwG/Mcpfk8Z5zp3HayX7GaTygkigHl5cBUs+IhcySiIexQ=="],
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
@@ -921,7 +921,7 @@
 
     "write-package": ["write-package@7.1.0", "", { "dependencies": { "deepmerge-ts": "^7.1.0", "read-pkg": "^9.0.1", "sort-keys": "^5.0.0", "type-fest": "^4.23.0", "write-json-file": "^6.0.0" } }, "sha512-DqUx8GI3r9BFWwU2DPKddL1E7xWfbFED82mLVhGXKlFEPe8IkBftzO7WfNwHtk7oGDHDeuH/o8VMpzzfMwmLUA=="],
 
-    "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+    "ws": ["ws@8.18.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
@@ -933,7 +933,7 @@
 
     "yoctocolors": ["yoctocolors@2.1.1", "", {}, "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ=="],
 
-    "zod": ["zod@3.24.1", "", {}, "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A=="],
+    "zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
@@ -943,7 +943,19 @@
 
     "@npmcli/move-file/mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
 
+    "@polkadot-api/cli/@types/node": ["@types/node@22.13.8", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-G3EfaZS+iOGYWLLRCEAXdWK9my08oHNZ+FHluRiggIYJPOXzhOiDgpVCUHaUvyIC5/fj7C/p637jdzC666AOKQ=="],
+
     "@polkadot-api/smoldot/@types/node": ["@types/node@22.10.9", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-Ir6hwgsKyNESl/gLOcEz3krR4CBGgliDqBQ2ma4wIhEx0w+xnoeTq3tdrNw15kU3SxogDjOgv9sqdtLW8mIHaw=="],
+
+    "@polkadot/api/rxjs": ["rxjs@7.8.1", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg=="],
+
+    "@polkadot/api-base/rxjs": ["rxjs@7.8.1", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg=="],
+
+    "@polkadot/api-derive/rxjs": ["rxjs@7.8.1", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg=="],
+
+    "@polkadot/rpc-core/rxjs": ["rxjs@7.8.1", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg=="],
+
+    "@polkadot/types/rxjs": ["rxjs@7.8.1", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg=="],
 
     "@substrate/connect/smoldot": ["smoldot@2.0.26", "", { "dependencies": { "ws": "^8.8.1" } }, "sha512-F+qYmH4z2s2FK+CxGj8moYcd1ekSIKH8ywkdqlOz88Dat35iB1DIYL11aILN46YSGMzQW/lbJNS307zBSDN5Ig=="],
 
@@ -954,6 +966,8 @@
     "@substrate/light-client-extension-helpers/@polkadot-api/observable-client": ["@polkadot-api/observable-client@0.3.2", "", { "dependencies": { "@polkadot-api/metadata-builders": "0.3.2", "@polkadot-api/substrate-bindings": "0.6.0", "@polkadot-api/utils": "0.1.0" }, "peerDependencies": { "@polkadot-api/substrate-client": "0.1.4", "rxjs": ">=7.8.0" } }, "sha512-HGgqWgEutVyOBXoGOPp4+IAq6CNdK/3MfQJmhCJb8YaJiaK4W6aRGrdQuQSTPHfERHCARt9BrOmEvTXAT257Ug=="],
 
     "@substrate/light-client-extension-helpers/@polkadot-api/substrate-client": ["@polkadot-api/substrate-client@0.1.4", "", { "dependencies": { "@polkadot-api/json-rpc-provider": "0.0.1", "@polkadot-api/utils": "0.1.0" } }, "sha512-MljrPobN0ZWTpn++da9vOvt+Ex+NlqTlr/XT7zi9sqPtDJiQcYl+d29hFAgpaeTqbeQKZwz3WDE9xcEfLE8c5A=="],
+
+    "@substrate/light-client-extension-helpers/rxjs": ["rxjs@7.8.1", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg=="],
 
     "@types/bn.js/@types/node": ["@types/node@22.10.9", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-Ir6hwgsKyNESl/gLOcEz3krR4CBGgliDqBQ2ma4wIhEx0w+xnoeTq3tdrNw15kU3SxogDjOgv9sqdtLW8mIHaw=="],
 
@@ -1033,6 +1047,8 @@
 
     "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
+    "smoldot/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+
     "ssri/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
@@ -1050,6 +1066,8 @@
     "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
 
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
+    "@substrate/connect/smoldot/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
     "@substrate/light-client-extension-helpers/@polkadot-api/observable-client/@polkadot-api/metadata-builders": ["@polkadot-api/metadata-builders@0.3.2", "", { "dependencies": { "@polkadot-api/substrate-bindings": "0.6.0", "@polkadot-api/utils": "0.1.0" } }, "sha512-TKpfoT6vTb+513KDzMBTfCb/ORdgRnsS3TDFpOhAhZ08ikvK+hjHMt5plPiAX/OWkm1Wc9I3+K6W0hX5Ab7MVg=="],
 

--- a/integration-tests/chopsticks/overrides/polimec.ts
+++ b/integration-tests/chopsticks/overrides/polimec.ts
@@ -1,4 +1,4 @@
-import { INITIAL_BALANCES, ETH_ADDRESS } from '@/constants';
+import { INITIAL_BALANCES } from '@/constants';
 import { Accounts } from '@/types';
 
 export const POLIMEC_WASM =

--- a/integration-tests/chopsticks/package.json
+++ b/integration-tests/chopsticks/package.json
@@ -7,9 +7,9 @@
     "test": "env LOG_LEVEL=error bun test"
   },
   "devDependencies": {
-    "@acala-network/chopsticks": "1.0.2",
+    "@acala-network/chopsticks": "1.0.3",
     "@biomejs/biome": "1.9.4",
-    "@polkadot-labs/hdkd": "0.0.11",
+    "@polkadot-labs/hdkd": "0.0.12",
     "@types/bun": "latest"
   },
   "peerDependencies": {
@@ -17,6 +17,6 @@
   },
   "dependencies": {
     "@polkadot-api/descriptors": "file:.papi/descriptors",
-    "polkadot-api": "^1.9.0"
+    "polkadot-api": "^1.9.3"
   }
 }

--- a/integration-tests/chopsticks/src/managers/PolimecManager.ts
+++ b/integration-tests/chopsticks/src/managers/PolimecManager.ts
@@ -74,9 +74,8 @@ export class PolimecManager extends BaseChainManager {
   async getXcmFee() {
     const api = this.getApi(Chains.Polimec);
     const events = await api.event.PolkadotXcm.FeesPaid.pull();
-    console.dir(events, { depth: null });
 
-    return events[0]?.payload.fees?.[0]?.fun?.value ?? 0n;
+    return (events[0]?.payload.fees?.[0]?.fun?.value as bigint) ?? 0n;
   }
 
   async getTransactionFee() {

--- a/integration-tests/chopsticks/src/setup.ts
+++ b/integration-tests/chopsticks/src/setup.ts
@@ -100,7 +100,6 @@ export class ChainSetup {
       'wasm-override': POLIMEC_WASM,
       'import-storage': polimec_storage,
       'build-block-mode': BuildBlockMode.Instant,
-      'runtime-log-level': 5,
     });
   }
 

--- a/integration-tests/chopsticks/src/tests/polimec.test.ts
+++ b/integration-tests/chopsticks/src/tests/polimec.test.ts
@@ -19,35 +19,35 @@ describe('Polimec -> Hub Transfer Tests', () => {
   });
   afterAll(async () => await chainSetup.cleanup());
 
-  // test(
-  //   'Send USDC to Hub',
-  //   () =>
-  //     transferTest.testTransfer({
-  //       account: Accounts.BOB,
-  //       assets: [[Asset.USDC, TRANSFER_AMOUNTS.TOKENS, AssetSourceRelation.Sibling]],
-  //     }),
-  //   { timeout: 25000 },
-  // );
-  //
-  // test(
-  //   'Send USDT to Hub',
-  //   () =>
-  //     transferTest.testTransfer({
-  //       account: Accounts.BOB,
-  //       assets: [[Asset.USDT, TRANSFER_AMOUNTS.TOKENS, AssetSourceRelation.Sibling]],
-  //     }),
-  //   { timeout: 25000 },
-  // );
+  test(
+    'Send USDC to Hub',
+    () =>
+      transferTest.testTransfer({
+        account: Accounts.BOB,
+        assets: [[Asset.USDC, TRANSFER_AMOUNTS.TOKENS, AssetSourceRelation.Sibling]],
+      }),
+    { timeout: 25000 },
+  );
 
-  // test(
-  //   'Send DOT to Hub',
-  //   () =>
-  //     transferTest.testTransfer({
-  //       account: Accounts.BOB,
-  //       assets: [[Asset.DOT, TRANSFER_AMOUNTS.NATIVE, AssetSourceRelation.Parent]],
-  //     }),
-  //   { timeout: 25000 },
-  // );
+  test(
+    'Send USDT to Hub',
+    () =>
+      transferTest.testTransfer({
+        account: Accounts.BOB,
+        assets: [[Asset.USDT, TRANSFER_AMOUNTS.TOKENS, AssetSourceRelation.Sibling]],
+      }),
+    { timeout: 25000 },
+  );
+
+  test(
+    'Send DOT to Hub',
+    () =>
+      transferTest.testTransfer({
+        account: Accounts.BOB,
+        assets: [[Asset.DOT, TRANSFER_AMOUNTS.NATIVE, AssetSourceRelation.Parent]],
+      }),
+    { timeout: 25000 },
+  );
 
   test(
     'Send PLMC to Hub',

--- a/integration-tests/chopsticks/src/transfers/BaseTransfer.ts
+++ b/integration-tests/chopsticks/src/transfers/BaseTransfer.ts
@@ -64,7 +64,6 @@ export abstract class BaseTransferTest {
   protected async verifyExecution() {
     const events = await this.destManager.getMessageQueueEvents();
 
-    console.dir(events, { depth: null });
     expect(events).not.toBeEmpty();
     expect(events).toBeArray();
     expect(events).toHaveLength(1);

--- a/integration-tests/chopsticks/src/transfers/BridgeToPolimec.ts
+++ b/integration-tests/chopsticks/src/transfers/BridgeToPolimec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'bun:test';
-import { DEFAULT_TOPIC, ETH_AMOUNT, FEE_AMOUNT, ETH_ADDRESS } from '@/constants';
+import { DEFAULT_TOPIC, ETH_ADDRESS, ETH_AMOUNT, FEE_AMOUNT } from '@/constants';
 import type { BridgerHubManagaer } from '@/managers/BridgeHubManager';
 import type { PolimecManager } from '@/managers/PolimecManager';
 import type { PolkadotHubManager } from '@/managers/PolkadotHubManager';
@@ -101,9 +101,6 @@ export class BridgeToPolimecTransfer extends BaseTransferTest {
     const issuedEventsOnDest = dryRunOnDest.value.emitted_events.filter(
       (event) => event.type === 'ForeignAssets' && event.value.type === 'Issued',
     );
-
-    console.log('Issued Events on Destination: \n');
-    console.dir(issuedEventsOnDest, { depth: null });
 
     // TODO: Check why we have 3 events instead of 2 (ETH + DOT). Curently we have 3 events (ETH + DOT + DOT)
     expect(issuedEventsOnDest.length).toBe(3);

--- a/integration-tests/chopsticks/src/transfers/HubToPolimec.ts
+++ b/integration-tests/chopsticks/src/transfers/HubToPolimec.ts
@@ -27,7 +27,7 @@ export class HubToPolimecTransfer extends BaseTransferTest {
     super(sourceManager, destManager);
   }
 
-  async executeTransfer({ account, assets }: TransferOptions) {
+  async executeTransfer({ account, assets, fee_asset_item }: TransferOptions) {
     const [sourceBlock, destBlock] = await Promise.all([
       this.sourceManager.getBlockNumber(),
       this.destManager.getBlockNumber(),
@@ -39,6 +39,7 @@ export class HubToPolimecTransfer extends BaseTransferTest {
       toChain: Chains.Polimec,
       assets: versioned_assets,
       recv: account,
+      fee_asset_item: fee_asset_item ?? 0,
     });
 
     const api = this.sourceManager.getApi(Chains.PolkadotHub);
@@ -113,6 +114,7 @@ export class HubToPolimecTransfer extends BaseTransferTest {
       toChain: Chains.Polimec,
       assets: versioned_assets,
       recv: transferOptions.account,
+      fee_asset_item: transferOptions.fee_asset_item ?? 0,
     });
 
     let remoteFeeAssetId: XcmVersionedAssetId;

--- a/integration-tests/chopsticks/src/transfers/PolimecToHub.ts
+++ b/integration-tests/chopsticks/src/transfers/PolimecToHub.ts
@@ -1,5 +1,4 @@
 import { expect } from 'bun:test';
-import { INITIAL_BALANCES } from '@/constants';
 import type { PolimecManager } from '@/managers/PolimecManager';
 import type { PolkadotHubManager } from '@/managers/PolkadotHubManager';
 import {
@@ -46,7 +45,6 @@ export class PolimecToHubTransfer extends BaseTransferTest {
       .getXcmPallet()
       .transfer_assets(data)
       .signAndSubmit(this.sourceManager.getSigner(account));
-    console.dir(res, { depth: null });
 
     expect(res.ok).toBeTrue();
     return { sourceBlock, destBlock };

--- a/integration-tests/chopsticks/src/transfers/PolkadotToPolimec.ts
+++ b/integration-tests/chopsticks/src/transfers/PolkadotToPolimec.ts
@@ -121,8 +121,8 @@ export class PolkadotToPolimecTransfer extends BaseTransferTest {
       toChain: Chains.PolkadotHub,
       assets: versioned_assets,
       recv: transferOptions.account,
+      fee_asset_item: transferOptions.fee_asset_item ?? 0,
     });
-    console.dir(transferData, { depth: null, colors: true });
 
     let remoteFeeAssetId: XcmVersionedAssetId;
     const lastAsset = unwrap(transferOptions.assets[0]);

--- a/integration-tests/chopsticks/src/types.ts
+++ b/integration-tests/chopsticks/src/types.ts
@@ -10,8 +10,7 @@ import {
   type polimec,
   type polkadot,
 } from '@polkadot-api/descriptors';
-import { FixedSizeBinary, type PolkadotClient, type TypedApi } from 'polkadot-api';
-import { ETH_ADDRESS } from './constants';
+import type { PolkadotClient, TypedApi } from 'polkadot-api';
 
 type Polimec = typeof polimec;
 type PolkadotHub = typeof pah;


### PR DESCRIPTION
## What?

This pull request includes several updates and improvements to the `integration-tests/chopsticks` project. The main changes involve updating dependencies, enhancing test cases, and cleaning up the codebase by removing unnecessary console logs and imports.

### Dependency Updates:
* Updated `@acala-network/chopsticks` to version `1.0.3` and `@polkadot-labs/hdkd` to version `0.0.12` in `package.json`.
* Updated `polkadot-api` dependency to version `^1.9.3` in `package.json`.

### Test Case Enhancements:
* Re-enabled previously commented-out test cases for transferring USDC, USDT, and DOT to the Hub in `polimec.test.ts`.

### Code Cleanup:
* Removed unnecessary console logs from various files, including `PolimecManager.ts`, `BaseTransfer.ts`, `BridgeToPolimec.ts`, `HubToPolimec.ts`, `PolimecToHub.ts`, and `PolkadotToPolimec.ts`. [[1]](diffhunk://#diff-17504b68de01739408ba3271f1474bc42e5e8544b68aab412f359b1345b54fa2L77-R78) [[2]](diffhunk://#diff-5dd414351aca9c6251af3425bc64e3032d2da671fd96d6912c104be8e91a2c36L67) [[3]](diffhunk://#diff-d3f932bd8fa0e6df0cbaf55474b048e8008b43a22b2f502d1ea624fd1d0b9b7eL105-L107) [[4]](diffhunk://#diff-1e5c3625dda1821bb7716a768e632713bb3b4bdaeb8105f0e7fb92761aeec0a1R117) [[5]](diffhunk://#diff-a6b4d0706a66eb8e96a37d085dc9a5b248854854c12d437295efddba2ea5908dL49) [[6]](diffhunk://#diff-31316894b2f94a7e3245783d130ae173feb892061bbe6a5fdcacfb445f999004R124-L125)
* Removed unused import `ETH_ADDRESS` from `polimec.ts`, `BridgeToPolimec.ts`, and `PolimecToHub.ts`. [[1]](diffhunk://#diff-b166cb800d57cb015c4fe852e382234955e8733273ff1d7352aa25bf45c81e79L1-R1) [[2]](diffhunk://#diff-d3f932bd8fa0e6df0cbaf55474b048e8008b43a22b2f502d1ea624fd1d0b9b7eL2-R2) [[3]](diffhunk://#diff-a6b4d0706a66eb8e96a37d085dc9a5b248854854c12d437295efddba2ea5908dL2)

### Documentation Update:
* Added prerequisites and usage instructions to the `README.md` file in the `chopsticks` directory.
