### PR TITLE
⚡️ Remove `AccountId` and `id` from stored value

### DIFF
--- a/pallets/funding/src/functions/2_evaluation.rs
+++ b/pallets/funding/src/functions/2_evaluation.rs
@@ -113,9 +113,7 @@ impl<T: Config> Pallet<T> {
 		let early_usd_amount = usd_amount.min(remaining_for_early_reward_usd);
 		let late_usd_amount = usd_amount.checked_sub(early_usd_amount).ok_or(Error::<T>::BadMath)?;
 		let new_evaluation = EvaluationInfoOf::<T> {
-			id: evaluation_id,
 			did: did.clone(),
-			project_id,
 			evaluator: evaluator.clone(),
 			original_plmc_bond: plmc_bond,
 			current_plmc_bond: plmc_bond,

--- a/pallets/funding/src/functions/5_settlement.rs
+++ b/pallets/funding/src/functions/5_settlement.rs
@@ -107,7 +107,11 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// Settle an evaluation, by maybe minting CTs, and releasing the PLMC bond.
-	pub fn do_settle_evaluation(evaluation: EvaluationInfoOf<T>, project_id: ProjectId) -> DispatchResult {
+	pub fn do_settle_evaluation(
+		evaluation: EvaluationInfoOf<T>,
+		project_id: ProjectId,
+		evaluation_id: u32,
+	) -> DispatchResult {
 		let project_details = ProjectsDetails::<T>::get(project_id).ok_or(Error::<T>::ProjectDetailsNotFound)?;
 
 		ensure!(
@@ -143,12 +147,12 @@ impl<T: Config> Pallet<T> {
 				evaluation.receiving_account,
 			)?;
 		}
-		Evaluations::<T>::remove((project_id, evaluation.evaluator.clone(), evaluation.id));
+		Evaluations::<T>::remove((project_id, evaluation.evaluator.clone(), evaluation_id));
 
 		Self::deposit_event(Event::EvaluationSettled {
 			project_id,
 			account: evaluation.evaluator,
-			id: evaluation.id,
+			id: evaluation_id,
 			plmc_released,
 			ct_rewarded,
 		});

--- a/pallets/funding/src/tests/2_evaluation.rs
+++ b/pallets/funding/src/tests/2_evaluation.rs
@@ -552,9 +552,7 @@ mod evaluate_extrinsic {
 				assert_eq!(evaluations.len(), 1);
 				let stored_evaluation = &evaluations[0];
 				let expected_evaluation_item = EvaluationInfoOf::<TestRuntime> {
-					id: 0,
 					did,
-					project_id: 0,
 					evaluator: EVALUATOR_1,
 					original_plmc_bond: necessary_plmc[0].plmc_amount,
 					current_plmc_bond: necessary_plmc[0].plmc_amount,

--- a/pallets/funding/src/types.rs
+++ b/pallets/funding/src/types.rs
@@ -36,7 +36,6 @@ use polimec_common::assets::AcceptedFundingAsset;
 use sp_runtime::traits::Zero;
 
 pub mod config {
-	#[allow(clippy::wildcard_imports)]
 	use super::*;
 	use crate::{Balance, BlockNumberFor};
 
@@ -304,10 +303,8 @@ pub mod storage {
 		pub funding_end_block: Option<BlockNumber>,
 	}
 	#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen, Ord, PartialOrd)]
-	pub struct EvaluationInfo<Id, Did, ProjectId, AccountId, BlockNumber> {
-		pub id: Id,
+	pub struct EvaluationInfo<Did, AccountId, BlockNumber> {
 		pub did: Did,
-		pub project_id: ProjectId,
 		pub evaluator: AccountId,
 		pub original_plmc_bond: Balance,
 		// An evaluation bond can be converted to participation bond


### PR DESCRIPTION
This pull request refactors the `EvaluationInfo` structure and associated logic across the `pallets/funding` module to simplify its design by removing the `id` and `project_id` fields from the structure. The changes also update related functions, storage, and tests to accommodate this refactoring. Additionally, some minor cleanups were performed.

### Refactoring of `EvaluationInfo` and Related Logic:

* **`EvaluationInfo` Structure Simplification**:
  - Removed the `id` and `project_id` fields from the `EvaluationInfo` struct definition in `pallets/funding/src/types.rs`. The struct now relies on external identifiers for these fields.
  - Updated the associated type alias `EvaluationInfoOf<T>` in `pallets/funding/src/lib.rs` to reflect the new structure.

* **Function Updates**:
  - Updated `do_settle_evaluation` in `pallets/funding/src/functions/5_settlement.rs` to accept `evaluation_id` as a separate parameter instead of using it from the `EvaluationInfo` struct. [[1]](diffhunk://#diff-5a83a19aa7c206ac2217fe2db4d5f7007dbbcc8a21aa63ebfadd9d35ae11b3c4L110-R114) [[2]](diffhunk://#diff-5a83a19aa7c206ac2217fe2db4d5f7007dbbcc8a21aa63ebfadd9d35ae11b3c4L146-R155)
  - Adjusted `try_plmc_participation_lock` to iterate over evaluation IDs and include them in updates to the `Evaluations` storage.
  - Modified `settle_project` and `get_evaluations` in `pallets/funding/src/instantiator/chain_interactions.rs` to handle the new structure. [[1]](diffhunk://#diff-85914a5b2af457238c81931b2e3d12b5612538f6e65f72a069167411b7d9fbaaL484-R486) [[2]](diffhunk://#diff-85914a5b2af457238c81931b2e3d12b5612538f6e65f72a069167411b7d9fbaaL496-R503)

* **Storage Updates**:
  - Updated all references to `Evaluations` storage to use external `evaluation_id` where necessary, ensuring compatibility with the new structure. [[1]](diffhunk://#diff-6e00ce3c2a2b6cea352ed5c274ddaa2ac3123a2fcfffab24e9f5ca79a2ace44eL102-R115) [[2]](diffhunk://#diff-85914a5b2af457238c81931b2e3d12b5612538f6e65f72a069167411b7d9fbaaL484-R486)

### Test Adjustments:

* **Test Updates for `EvaluationInfo` Changes**:
  - Updated tests in `pallets/funding/src/tests/5_settlement.rs` to reflect the new `EvaluationInfo` structure by using tuples `(AccountId, EvaluationId, EvaluationInfo)` instead of the old structure. [[1]](diffhunk://#diff-ab99f14a7a53e8ddb4d8fda7d60d249b13f55391ac78d1036a4e8561e07eb9e0L15-R15) [[2]](diffhunk://#diff-ab99f14a7a53e8ddb4d8fda7d60d249b13f55391ac78d1036a4e8561e07eb9e0L373-R373) [[3]](diffhunk://#diff-ab99f14a7a53e8ddb4d8fda7d60d249b13f55391ac78d1036a4e8561e07eb9e0L465-R472)
  - Adjusted assertions and test logic to handle the separation of `evaluation_id` from `EvaluationInfo`. [[1]](diffhunk://#diff-ab99f14a7a53e8ddb4d8fda7d60d249b13f55391ac78d1036a4e8561e07eb9e0L29-R29) [[2]](diffhunk://#diff-ab99f14a7a53e8ddb4d8fda7d60d249b13f55391ac78d1036a4e8561e07eb9e0L440-R451)

### Minor Cleanups:

* Removed unused `id` and `project_id` fields from `EvaluationInfo` in `pallets/funding/src/functions/2_evaluation.rs` and associated logic. [[1]](diffhunk://#diff-3212f81c950c02ae5f8f0087a32939e8056a8eb4192df0debe7865a7bda34a02L116-L118) [[2]](diffhunk://#diff-80438b41f52ff90f38ce2f357d19d3f1523e92a7ddfcf6d68753d88d73001b48L555-L557)
* Removed unnecessary `#[allow(unreachable_patterns)]` directive in `pallets/funding/src/lib.rs`.
* Added `BlockNumberFor` import to `pallets/funding/src/lib.rs` for consistency.

These changes streamline the `EvaluationInfo` structure and improve the maintainability of the codebase by reducing redundancy and simplifying related logic.