### PR TITLE
🎨 Refactor the Price Buckets

### DIFF
--- a/pallets/funding/src/benchmarking.rs
+++ b/pallets/funding/src/benchmarking.rs
@@ -784,7 +784,7 @@ mod benchmarks {
 		let increase = project_metadata.minimum_price * PriceOf::<T>::saturating_from_rational(5, 10);
 		let target_price = project_metadata.minimum_price + increase;
 
-		let mut new_bucket = Pallet::<T>::create_bucket_from_metadata(&project_metadata).unwrap();
+		let mut new_bucket = Pallet::<T>::create_bucket_from_metadata(&project_metadata);
 		new_bucket.current_price = target_price;
 		new_bucket.amount_left = new_bucket.delta_amount;
 

--- a/pallets/funding/src/functions/1_application.rs
+++ b/pallets/funding/src/functions/1_application.rs
@@ -48,7 +48,7 @@ impl<T: Config> Pallet<T> {
 			funding_end_block: None,
 		};
 
-		let bucket: BucketOf<T> = Self::create_bucket_from_metadata(project_metadata)?;
+		let bucket = Self::create_bucket_from_metadata(project_metadata);
 
 		Ok((project_details, bucket))
 	}

--- a/pallets/funding/src/functions/misc.rs
+++ b/pallets/funding/src/functions/misc.rs
@@ -23,17 +23,10 @@ impl<T: Config> Pallet<T> {
 		T::PalletId::get().into_sub_account_truncating(index.saturating_add(One::one()))
 	}
 
-	pub fn create_bucket_from_metadata(metadata: &ProjectMetadataOf<T>) -> Result<BucketOf<T>, DispatchError> {
+	pub fn create_bucket_from_metadata(metadata: &ProjectMetadataOf<T>) -> BucketOf<T> {
 		let auction_allocation_size = metadata.total_allocation_size;
-		let bucket_delta_amount = Percent::from_percent(10) * auction_allocation_size;
-		let ten_percent_in_price: <T as Config>::Price =
-			PriceOf::<T>::checked_from_rational(1, 10).ok_or(Error::<T>::BadMath)?;
-		let bucket_delta_price: <T as Config>::Price = metadata.minimum_price.saturating_mul(ten_percent_in_price);
 
-		let bucket: BucketOf<T> =
-			Bucket::new(auction_allocation_size, metadata.minimum_price, bucket_delta_price, bucket_delta_amount);
-
-		Ok(bucket)
+		Bucket::new(auction_allocation_size, metadata.minimum_price)
 	}
 
 	pub fn calculate_plmc_bond(ticket_size: Balance, multiplier: MultiplierOf<T>) -> Result<Balance, DispatchError> {

--- a/pallets/funding/src/instantiator/calculations.rs
+++ b/pallets/funding/src/instantiator/calculations.rs
@@ -44,7 +44,7 @@ impl<
 		let mut bucket = if let Some(bucket) = maybe_bucket {
 			bucket
 		} else {
-			Pallet::<T>::create_bucket_from_metadata(&project_metadata).unwrap()
+			Pallet::<T>::create_bucket_from_metadata(&project_metadata)
 		};
 		for bid in bids {
 			let mut amount_to_bid = bid.amount;
@@ -484,7 +484,7 @@ impl<
 		project_metadata: ProjectMetadataOf<T>,
 		usd_target: Balance,
 	) -> Vec<BidParams<T>> {
-		let mut bucket = Pallet::<T>::create_bucket_from_metadata(&project_metadata).unwrap();
+		let mut bucket = Pallet::<T>::create_bucket_from_metadata(&project_metadata);
 		bucket.update(project_metadata.total_allocation_size);
 
 		// Increase bucket price until we go past the target usd amount
@@ -535,7 +535,7 @@ impl<
 		bucket: BucketOf<T>,
 		funding_asset: AcceptedFundingAsset,
 	) -> Vec<BidParams<T>> {
-		let mut new_bucket = Pallet::<T>::create_bucket_from_metadata(&project_metadata).unwrap();
+		let mut new_bucket = Pallet::<T>::create_bucket_from_metadata(&project_metadata);
 		assert_eq!(new_bucket.delta_amount, bucket.delta_amount, "Buckets must have the same delta amount");
 		assert_eq!(new_bucket.delta_price, bucket.delta_price, "Buckets must have the same delta price");
 		assert_eq!(new_bucket.initial_price, bucket.initial_price, "Buckets must have the same initial price");

--- a/pallets/funding/src/instantiator/tests.rs
+++ b/pallets/funding/src/instantiator/tests.rs
@@ -17,7 +17,7 @@ fn generate_bids_from_bucket() {
 	let desired_bucket_price_aware =
 		PriceProviderOf::<TestRuntime>::calculate_decimals_aware_price(desired_real_wap, USD_DECIMALS, CT_DECIMALS)
 			.unwrap();
-	let mut necessary_bucket = Pallet::<TestRuntime>::create_bucket_from_metadata(&project_metadata).unwrap();
+	let mut necessary_bucket = Pallet::<TestRuntime>::create_bucket_from_metadata(&project_metadata);
 	necessary_bucket.current_price = desired_bucket_price_aware;
 	necessary_bucket.amount_left = necessary_bucket.delta_amount;
 

--- a/pallets/funding/src/tests/1_application.rs
+++ b/pallets/funding/src/tests/1_application.rs
@@ -998,7 +998,7 @@ mod edit_project_extrinsic {
 			// Project details reflect changes
 			assert_eq!(inst.get_project_details(project_id).fundraising_target_usd, 100_000 * USD_UNIT);
 			// Bucket reflects changes
-			let new_bucket = Pallet::<TestRuntime>::create_bucket_from_metadata(&new_metadata).unwrap();
+			let new_bucket = Pallet::<TestRuntime>::create_bucket_from_metadata(&new_metadata);
 			let stored_bucket = inst.execute(|| Buckets::<TestRuntime>::get(project_id).unwrap());
 			assert_eq!(stored_bucket, new_bucket);
 			// Event emitted

--- a/pallets/funding/src/tests/3_auction.rs
+++ b/pallets/funding/src/tests/3_auction.rs
@@ -171,7 +171,7 @@ mod round_flow {
 	fn auction_oversubscription() {
 		let mut inst = MockInstantiator::new(Some(RefCell::new(new_test_ext())));
 		let project_metadata = default_project_metadata(ISSUER_1);
-		let mut bucket = Pallet::<TestRuntime>::create_bucket_from_metadata(&project_metadata).unwrap();
+		let mut bucket = Pallet::<TestRuntime>::create_bucket_from_metadata(&project_metadata);
 		bucket.current_price =
 			bucket.initial_price + (bucket.delta_price.mul(PriceOf::<TestRuntime>::from_float(10.0)));
 		bucket.amount_left = bucket.delta_amount;

--- a/pallets/funding/src/tests/misc.rs
+++ b/pallets/funding/src/tests/misc.rs
@@ -108,7 +108,7 @@ mod inner_functions {
 	pub fn calculate_usd_sold_from_bucket() {
 		let project_metadata = default_project_metadata(ISSUER_1);
 
-		let mut bucket = Pallet::<TestRuntime>::create_bucket_from_metadata(&project_metadata).unwrap();
+		let mut bucket = Pallet::<TestRuntime>::create_bucket_from_metadata(&project_metadata);
 		bucket.update(10_000 * CT_UNIT);
 
 		// We bought 10k CTs at a price of 10USD, meaning we should get 100k USD
@@ -116,7 +116,7 @@ mod inner_functions {
 		assert_eq!(usd_sold, 100_000 * USD_UNIT);
 
 		// This bucket has 2 buckets sold out on top of the first one
-		let mut bucket = Pallet::<TestRuntime>::create_bucket_from_metadata(&project_metadata).unwrap();
+		let mut bucket = Pallet::<TestRuntime>::create_bucket_from_metadata(&project_metadata);
 
 		let usd_raised_first_bucket = bucket.current_price.saturating_mul_int(400_000 * CT_UNIT);
 		bucket.update(project_metadata.total_allocation_size);

--- a/pallets/funding/src/types.rs
+++ b/pallets/funding/src/types.rs
@@ -27,7 +27,10 @@ pub use inner::*;
 use polimec_common::{DAYS, USD_DECIMALS};
 use serde::{Deserialize, Serialize};
 use sp_arithmetic::{traits::Saturating, FixedPointNumber, FixedU128};
-use sp_runtime::traits::{Convert, One};
+use sp_runtime::{
+	traits::{Convert, One},
+	Percent,
+};
 pub use storage::*;
 
 use crate::{traits::VestingDurationCalculation, Config};
@@ -373,12 +376,11 @@ pub mod storage {
 
 	impl<Price: FixedPointNumber> Bucket<Price> {
 		/// Creates a new bucket with the given parameters.
-		pub const fn new(
-			amount_left: Balance,
-			initial_price: Price,
-			delta_price: Price,
-			delta_amount: Balance,
-		) -> Self {
+		pub fn new(amount_left: Balance, initial_price: Price) -> Self {
+			let ten_percent = Percent::from_percent(10);
+			let delta_amount = ten_percent * amount_left;
+			let ten_percent_fixed = Price::checked_from_rational(1, 10).expect("10% is a valid fixed point number");
+			let delta_price = ten_percent_fixed * initial_price;
 			Self { amount_left, current_price: initial_price, initial_price, delta_price, delta_amount }
 		}
 

--- a/polimec-common/common/src/lib.rs
+++ b/polimec-common/common/src/lib.rs
@@ -385,7 +385,6 @@ pub trait ProvideAssetPrice {
 	/// # Arguments
 	///
 	/// * `asset_id`: The identifier of the asset.
-	/// * `usd_decimals`: The number of decimal places for the USD (or pricing) currency.
 	/// * `asset_decimals`: The number of decimal places for the asset.
 	///
 	/// # Returns


### PR DESCRIPTION
This pull request simplifies the `create_bucket_from_metadata` function and its usage across the `pallets/funding` module by removing unnecessary error handling and making the `Bucket::new` constructor more concise. Additionally, it includes minor cleanup in related files.

### Simplification of `create_bucket_from_metadata`:

* [`pallets/funding/src/functions/misc.rs`](diffhunk://#diff-6e00ce3c2a2b6cea352ed5c274ddaa2ac3123a2fcfffab24e9f5ca79a2ace44eL26-R29): Removed the `Result` return type and unnecessary error handling in the `create_bucket_from_metadata` function. The function now directly returns a `BucketOf<T>` object.
* [`pallets/funding/src/types.rs`](diffhunk://#diff-d5a7ca3423acfb2236018006a4ac93760a9e9893a8c864e55bef34403cafcb5dL376-R383): Simplified the `Bucket::new` constructor by removing redundant parameters and calculations, and moved the 10% calculation logic into the constructor.

### Updates to function calls:

* Updated all calls to `create_bucket_from_metadata` across the module to remove `.unwrap()` since the function no longer returns a `Result`. This change affects:
  - `pallets/funding/src/benchmarking.rs`
  - `pallets/funding/src/functions/1_application.rs`
  - `pallets/funding/src/instantiator/calculations.rs` [[1]](diffhunk://#diff-808991f71e78e2c3b44661bdb1525f5ccf042a8d32d916e0ede1d2f5eee3fc69L47-R47) [[2]](diffhunk://#diff-808991f71e78e2c3b44661bdb1525f5ccf042a8d32d916e0ede1d2f5eee3fc69L487-R487) [[3]](diffhunk://#diff-808991f71e78e2c3b44661bdb1525f5ccf042a8d32d916e0ede1d2f5eee3fc69L538-R538)
  - `pallets/funding/src/tests/1_application.rs`
  - `pallets/funding/src/tests/3_auction.rs`
  - `pallets/funding/src/tests/misc.rs` [[1]](diffhunk://#diff-520affcae098c7401d6c83ae4160452b5e1b4b59169a6a88c8815d75d5f7c832L111-R119) [[2]](diffhunk://#diff-520affcae098c7401d6c83ae4160452b5e1b4b59169a6a88c8815d75d5f7c832L111-R119)

### Code cleanup:

* [`pallets/funding/src/types.rs`](diffhunk://#diff-d5a7ca3423acfb2236018006a4ac93760a9e9893a8c864e55bef34403cafcb5dL30-R33): Added `Percent` to the imports to support the updated `Bucket::new` implementation.
* [`polimec-common/common/src/lib.rs`](diffhunk://#diff-01c9e1130ca712a94685420417c6f54243234bc17221b7dde5da9a5c84179144L388): Removed an unused parameter (`usd_decimals`) from the documentation of the `ProvideAssetPrice` trait.