### PR TITLE
🏗️ Migrate pallet staking to use new block time

### DIFF
--- a/integration-tests/src/constants.rs
+++ b/integration-tests/src/constants.rs
@@ -16,10 +16,10 @@
 
 use frame_support::BoundedVec;
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
-use pallet_parachain_staking::inflation::{perbill_annual_to_perbill_round, BLOCKS_PER_YEAR};
+use pallet_parachain_staking::inflation::perbill_annual_to_perbill_round;
 pub use parachains_common::{AccountId, AssetHubPolkadotAuraId, AuraId, Balance, BlockNumber};
 use polimec_common::assets::AcceptedFundingAsset;
-use polimec_runtime::{pallet_parachain_staking::Range, PLMC};
+use polimec_runtime::{pallet_parachain_staking::Range, BLOCKS_PER_YEAR, PLMC};
 use polkadot_primitives::{AssignmentId, ValidatorId};
 pub use polkadot_runtime_parachains::configuration::HostConfiguration;
 use sc_consensus_grandpa::AuthorityId as GrandpaId;

--- a/nodes/parachain/src/chain_spec/common.rs
+++ b/nodes/parachain/src/chain_spec/common.rs
@@ -6,12 +6,9 @@ use polimec_common::assets::AcceptedFundingAsset;
 #[cfg(not(feature = "runtime-benchmarks"))]
 use polimec_runtime::MinCandidateStk;
 use polimec_runtime::{
-	pallet_parachain_staking::{
-		inflation::{perbill_annual_to_perbill_round, BLOCKS_PER_YEAR},
-		InflationInfo, Range,
-	},
+	pallet_parachain_staking::{inflation::perbill_annual_to_perbill_round, InflationInfo, Range},
 	AccountId, AuraId as AuthorityId, Balance, BlockchainOperationTreasury, ContributionTreasuryAccount,
-	ExistentialDeposit, FeeRecipient, OracleProvidersMembershipConfig, Runtime, TreasuryAccount, PLMC,
+	ExistentialDeposit, FeeRecipient, OracleProvidersMembershipConfig, Runtime, TreasuryAccount, BLOCKS_PER_YEAR, PLMC,
 };
 use sp_core::crypto::UncheckedInto;
 use sp_runtime::{traits::AccountIdConversion, Perbill, Percent};

--- a/pallets/parachain-staking/src/inflation.rs
+++ b/pallets/parachain-staking/src/inflation.rs
@@ -25,13 +25,9 @@ use serde::{Deserialize, Serialize};
 use sp_runtime::{PerThing, Perbill, RuntimeDebug};
 use substrate_fixed::{transcendental::pow as floatpow, types::I64F64};
 
-const SECONDS_PER_YEAR: u32 = 31557600;
-const SECONDS_PER_BLOCK: u32 = 12;
-pub const BLOCKS_PER_YEAR: u32 = SECONDS_PER_YEAR / SECONDS_PER_BLOCK;
-
 fn rounds_per_year<T: Config>() -> u32 {
 	let blocks_per_round = <Pallet<T>>::round().length;
-	BLOCKS_PER_YEAR / blocks_per_round
+	T::BLOCKS_PER_YEAR / blocks_per_round
 }
 
 #[derive(
@@ -99,8 +95,8 @@ impl<Balance> InflationInfo<Balance> {
 	}
 
 	/// Reset round inflation rate based on changes to round length
-	pub fn reset_round(&mut self, new_length: u32) {
-		let periods = BLOCKS_PER_YEAR / new_length;
+	pub fn reset_round<T: Config>(&mut self, new_length: u32) {
+		let periods = T::BLOCKS_PER_YEAR / new_length;
 		self.round = perbill_annual_to_perbill_round(self.annual, periods);
 	}
 

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -200,6 +200,9 @@ pub mod pallet {
 		type OnNewRound: OnNewRound;
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
+
+		/// Blocks per one year
+		const BLOCKS_PER_YEAR: u32;
 	}
 
 	#[pallet::error]
@@ -883,7 +886,7 @@ pub mod pallet {
 			round.length = new;
 			// update per-round inflation given new rounds per year
 			let mut inflation_config = <InflationConfig<T>>::get();
-			inflation_config.reset_round(new);
+			inflation_config.reset_round::<T>(new);
 			<Round<T>>::put(round);
 			Self::deposit_event(Event::BlocksPerRoundSet {
 				current_round: now,

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -184,6 +184,8 @@ impl Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type WeightInfo = ();
+
+	const BLOCKS_PER_YEAR: u32 = 365 * 24 * 60 * 60 / 12;
 }
 
 pub(crate) struct ExtBuilder {

--- a/runtimes/polimec/src/lib.rs
+++ b/runtimes/polimec/src/lib.rs
@@ -785,6 +785,9 @@ impl pallet_preimage::Config for Runtime {
 	type WeightInfo = weights::pallet_preimage::WeightInfo<Runtime>;
 }
 
+/// Number of blocks in one year
+pub const BLOCKS_PER_YEAR: BlockNumber = DAYS * 365;
+
 impl pallet_parachain_staking::Config for Runtime {
 	type Balance = Balance;
 	type CandidateBondLessDelay = CandidateBondLessDelay;
@@ -811,6 +814,8 @@ impl pallet_parachain_staking::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type WeightInfo = weights::pallet_parachain_staking::WeightInfo<Runtime>;
+
+	const BLOCKS_PER_YEAR: BlockNumber = BLOCKS_PER_YEAR;
 }
 
 impl pallet_membership::Config<pallet_membership::Instance1> for Runtime {

--- a/runtimes/shared-configuration/src/time.rs
+++ b/runtimes/shared-configuration/src/time.rs
@@ -31,3 +31,8 @@ pub const RELAY_CHAIN_SLOT_DURATION_MILLIS: u32 = 6000;
 /// Change this to adjust the block time.
 pub const MILLISECS_PER_BLOCK: u64 = 6000;
 pub const SLOT_DURATION: u64 = MILLISECS_PER_BLOCK;
+
+// Time is measured by number of blocks.
+pub const MINUTES: u32 = 60_000 / (MILLISECS_PER_BLOCK as u32);
+pub const HOURS: u32 = MINUTES * 60;
+pub const DAYS: u32 = HOURS * 24;


### PR DESCRIPTION
This pull request introduces a refactor to centralize the definition of `BLOCKS_PER_YEAR` across the codebase, replacing hardcoded values with a configurable constant. This improves maintainability and consistency. Key changes include modifications to the `pallet_parachain_staking` module, runtime configurations, and shared time constants.

### Refactoring and Centralization of `BLOCKS_PER_YEAR`:

* **`pallet_parachain_staking` updates:**
  - Added `BLOCKS_PER_YEAR` as an associated constant in the `Config` trait, making it configurable per runtime. (`pallets/parachain-staking/src/lib.rs`, [pallets/parachain-staking/src/lib.rsR203-R205](diffhunk://#diff-842251b834245800808bd740184c1e3b18c6af1f95fb1bd4d484420017fdf86eR203-R205))
  - Updated the `reset_round` method to use the configurable `BLOCKS_PER_YEAR` instead of a hardcoded value. (`pallets/parachain-staking/src/inflation.rs`, [pallets/parachain-staking/src/inflation.rsL102-R99](diffhunk://#diff-eb1fe29cf7ba301ca124060ab308946ba26133e77ad9fa0b331781c5288877d0L102-R99))
  - Adjusted the `round.length` update logic to use the new `reset_round` implementation. (`pallets/parachain-staking/src/lib.rs`, [pallets/parachain-staking/src/lib.rsL886-R889](diffhunk://#diff-842251b834245800808bd740184c1e3b18c6af1f95fb1bd4d484420017fdf86eL886-R889))

* **Runtime-specific configurations:**
  - Defined `BLOCKS_PER_YEAR` for the `Test` runtime in the mock file. (`pallets/parachain-staking/src/mock.rs`, [pallets/parachain-staking/src/mock.rsR187-R188](diffhunk://#diff-75e5a84c910859aa75adb95f11e6d0b0a1a4d4e8fa742c0ac366f524a7134929R187-R188))
  - Introduced `BLOCKS_PER_YEAR` as a constant in the Polimec runtime and integrated it into the `pallet_parachain_staking::Config` implementation. (`runtimes/polimec/src/lib.rs`, [[1]](diffhunk://#diff-fa44a5ad015c5d189a690374b9164d3a58b7218228b56c151327dd62d143ee1bR788-R790) [[2]](diffhunk://#diff-fa44a5ad015c5d189a690374b9164d3a58b7218228b56c151327dd62d143ee1bR817-R818)

### Shared Time Constants:

* Added constants for `MINUTES`, `HOURS`, and `DAYS` to the shared time configuration file for better readability and reusability of time calculations. (`runtimes/shared-configuration/src/time.rs`, [runtimes/shared-configuration/src/time.rsR34-R38](diffhunk://#diff-c825192f216770067c386660e13749eb80cf7be12a2b62867e330cda23713dfaR34-R38))

### Code Cleanup:

* Removed redundant imports of `BLOCKS_PER_YEAR` in files where it is now accessed via the `Config` trait or runtime constants. (`integration-tests/src/constants.rs`, [[1]](diffhunk://#diff-7b342ffeb1b99c7070f0924ae1eec48d0cf9ecdba069f0b862ce98b790479b2eL19-R22); `nodes/parachain/src/chain_spec/common.rs`, [[2]](diffhunk://#diff-8f5f44419ccd27cafaa627a3bc9fa254d41ee4508d5b81876627359376103872L9-R11)
* Deleted the hardcoded `BLOCKS_PER_YEAR` definition in `pallet_parachain_staking/src/inflation.rs` to avoid duplication. (`pallets/parachain-staking/src/inflation.rs`, [pallets/parachain-staking/src/inflation.rsL28-R30](diffhunk://#diff-eb1fe29cf7ba301ca124060ab308946ba26133e77ad9fa0b331781c5288877d0L28-R30))