### PR TITLE
🚑️ Bump frame-executive and sp-api-proc-macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,9 +469,9 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "asset-hub-westend-runtime"
-version = "0.27.3"
+version = "0.27.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0771a324855dd5b73ee3abb618ef3cef12410ac4a13c47764f8fdecaf2823a69"
+checksum = "6df59ae4760f30fe3bcf7940aac9cb895f35b272a056d846fc10027dadaa5a26"
 dependencies = [
  "assets-common",
  "bp-asset-hub-rococo",
@@ -1617,15 +1617,14 @@ dependencies = [
 
 [[package]]
 name = "cid"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd94671561e36e4e7de75f753f577edafb0e7c05d6e4547229fdf7938fbcd2c3"
+checksum = "3147d8272e8fa0ccd29ce51194dd98f79ddfb8191ba9e3409884e751798acf3a"
 dependencies = [
  "core2",
  "multibase",
- "multihash 0.18.1",
- "serde",
- "unsigned-varint 0.7.2",
+ "multihash 0.19.3",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -2941,7 +2940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e4fdb82bd54a12e42fb58a800dcae6b9e13982238ce2296dc3570b92148e1f"
 dependencies = [
  "data-encoding",
- "syn 2.0.100",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3321,9 +3320,9 @@ dependencies = [
 
 [[package]]
 name = "emulated-integration-tests-common"
-version = "19.0.2"
+version = "19.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "438b706f12ea5e56d1bba7350abe5402800ca94910342c8e4b7eea08b7056d17"
+checksum = "9357720f7c7740b03e3759372b0eb7f74c047337bb1ab6e72be03409d4aaff14"
 dependencies = [
  "asset-test-utils",
  "bp-messages",
@@ -3353,6 +3352,7 @@ dependencies = [
  "sp-runtime",
  "staging-xcm",
  "xcm-emulator",
+ "xcm-simulator",
 ]
 
 [[package]]
@@ -3457,7 +3457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3804,9 +3804,9 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "frame-benchmarking"
-version = "39.0.0"
+version = "39.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c221b23f5cc5990830c4010bc01eac1cf401327e2bec362b0d28cb261809958"
+checksum = "243a7b247c6a1ebf89c43eb8f3bfaea60965aa9712dceca781ef09579263d343"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3829,9 +3829,9 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "46.1.0"
+version = "46.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94cc896c787382b70a7761dd193a797711ea73ef48ad5d87ee89bbebf28e3914"
+checksum = "cbd56d645dae5cb7f386f628abbb798f370c158a10616aefdcae1f1a3e5e2509"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -3892,9 +3892,9 @@ dependencies = [
 
 [[package]]
 name = "frame-election-provider-solution-type"
-version = "14.0.1"
+version = "14.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8156f209055d352994ecd49e19658c6b469d7c6de923bd79868957d0dcfb6f71"
+checksum = "bc435a406e04540f00979782c45db0534440873ae526e07a290c286cfcb99b09"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -3904,9 +3904,9 @@ dependencies = [
 
 [[package]]
 name = "frame-election-provider-support"
-version = "39.0.0"
+version = "39.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d62cba64438e4f6f8b78c8c7ec1953ba3c3f4933245412b44501b31df0f87ef"
+checksum = "2d5a6d33db65e59084460e153c409c29737b6441fd52159a6f022e9ecd8344c4"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3921,9 +3921,9 @@ dependencies = [
 
 [[package]]
 name = "frame-executive"
-version = "39.1.0"
+version = "39.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e71d2a46f2dfabd97d597de29b69c331fc3ca5602848aa0a235823e675fd0678"
+checksum = "f4c2806f902c7d45223df81eb83ed1e422456cb12984bd77128f2cb4ca29a139"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -5461,7 +5461,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.0",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6872,18 +6872,17 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litep2p"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3aa5628ae2b2283aa01dfa58947f1926aedba0160dd25041e2cd4bc71534c9"
+checksum = "d71056c23c896bb0e18113b2d2f1989be95135e6bdeedb0b757422ee21a073eb"
 dependencies = [
  "async-trait",
  "bs58",
  "bytes",
- "cid 0.10.1",
+ "cid 0.11.1",
  "ed25519-dalek",
  "futures",
  "futures-timer",
- "hex-literal",
  "hickory-resolver",
  "indexmap 2.9.0",
  "libc",
@@ -6893,12 +6892,9 @@ dependencies = [
  "network-interface",
  "parking_lot 0.12.3",
  "pin-project",
- "prost 0.12.6",
+ "prost 0.13.5",
  "prost-build",
  "rand 0.8.5",
- "rcgen 0.10.0",
- "ring 0.16.20",
- "rustls 0.20.9",
  "serde",
  "sha2 0.10.8",
  "simple-dns",
@@ -7369,23 +7365,6 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd8a792c1694c6da4f68db0a9d707c72bd260994da179e6030a5dcee00bb815"
-dependencies = [
- "blake2b_simd",
- "blake2s_simd",
- "blake3",
- "core2",
- "digest 0.10.7",
- "multihash-derive",
- "sha2 0.10.8",
- "sha3",
- "unsigned-varint 0.7.2",
-]
-
-[[package]]
-name = "multihash"
 version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
@@ -7541,9 +7520,9 @@ dependencies = [
 
 [[package]]
 name = "network-interface"
-version = "1.1.4"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a43439bf756eed340bdf8feba761e2d50c7d47175d87545cd5cbe4a137c4d1"
+checksum = "c3329f515506e4a2de3aa6e07027a6758e22e0f0e8eaf64fa47261cec2282602"
 dependencies = [
  "cc",
  "libc",
@@ -8219,9 +8198,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-beefy"
-version = "40.1.0"
+version = "40.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c163fa041eb848fb68900ba0cea3c213f34282241959f327bbe10c93d5aa124"
+checksum = "13f7788811909f3c7858bec28a66dae50a3be26d4cc8578b23052d561a6cd4de"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8465,9 +8444,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-election-provider-multi-phase"
-version = "38.1.0"
+version = "38.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b93092065f6b31fbf6e5788a889d712859cf5402cc5d487fe6a241f102bcac6"
+checksum = "80033a0f457cf66d3bfd09ed51137cc5a0a6d55f23a2d778a8d998e993d2982a"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8835,9 +8814,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools"
-version = "37.0.1"
+version = "37.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e8dc7d47b8233a3b4579e1400b0f032bf54d09af90037e6b71221d7858c3adf"
+checksum = "1329a039994c3bdc4c56bbf52601f8630d717845a487ee73dbf904178b185d34"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8875,9 +8854,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
-version = "35.0.0"
+version = "35.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40136a17d80af5acf0efd78caad3529beb8a50a4fbad442e528ea9a60ff719e"
+checksum = "c8d85af8e4aaba0f244daccb487f7ec859a7c1de6d3455fa6b0f929e76273156"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -9109,9 +9088,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-scheduler"
-version = "40.1.0"
+version = "40.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6efb66648d83ce14caaa5cb062fa54021222e964dc58c7326aee44f27db96b46"
+checksum = "e290bcd7f5e1eefcd5eec1e21efa9ac690c6f97e4534aa3831ff78b7d1fbda68"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9441,9 +9420,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm"
-version = "18.1.0"
+version = "18.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1d95aa6954c1ac5ecac000a3d9d3203399498c3a79ec508cdb81acecacd77f"
+checksum = "00c70b60f0a76bcca27686889da513b2e1440979d0192cc34c738e75112c88c0"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -9483,9 +9462,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-bridge-hub"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bd00ad5cff288bfdf216dba30efdc0e2a7d19d53dfd307864428ee1cc12d04"
+checksum = "13c2078cc35fe19754c4aa85a597d718a369055abb47d481d0197eb748bf079d"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -11909,7 +11888,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.9",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12608,7 +12587,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12621,18 +12600,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.3",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustls"
-version = "0.20.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
-dependencies = [
- "ring 0.16.20",
- "sct",
- "webpki",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12779,7 +12747,7 @@ dependencies = [
  "security-framework 3.2.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13514,9 +13482,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.48.3"
+version = "0.48.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b3e6927803b73e7f88fd36d428d3238e4e430c3c963fde0857338c768fe0fad"
+checksum = "8c4337c3707ea575ec354656ee7847eafe73432af2c07c944f609a83285eee66"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -15202,9 +15170,9 @@ dependencies = [
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "21.0.0"
+version = "21.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37f8b9621cfa68a45d6f9c124e672b8f6780839a6c95279a7877d244fef8d1dc"
+checksum = "e1b4dc9405403cef6bf181dba43bfd157f8900a8169e9975ece77be54491dad8"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -15624,9 +15592,9 @@ dependencies = [
 
 [[package]]
 name = "sp-npos-elections"
-version = "35.0.0"
+version = "35.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6df43d267689ec0e10e61eff57543af326f769481215cd43022e791c32ce30a3"
+checksum = "a26266f752840c9bc2cf37a273453407f5e28dd48ed5c1e6271cf75acc843b59"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16049,9 +16017,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm"
-version = "15.0.3"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b570c175519cb507fd7c16d69c43f77e87853cc7cc0d88bf4aabca028775363b"
+checksum = "40fdb8384388024e85d9c22bfd9a79d47a07f589cd276e94ead79b5c05f6910c"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -16071,9 +16039,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-builder"
-version = "18.2.0"
+version = "18.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb41713b55123a0ec0d2690899cce5cd7354217455650f3bc80c75dd39ad8f02"
+checksum = "807d4c9e1f688b98df437f6d146c873e7f4464f5835ed3ab15a6864b96deeb7e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -16094,9 +16062,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-executor"
-version = "18.0.2"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c901632fd40c746e0607335d7d720949eb46f2d08800404f19ab5be2cdcff410"
+checksum = "59ce69c5c34e910df78b213e7c0f9b3c0f79ad24e5e66587a9dbe7b3ee09ece6"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -16612,7 +16580,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix 1.0.5",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -16927,9 +16895,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -17933,16 +17901,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
-dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
-]
-
-[[package]]
 name = "webpki-root-certs"
 version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17968,9 +17926,9 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime"
-version = "21.1.0"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d0f8825746e1ddc4037b25ac1efb6ada1b4a0372206e86f6ec1cc3b3827a4c"
+checksum = "8a72523849da1b274fa5bb93fa31fc7d8558820435ba798b8c9158b9ac333408"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -18132,7 +18090,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -18557,9 +18515,9 @@ dependencies = [
 
 [[package]]
 name = "xcm-emulator"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071417f8c2ff55d4ca434220aec564c20a3fee10dd31d3cfae1e1807c3040e94"
+checksum = "1dc6e140626e6776a7629b3c1891cc8f0a74bef794c6af1b5872cae0f21aa8d4"
 dependencies = [
  "array-bytes",
  "cumulus-pallet-parachain-system",
@@ -18588,6 +18546,7 @@ dependencies = [
  "sp-tracing",
  "staging-xcm",
  "staging-xcm-executor",
+ "xcm-simulator",
 ]
 
 [[package]]
@@ -18604,9 +18563,9 @@ dependencies = [
 
 [[package]]
 name = "xcm-runtime-apis"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd97b4d476b2444e55b40ac29474011138d9d891c8ffe480eadaf93e6778794"
+checksum = "0f43f0f524f1a448ad2e30af5e693211967651ce7e012465e865674fc4fc6587"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -18614,6 +18573,29 @@ dependencies = [
  "sp-api",
  "sp-weights",
  "staging-xcm",
+ "staging-xcm-executor",
+]
+
+[[package]]
+name = "xcm-simulator"
+version = "18.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36119d79dd3b4d0e18b22fe9bba9e9860dc5cc9460b75b6287c0c745224987e"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "paste",
+ "polkadot-core-primitives",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
+ "polkadot-runtime-parachains",
+ "scale-info",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "staging-xcm",
+ "staging-xcm-builder",
  "staging-xcm-executor",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,13 +109,13 @@ variant_count = "1.1.0"
 parking_lot = { version = "0.12.1", default-features = false }
 
 # Emulations
-xcm-emulator = { version = "0.17.1", default-features = false }
+xcm-emulator = { version = "0.17.2", default-features = false }
 
 # Substrate (with default disabled)
 impl-trait-for-tuples = { version = "0.2.2", default-features = false }
-frame-benchmarking = { version = "39.0.0", default-features = false }
-frame-benchmarking-cli = { version = "46.1.0" }
-frame-executive = { version = "39.1.0", default-features = false }
+frame-benchmarking = { version = "39.1.0", default-features = false }
+frame-benchmarking-cli = { version = "46.2.0" }
+frame-executive = { version = "39.1.1", default-features = false }
 frame-support = { version = "39.1.0", default-features = false }
 frame-system = { version = "39.1.0", default-features = false }
 frame-system-rpc-runtime-api = { version = "35.0.0", default-features = false }
@@ -142,7 +142,7 @@ sp-transaction-pool = { version = "35.0.0", default-features = false }
 sp-trie = { version = "38.0.0", default-features = false }
 sp-version = { version = "38.0.0", default-features = false }
 sp-consensus-grandpa = { version = "22.0.0", default-features = false }
-sp-npos-elections = { version = "35.0.0", default-features = false }
+sp-npos-elections = { version = "35.1.0", default-features = false }
 sp-tracing = { version = "17.0.1", default-features = false }
 pallet-im-online = { version = "38.1.0", default-features = false }
 sp-authority-discovery = { version = "35.0.0", default-features = false }
@@ -160,7 +160,7 @@ pallet-authorship = { version = "39.0.0", default-features = false }
 pallet-session = { version = "39.0.0", default-features = false }
 pallet-timestamp = { version = "38.0.0", default-features = false }
 pallet-collective = { version = "39.1.0", default-features = false }
-pallet-scheduler = { version = "40.1.0", default-features = false }
+pallet-scheduler = { version = "40.2.0", default-features = false }
 pallet-sudo = { version = "39.0.0", default-features = false }
 pallet-transaction-payment = { version = "39.1.0", default-features = false }
 pallet-transaction-payment-rpc-runtime-api = { version = "39.0.0", default-features = false }
@@ -178,17 +178,17 @@ pallet-asset-tx-payment = { version = "39.1.0", default-features = false }
 pallet-skip-feeless-payment = { version = "14.1.0", default-features = false }
 
 # Polkadot (with default disabled)
-pallet-xcm = { version = "18.1.0", default-features = false }
+pallet-xcm = { version = "18.1.1", default-features = false }
 pallet-collator-selection = { version = "20.1.0", default-features = false }
 polkadot-parachain-primitives = { version = "15.0.0", default-features = false }
 polkadot-runtime-parachains = { version = "18.1.0", default-features = false }
 polkadot-core-primitives = { version = "16.0.0", default-features = false }
-xcm = { version = "15.0.3", package = 'staging-xcm', default-features = false }
-xcm-builder = { version = "18.2.0", package = 'staging-xcm-builder', default-features = false }
-xcm-executor = { version = "18.0.2", package = 'staging-xcm-executor', default-features = false }
+xcm = { version = "15.1.0", package = 'staging-xcm', default-features = false }
+xcm-builder = { version = "18.2.1", package = 'staging-xcm-builder', default-features = false }
+xcm-executor = { version = "18.0.3", package = 'staging-xcm-executor', default-features = false }
 polkadot-runtime-common = { version = "18.1.0", default-features = false }
 polkadot-primitives = { version = "17.1.0", default-features = false }
-xcm-runtime-apis = { version = "0.5.2", default-features = false }
+xcm-runtime-apis = { version = "0.5.3", default-features = false }
 
 # Cumulus (with default disabled)
 cumulus-pallet-aura-ext = { version = "0.18.0", default-features = false }
@@ -220,7 +220,7 @@ sc-basic-authorship = { version = "0.48.0" }
 sc-client-api = { version = "38.0.0" }
 sc-consensus = { version = "0.47.0" }
 sc-consensus-aura = { version = "0.48.0" }
-sc-network = { version = "0.48.3" }
+sc-network = { version = "0.48.4" }
 sc-offchain = { version = "43.0.0" }
 sc-network-sync = { version = "0.47.0" }
 sc-cli = { version = "0.50.1" }
@@ -248,8 +248,8 @@ cumulus-pallet-session-benchmarking = { version = "20.0.0", default-features = f
 # Runtimes
 polimec-runtime = { path = "runtimes/polimec" }
 westend-runtime-constants = { version = "18.0.0" }
-westend-runtime = { version = "21.1.0" }
-asset-hub-westend-runtime = { version = "0.27.2" }
+westend-runtime = { version = "21.2.0" }
+asset-hub-westend-runtime = { version = "0.27.4" }
 
 # tests
-emulated-integration-tests-common = { version = "19.0.2" }
+emulated-integration-tests-common = { version = "19.1.0" }

--- a/runtimes/polimec/src/lib.rs
+++ b/runtimes/polimec/src/lib.rs
@@ -179,23 +179,13 @@ pub type Migrations = migrations::Unreleased;
 /// The runtime migrations per release.
 #[allow(missing_docs)]
 pub mod migrations {
-	use crate::{parameter_types, Runtime, RuntimeDbWeight};
-	use frame_support::migrations::RemovePallet;
-
-	parameter_types! {
-		/// The name of the Identity pallet.
-		pub const IdentityPalletName: &'static str = "Identity";
-	}
+	use crate::Runtime;
 
 	/// Unreleased migrations. Add new ones here:
 	pub type Unreleased = (
 		// permanent
 		pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,
 		// temporary
-		RemovePallet<IdentityPalletName, RuntimeDbWeight>,
-		pallet_funding::migrations::vesting_info::v7::MigrationToV8<Runtime>,
-		pallet_linear_release::migrations::LinearReleaseVestingMigrationV1<Runtime>,
-		super::custom_migrations::vesting::v1::UncheckedMigrationToAsyncBacking<Runtime>,
 	);
 }
 
@@ -242,10 +232,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("polimec-mainnet"),
 	impl_name: Cow::Borrowed("polimec-mainnet"),
 	authoring_version: 1,
-	spec_version: 1_001_000,
+	spec_version: 1_001_001,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 8,
+	transaction_version: 9,
 	system_version: 1,
 };
 


### PR DESCRIPTION
This PR updates dependencies in `Cargo.toml` and makes runtime changes in `runtimes/polimec/src/lib.rs`. The updates primarily include version bumps for various Polkadot-SDK dependencies.

### Dependency Updates in `Cargo.toml`:

* Updated versions for Substrate-related crates, including `xcm-emulator`, `frame-benchmarking`, `frame-executive`, `sp-npos-elections`, `pallet-scheduler`, `pallet-xcm`, and `sp-api-proc-macro`.

* Updated runtime versions for `westend-runtime`, `asset-hub-westend-runtime`, and `emulated-integration-tests-common`.

### Runtime Changes in `runtimes/polimec/src/lib.rs`:

* Simplified the `migrations` module by removing already executed migration, such as `RemovePallet`, and other legacy migration logic. 

* Incremented the `spec_version` from `1_001_000` to `1_001_001` and the `transaction_version` from `8` to `9`.